### PR TITLE
Added unset method to extendable_contextuable_graph.rs

### DIFF
--- a/deep_causality/src/protocols/contextuable_graph/mod.rs
+++ b/deep_causality/src/protocols/contextuable_graph/mod.rs
@@ -45,6 +45,8 @@ where
     fn extra_ctx_check_exists(&self, idx: u64) -> bool;
     fn extra_ctx_get_current_id(&self) -> u64;
     fn extra_ctx_set_current_id(&mut self, idx: u64) -> Result<(), ContextIndexError>;
+    fn extra_ctx_unset_current_id(&mut self) -> Result<(), ContextIndexError>;
+
     fn extra_ctx_add_node(
         &mut self,
         value: Contextoid<D, S, T, ST, V>,

--- a/deep_causality/src/types/context_types/context_graph/extendable_contextuable_graph.rs
+++ b/deep_causality/src/types/context_types/context_graph/extendable_contextuable_graph.rs
@@ -51,6 +51,12 @@ where
         Ok(())
     }
 
+    fn extra_ctx_unset_current_id(&mut self) -> Result<(), ContextIndexError> {
+        self.extra_context_id = 0;
+
+        Ok(())
+    }
+
     fn extra_ctx_add_node(
         &mut self,
         value: Contextoid<D, S, T, ST, V>,

--- a/deep_causality/tests/types/context_types/context_graph/extendable_context_tests.rs
+++ b/deep_causality/tests/types/context_types/context_graph/extendable_context_tests.rs
@@ -107,6 +107,32 @@ fn test_extra_ctx_set_current_id() {
 }
 
 #[test]
+fn test_extra_ctx_unset_current_id() {
+    let id = 1;
+    let mut context = get_context();
+    assert_eq!(context.id(), id);
+
+    let capacity = 10;
+    let default = true;
+
+    let ctx_id = context.extra_ctx_add_new(capacity, default);
+    assert_eq!(ctx_id, 1);
+
+    let exists = context.extra_ctx_check_exists(ctx_id);
+    assert!(exists);
+
+    let current_id = context.extra_ctx_get_current_id();
+    assert_eq!(current_id, ctx_id);
+
+    let res = context.extra_ctx_unset_current_id();
+    assert!(res.is_ok());
+
+    // Zero is the default value for the extra context if nothing else is set
+    let current_id = context.extra_ctx_get_current_id();
+    assert_eq!(current_id, 0);
+}
+
+#[test]
 fn test_extra_ctx_set_current_id_err() {
     let id = 1;
     let mut context = get_context();


### PR DESCRIPTION

## Describe your changes

Added unset method to extendable_contextuable_graph.rs

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.
