### PR TITLE
Fix tag in Cargo.toml

### DIFF
--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -10,7 +10,7 @@ description = "Computational causality library. Provides causality graph, collec
 documentation = "https://docs.rs/deep_causality"
 homepage = "https://deepcausality.com/about/"
 repository = "https://github.com/deepcausality/deep_causality.rs"
-keywords = ["cauality", "causal-graph", "causal-reasoning", "graph"]
+keywords = ["causality", "causal-graph", "causal-reasoning", "graph"]
 categories = ["data-structures", "science", "aerospace", "finance", "mathematics"]
 authors = ["Marvin Hansen <marvin.hansen@gmail.com>", ]
 


### PR DESCRIPTION
Signed-off-by: Jorge Perez Burgos <vaijira@gmail.com>

Fix causality tag in cargo to be able to find the crate.