### PR TITLE
Updated deep causality code examples to use latest version.

### DIFF
--- a/deep_causality/examples/csm/Cargo.toml
+++ b/deep_causality/examples/csm/Cargo.toml
@@ -6,4 +6,4 @@ rust-version = "1.65"
 publish = false
 
 [dependencies]
-deep_causality = "0.3.1"
+deep_causality = "0.4.0"

--- a/deep_causality/examples/ctx/Cargo.toml
+++ b/deep_causality/examples/ctx/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 
 [dependencies]
-deep_causality = "0.3.1"
+deep_causality = "0.4.0"
 
 # chrono default-features = false mitigates "RUSTSEC-2020-0071".
 # See https://rustsec.org/advisories/RUSTSEC-2020-0071.html

--- a/deep_causality/examples/dtx/Cargo.toml
+++ b/deep_causality/examples/dtx/Cargo.toml
@@ -7,12 +7,11 @@ publish = false
 
 
 [dependencies]
-deep_causality = "0.3.1"
+deep_causality = "0.4.0"
 
 # chrono default-features = false mitigates "RUSTSEC-2020-0071".
 # See https://rustsec.org/advisories/RUSTSEC-2020-0071.html
 chrono = { version = "0.4.26", default-features = false , features = ["serde", "clock"] }
 parquet = "45.0"
-#petgraph = "0.6"
 rust_decimal = "1.31"
 serde = { version = "1.0.181", features = ["derive"] }

--- a/deep_causality/examples/smoking/Cargo.toml
+++ b/deep_causality/examples/smoking/Cargo.toml
@@ -6,4 +6,4 @@ rust-version = "1.65"
 publish = false
 
 [dependencies]
-deep_causality = "0.3.1"
+deep_causality = "0.4.0"


### PR DESCRIPTION
## Describe your changes

Updated deep causality code examples to use latest release, 0.4.0
