### PR TITLE
Preparing release 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "dcl_data_structures",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "ultragraph"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "deep_causality_macros",

--- a/deep_causality/CHANGELOG.md
+++ b/deep_causality/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.8.1](https://github.com/marvin-hansen/deep_causality/compare/deep_causality-v0.8.0...deep_causality-v0.8.1) - 2025-07-10
+
+### Other
+
+- Fixed memory leak in ultragraph bench ([#261](https://github.com/marvin-hansen/deep_causality/pull/261))

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.80"
 readme = "../README.md"
@@ -28,7 +28,7 @@ version = "0.8.0"
 
 [dependencies.ultragraph]
 path = "../ultragraph"
-version = "0.8.0"
+version = "0.8.1"
 
 
 [dev-dependencies]

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1](https://github.com/marvin-hansen/deep_causality/compare/ultragraph-v0.8.0...ultragraph-v0.8.1) - 2025-07-10
+
+### Other
+
+- Improved perf of deduplication in brandes_bfs_and_path_counting
+- Improved test coverage
+- Fixed breaking API by restring previous public re-export.
+- Added test coverage for betweenness_centrality algo.
+- Implemented Brandes' algorithm
+- Refactored ultragraph's trait system and algo implementations for better maintainability.
+- Updated README.md
+- Formatting and linting.
+- Improved test coverage.
+- Added Tarjan's algorithm to UltraGraph.
+- Improved test coverage for Dijkstra's algorithm. Improved docstring.
+- Removed problematic check in Dijkstra's algorithm
+- Added Dijkstra's algorithm to UltraGraph.
+- Fixed a memory leak in the ultragraph benchmark.
+
 ## [0.5.6](https://github.com/marvin-hansen/deep_causality/compare/ultragraph-v0.5.5...ultragraph-v0.5.6) - 2025-06-19
 
 ### Other

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultragraph"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.80"
 repository = "https://github.com/deepcausality/deep_causality.rs"


### PR DESCRIPTION
### **User description**
## Describe your changes

Preparing release 

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


___

### **PR Type**
Other


___

### **Description**
- Version bump to 0.8.1 for both packages

- Added changelog entries documenting recent changes

- Updated dependency versions for consistency


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Version 0.8.0"] --> B["Update Cargo.toml versions"]
  B --> C["Add changelog entries"]
  C --> D["Version 0.8.1 release"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Initialize changelog with version 0.8.1 entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/CHANGELOG.md

<li>Created new changelog file following Keep a Changelog format<br> <li> Added entry for version 0.8.1 with memory leak fix reference


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/266/files#diff-d4a76e500dfa2bf26b47a62aaba982b9edc91ab74438bbd84a688f9ecc6b81b6">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 0.8.1 changes and improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ultragraph/CHANGELOG.md

<li>Added comprehensive changelog entry for version 0.8.1<br> <li> Documented multiple improvements including performance, algorithms, <br>and bug fixes


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/266/files#diff-42f4dceb4cd8d07520393f89baed5e0c94d61a4e1f3f3f68c98c4158d4432f15">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Version bump to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/Cargo.toml

<li>Bumped package version from 0.8.0 to 0.8.1<br> <li> Updated ultragraph dependency version to 0.8.1


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/266/files#diff-b366551c9d266d56acc35e91c5cb8efa4dd5eff9dc87e78af04678bac452332b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Version bump to 0.8.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ultragraph/Cargo.toml

- Updated package version from 0.8.0 to 0.8.1


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/266/files#diff-d22c66ec709b1af5a173cd041ec828a006d041f453f6ff9f2a33d65954d00665">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>