### PR TITLE
feat(deep_causality): Added Configurable Reasoning Modalities to Causal Collectins.

### DIFF
--- a/deep_causality/benches/benchmarks/bench_collection.rs
+++ b/deep_causality/benches/benchmarks/bench_collection.rs
@@ -20,7 +20,7 @@ fn small_causality_collection_benchmark(criterion: &mut Criterion) {
 
     criterion.bench_function("small_causality_collection_propagation", |bencher| {
         bencher.iter(|| {
-            coll.evaluate_deterministic_propagation(&evidence, &AggregateLogic::All)
+            coll.evaluate_deterministic(&evidence, &AggregateLogic::All)
                 .unwrap()
         })
     });
@@ -32,7 +32,7 @@ fn medium_causality_collection_benchmark(criterion: &mut Criterion) {
 
     criterion.bench_function("medium_causality_collection_propagation", |bencher| {
         bencher.iter(|| {
-            coll.evaluate_deterministic_propagation(&evidence, &AggregateLogic::All)
+            coll.evaluate_deterministic(&evidence, &AggregateLogic::All)
                 .unwrap()
         })
     });
@@ -44,7 +44,7 @@ fn large_causality_collection_benchmark(criterion: &mut Criterion) {
 
     criterion.bench_function("large_causality_collection_propagation", |bencher| {
         bencher.iter(|| {
-            coll.evaluate_deterministic_propagation(&evidence, &AggregateLogic::All)
+            coll.evaluate_deterministic(&evidence, &AggregateLogic::All)
                 .unwrap()
         })
     });

--- a/deep_causality/src/traits/causable/causable_reasoning.rs
+++ b/deep_causality/src/traits/causable/causable_reasoning.rs
@@ -60,7 +60,7 @@ where
     ///
     /// # Errors
     /// Returns a `CausalityError` if any `Causable` item returns a non-deterministic effect.
-    fn evaluate_deterministic_propagation(
+    fn evaluate_deterministic(
         &self,
         effect: &PropagatingEffect,
         logic: &AggregateLogic,
@@ -84,7 +84,7 @@ where
     ///
     /// # Errors
     /// Returns a `CausalityError` if a `ContextualLink` is encountered.
-    fn evaluate_probabilistic_propagation(
+    fn evaluate_probabilistic(
         &self,
         effect: &PropagatingEffect,
         logic: &AggregateLogic,
@@ -115,7 +115,7 @@ where
     /// # Errors
     /// Returns a `CausalityError` if a `ContextualLink` is encountered, as it cannot be
     /// converted to a numerical probability.
-    fn evaluate_mixed_propagation(
+    fn evaluate_mixed(
         &self,
         effect: &PropagatingEffect,
         logic: &AggregateLogic,

--- a/deep_causality/src/traits/causable/causable_reasoning_deterministic.rs
+++ b/deep_causality/src/traits/causable/causable_reasoning_deterministic.rs
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use crate::{AggregateLogic, Causable, CausalityError, PropagatingEffect};
+
+/// Evaluates a collection of `Causable` items against a specific `AggregateLogic`.
+///
+/// This is a private helper function that encapsulates the core reasoning logic,
+/// allowing the public-facing trait method to remain a simple delegation.
+/// It is optimized to short-circuit for performance where possible.
+///
+/// # Arguments
+/// * `items` - A vector of references to `Causable` items.
+/// * `effect` - The `PropagatingEffect` to pass to each item's `evaluate` method.
+/// * `logic` - The aggregation logic to apply.
+///
+/// # Returns
+/// A `Result` containing the final `PropagatingEffect::Deterministic` outcome
+/// or a `CausalityError` if any item returns a non-deterministic effect.
+pub fn _evaluate_deterministic_logic<T: Causable>(
+    items: Vec<&T>,
+    effect: &PropagatingEffect,
+    logic: &AggregateLogic,
+) -> Result<PropagatingEffect, CausalityError> {
+    if items.is_empty() {
+        return Err(CausalityError(
+            "No Causaloids found to evaluate".to_string(),
+        ));
+    }
+
+    let mut true_count = 0;
+
+    for cause in items {
+        let evaluated_effect = cause.evaluate(effect)?;
+
+        let value = match evaluated_effect {
+            PropagatingEffect::Deterministic(v) => v,
+            _ => {
+                // Strict contract: only deterministic effects are allowed.
+                return Err(CausalityError(format!(
+                    "evaluate_deterministic_propagation encountered a non-deterministic effect: {evaluated_effect:?}. Only Deterministic effects are allowed."
+                )));
+            }
+        };
+
+        match logic {
+            AggregateLogic::All => {
+                if !value {
+                    // Short-circuit on the first false.
+                    return Ok(PropagatingEffect::Deterministic(false));
+                }
+            }
+            AggregateLogic::Any => {
+                if value {
+                    // Short-circuit on the first true.
+                    return Ok(PropagatingEffect::Deterministic(true));
+                }
+            }
+            AggregateLogic::None => {
+                if value {
+                    // Short-circuit on the first true, as this violates the None condition.
+                    return Ok(PropagatingEffect::Deterministic(false));
+                }
+            }
+            AggregateLogic::Some(k) => {
+                if value {
+                    true_count += 1;
+                    if true_count >= *k {
+                        // Short-circuit as soon as the threshold is met.
+                        return Ok(PropagatingEffect::Deterministic(true));
+                    }
+                }
+            }
+        }
+    }
+
+    // If the loop completes, determine the final result for non-short-circuited paths.
+    let final_result = match logic {
+        // If we got here for All, it means no false values were found.
+        AggregateLogic::All => true,
+        // If we got here for Any, it means no true values were found.
+        AggregateLogic::Any => false,
+        // If we got here for None, it means no true values were found.
+        AggregateLogic::None => true,
+        // If we got here for Some(k), it means the threshold was never met.
+        AggregateLogic::Some(k) => true_count >= *k, // This will be false.
+    };
+
+    Ok(PropagatingEffect::Deterministic(final_result))
+}

--- a/deep_causality/src/traits/causable/causable_reasoning_mixed.rs
+++ b/deep_causality/src/traits/causable/causable_reasoning_mixed.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use crate::{AggregateLogic, Causable, CausalityError, NumericalValue, PropagatingEffect};
+
+/// Evaluates a collection of `Causable` items that may contain a mix of deterministic and
+/// probabilistic effects, aggregating them into a final deterministic outcome.
+///
+/// This is a private helper function that encapsulates the core reasoning logic,
+/// allowing the public-facing trait method to remain a simple delegation.
+/// It is optimized to short-circuit for performance where possible.
+///
+/// # Arguments
+/// * `items` - A vector of references to `Causable` items.
+/// * `effect` - The `PropagatingEffect` to pass to each item's `evaluate` method.
+/// * `logic` - The aggregation logic to apply.
+/// * `threshold` - The numerical threshold used to convert probabilistic effects to boolean.
+///
+/// # Returns
+/// A `Result` containing the final `PropagatingEffect` outcome.
+/// For `AggregateLogic::All`, it returns `PropagatingEffect::Deterministic` after applying the threshold.
+/// For `Any`, `None`, and `Some(k)`, it returns `PropagatingEffect::Deterministic`.
+/// Returns a `CausalityError` if any item returns an unsupported effect type.
+pub fn _evaluate_mixed_logic<T: Causable>(
+    items: Vec<&T>,
+    effect: &PropagatingEffect,
+    logic: &AggregateLogic,
+    threshold: NumericalValue,
+) -> Result<PropagatingEffect, CausalityError> {
+    if items.is_empty() {
+        return Err(CausalityError(
+            "No Causaloids found to evaluate".to_string(),
+        ));
+    }
+
+    match logic {
+        AggregateLogic::All => {
+            let mut cumulative_prob: NumericalValue = 1.0;
+            for cause in items {
+                let current_effect = cause.evaluate(effect)?;
+                let current_prob = match current_effect {
+                    PropagatingEffect::Deterministic(true) => 1.0,
+                    PropagatingEffect::Deterministic(false) => 0.0,
+                    PropagatingEffect::Probabilistic(p) => p,
+                    PropagatingEffect::Numerical(p) => p,
+                    _ => {
+                        return Err(CausalityError(format!(
+                            "evaluate_mixed_propagation encountered an unsupported effect: {current_effect:?}. Only probabilistic, deterministic, or numerical effects are allowed."
+                        )));
+                    }
+                };
+                cumulative_prob *= current_prob;
+            }
+            Ok(PropagatingEffect::Deterministic(
+                cumulative_prob > threshold,
+            ))
+        }
+        _ => {
+            let mut true_count = 0;
+            for cause in items {
+                let evaluated_effect = cause.evaluate(effect)?;
+                let value = match evaluated_effect {
+                    PropagatingEffect::Deterministic(b) => b,
+                    PropagatingEffect::Probabilistic(p) | PropagatingEffect::Numerical(p) => {
+                        p > threshold
+                    }
+                    _ => {
+                        return Err(CausalityError(format!(
+                            "evaluate_mixed_propagation encountered an unsupported effect: {evaluated_effect:?}. Only probabilistic, numerical, or deterministic effects are allowed."
+                        )));
+                    }
+                };
+
+                match logic {
+                    AggregateLogic::Any => {
+                        if value {
+                            return Ok(PropagatingEffect::Deterministic(true));
+                        }
+                    }
+                    AggregateLogic::None => {
+                        if value {
+                            return Ok(PropagatingEffect::Deterministic(false));
+                        }
+                    }
+                    AggregateLogic::Some(k) => {
+                        if value {
+                            true_count += 1;
+                            if true_count >= *k {
+                                return Ok(PropagatingEffect::Deterministic(true));
+                            }
+                        }
+                    }
+                    _ => unreachable!(), // All is handled above.
+                }
+            }
+
+            let final_result = match logic {
+                AggregateLogic::Any => false,
+                AggregateLogic::None => true,
+                AggregateLogic::Some(k) => true_count >= *k,
+                _ => unreachable!(), // All is handled above.
+            };
+            Ok(PropagatingEffect::Deterministic(final_result))
+        }
+    }
+}

--- a/deep_causality/src/traits/causable/causable_reasoning_probabilistic.rs
+++ b/deep_causality/src/traits/causable/causable_reasoning_probabilistic.rs
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use crate::{AggregateLogic, Causable, CausalityError, NumericalValue, PropagatingEffect};
+
+/// Evaluates a collection of `Causable` items against a specific `AggregateLogic`,
+/// using a provided `threshold` to convert probabilistic effects into boolean values.
+///
+/// # Arguments
+/// * `items` - A vector of references to `Causable` items.
+/// * `effect` - The `PropagatingEffect` to pass to each item's `evaluate` method.
+/// * `logic` - The aggregation logic to apply.
+/// * `threshold` - The numerical threshold used to convert probabilistic effects to boolean.
+///
+/// # Returns
+/// A `Result` containing the final `PropagatingEffect` outcome.
+/// For `AggregateLogic::All`, it returns `PropagatingEffect::Probabilistic`.
+/// For `Any`, `None`, and `Some(k)`, it returns `PropagatingEffect::Deterministic`.
+/// Returns a `CausalityError` if any item returns an unsupported effect type.
+pub fn _evaluate_probabilistic_logic<T: Causable>(
+    items: Vec<&T>,
+    effect: &PropagatingEffect,
+    logic: &AggregateLogic,
+    threshold: NumericalValue,
+) -> Result<PropagatingEffect, CausalityError> {
+    if items.is_empty() {
+        return Err(CausalityError(
+            "No Causaloids found to evaluate".to_string(),
+        ));
+    }
+
+    match logic {
+        AggregateLogic::All => {
+            // Preserve original behavior for All: multiply probabilities.
+            let mut cumulative_prob: NumericalValue = 1.0;
+            for cause in items {
+                let evaluated_effect = cause.evaluate(effect)?;
+                match evaluated_effect {
+                    PropagatingEffect::Probabilistic(p) | PropagatingEffect::Numerical(p) => {
+                        cumulative_prob *= p;
+                    }
+                    _ => {
+                        return Err(CausalityError(format!(
+                            "evaluate_probabilistic_propagation encountered a non-probabilistic effect: {evaluated_effect:?}. Only probabilistic or numerical effects are allowed for AggregateLogic::All."
+                        )));
+                    }
+                }
+            }
+            Ok(PropagatingEffect::Probabilistic(cumulative_prob))
+        }
+        _ => {
+            // For Any, None, Some(k): use threshold to convert to boolean and apply logic.
+            let mut true_count = 0;
+            for cause in items {
+                let evaluated_effect = cause.evaluate(effect)?;
+                let value = match evaluated_effect {
+                    PropagatingEffect::Probabilistic(p) | PropagatingEffect::Numerical(p) => {
+                        p > threshold
+                    }
+                    PropagatingEffect::Deterministic(b) => b,
+                    _ => {
+                        return Err(CausalityError(format!(
+                            "evaluate_probabilistic_propagation encountered an unsupported effect: {evaluated_effect:?}. Only probabilistic, numerical, or deterministic effects are allowed for other AggregateLogic types."
+                        )));
+                    }
+                };
+
+                match logic {
+                    AggregateLogic::Any => {
+                        if value {
+                            return Ok(PropagatingEffect::Deterministic(true));
+                        }
+                    }
+                    AggregateLogic::None => {
+                        if value {
+                            return Ok(PropagatingEffect::Deterministic(false));
+                        }
+                    }
+                    AggregateLogic::Some(k) => {
+                        if value {
+                            true_count += 1;
+                            if true_count >= *k {
+                                return Ok(PropagatingEffect::Deterministic(true));
+                            }
+                        }
+                    }
+                    _ => unreachable!(), // All is handled above.
+                }
+            }
+
+            let final_result = match logic {
+                AggregateLogic::Any => false,
+                AggregateLogic::None => true,
+                AggregateLogic::Some(k) => true_count >= *k,
+                _ => unreachable!(), // All is handled above.
+            };
+            Ok(PropagatingEffect::Deterministic(final_result))
+        }
+    }
+}

--- a/deep_causality/src/traits/causable/mod.rs
+++ b/deep_causality/src/traits/causable/mod.rs
@@ -5,6 +5,9 @@
 use crate::{CausalityError, Identifiable, PropagatingEffect};
 
 pub mod causable_reasoning;
+mod causable_reasoning_deterministic;
+mod causable_reasoning_mixed;
+mod causable_reasoning_probabilistic;
 
 /// The Causable trait defines the core behavior for all causal elements.
 ///

--- a/deep_causality/src/traits/causable_graph/graph_reasoning.rs
+++ b/deep_causality/src/traits/causable_graph/graph_reasoning.rs
@@ -90,9 +90,6 @@ where
             let effect = cause.evaluate(effect)?;
 
             match effect {
-                // If any cause halts, the entire subgraph reasoning halts immediately.
-                PropagatingEffect::Halting => return Ok(PropagatingEffect::Halting),
-
                 // If the cause is deterministically false, we stop traversing this path,
                 // but the overall subgraph reasoning does not fail or halt.
                 PropagatingEffect::Deterministic(false) => continue,
@@ -161,16 +158,7 @@ where
                 CausalityError(format!("Failed to get causaloid at index {index}"))
             })?;
 
-            let effect = cause.evaluate(effect)?;
-
-            match effect {
-                // If any node on the path is false or halts, the entire path fails.
-                PropagatingEffect::Deterministic(false) | PropagatingEffect::Halting => {
-                    return Ok(effect);
-                }
-                // Otherwise, continue to the next node.
-                _ => continue,
-            }
+            let _ = cause.evaluate(effect)?;
         }
 
         // If the loop completes, all nodes on the path were successfully evaluated.

--- a/deep_causality/src/types/causal_types/causaloid/causable.rs
+++ b/deep_causality/src/types/causal_types/causaloid/causable.rs
@@ -58,13 +58,9 @@ where
                 // Prioritizes Halting, then looks for the first Deterministic(true).
                 let mut has_true = false;
                 for cause in coll.iter() {
-                    match cause.evaluate(effect)? {
-                        PropagatingEffect::Halting => return Ok(PropagatingEffect::Halting),
-                        PropagatingEffect::Deterministic(true) => {
-                            has_true = true;
-                            break; // Short-circuit
-                        }
-                        _ => (), // Other effects are ignored for this aggregation
+                    if let PropagatingEffect::Deterministic(true) = cause.evaluate(effect)? {
+                        has_true = true;
+                        break; // Short-circuit
                     }
                 }
                 PropagatingEffect::Deterministic(has_true)

--- a/deep_causality/src/types/causal_types/causaloid/causable.rs
+++ b/deep_causality/src/types/causal_types/causaloid/causable.rs
@@ -4,12 +4,10 @@
  */
 
 use crate::errors::CausalityError;
-use crate::traits::causable::causable_reasoning::CausableReasoning;
-use crate::traits::contextuable::space_temporal::SpaceTemporal;
-use crate::traits::contextuable::spatial::Spatial;
-use crate::traits::contextuable::temporal::Temporal;
-use crate::types::causal_types::causaloid::causal_type::CausaloidType;
-use crate::{Causable, Causaloid, Datable, PropagatingEffect, Symbolic};
+use crate::{
+    Causable, CausableReasoning, Causaloid, CausaloidType, Datable, PropagatingEffect,
+    SpaceTemporal, Spatial, Symbolic, Temporal,
+};
 
 #[allow(clippy::type_complexity)]
 impl<D, S, T, ST, SYM, VS, VT> Causable for Causaloid<D, S, T, ST, SYM, VS, VT>

--- a/deep_causality/src/types/causal_types/causaloid_graph/causable.rs
+++ b/deep_causality/src/types/causal_types/causaloid_graph/causable.rs
@@ -29,10 +29,6 @@ where
         // This will traverse and evaluate the entire graph from the root.
         let effect = self.evaluate_subgraph_from_cause(root_index, effect)?;
 
-        if matches!(effect, PropagatingEffect::Halting) {
-            return Ok(PropagatingEffect::Halting);
-        }
-
         Ok(effect)
     }
 

--- a/deep_causality/src/types/model_types/assumption/debug.rs
+++ b/deep_causality/src/types/model_types/assumption/debug.rs
@@ -2,25 +2,12 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{Debug, Formatter};
 
-use crate::types::model_types::assumption::Assumption;
+use crate::Assumption;
 
 impl Debug for Assumption {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.fmt_write(f)
-    }
-}
-
-impl Display for Assumption {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.fmt_write(f)
-    }
-}
-
-impl Assumption {
-    // derive Debug isn't general enough to cover function pointers hence the function signature.
-    fn fmt_write(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "Assumption: id: {}, description: {}, assumption_tested: {}, assumption_valid: {}",

--- a/deep_causality/src/types/model_types/assumption/display.rs
+++ b/deep_causality/src/types/model_types/assumption/display.rs
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use crate::Assumption;
+use std::fmt::{Display, Formatter};
+
+impl Display for Assumption {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            // Delegate to debug
+            f,
+            "{self:?}"
+        )
+    }
+}

--- a/deep_causality/src/types/model_types/assumption/mod.rs
+++ b/deep_causality/src/types/model_types/assumption/mod.rs
@@ -9,6 +9,7 @@ use crate::{DescriptionValue, EvalFn, IdentificationValue};
 
 mod assumable;
 mod debug;
+mod display;
 mod identifiable;
 
 // Interior mutability in Rust, part 2: thread safety

--- a/deep_causality/src/types/reasoning_types/propagating_effect/debug.rs
+++ b/deep_causality/src/types/reasoning_types/propagating_effect/debug.rs
@@ -29,7 +29,6 @@ impl Debug for PropagatingEffect {
                 g.number_nodes(),
                 g.number_edges()
             ),
-            PropagatingEffect::Halting => write!(_f, "PropagatingEffect::Halting"),
             PropagatingEffect::RelayTo(idx, effect) => {
                 write!(_f, "PropagatingEffect::RelayTo({idx}, {effect:?})")
             }

--- a/deep_causality/src/types/reasoning_types/propagating_effect/mod.rs
+++ b/deep_causality/src/types/reasoning_types/propagating_effect/mod.rs
@@ -39,8 +39,6 @@ pub enum PropagatingEffect {
     Map(HashMap<IdentificationValue, Box<PropagatingEffect>>),
     /// A graph of effects, for passing complex relational data.
     Graph(Arc<EffectGraph>),
-    /// A terminal effect that explicitly halts the current reasoning path.
-    Halting,
     /// A dispatch command that directs a reasoning engine to jump to a specific
     /// next causaloid with the specified id (`usize`) and provide it with the encapsulated effect as its new input.
     RelayTo(usize, Box<PropagatingEffect>),
@@ -68,9 +66,6 @@ impl PropagatingEffect {
     }
     pub fn is_graph(&self) -> bool {
         matches!(self, PropagatingEffect::Graph(_))
-    }
-    pub fn is_halting(&self) -> bool {
-        matches!(self, PropagatingEffect::Halting)
     }
     pub fn is_relay_to(&self) -> bool {
         matches!(self, PropagatingEffect::RelayTo(_, _))

--- a/deep_causality/src/types/reasoning_types/propagating_effect/partial_eq.rs
+++ b/deep_causality/src/types/reasoning_types/propagating_effect/partial_eq.rs
@@ -15,7 +15,6 @@ impl PartialEq for PropagatingEffect {
             (Self::ContextualLink(l0, l1), Self::ContextualLink(r0, r1)) => l0 == r0 && l1 == r1,
             (Self::Map(l), Self::Map(r)) => l == r,
             (Self::Graph(l), Self::Graph(r)) => Arc::ptr_eq(l, r),
-            (Self::Halting, Self::Halting) => true,
             (Self::RelayTo(l0, l1), Self::RelayTo(r0, r1)) => l0 == r0 && l1 == r1,
             _ => false,
         }

--- a/deep_causality/src/utils_test/test_utils.rs
+++ b/deep_causality/src/utils_test/test_utils.rs
@@ -35,9 +35,9 @@ pub fn get_test_inf_vec() -> Vec<Inference> {
 }
 
 pub fn get_test_causality_vec() -> BaseCausaloidVec {
-    let q1 = get_test_causaloid();
-    let q2 = get_test_causaloid();
-    let q3 = get_test_causaloid();
+    let q1 = get_test_causaloid_deterministic();
+    let q2 = get_test_causaloid_deterministic();
+    let q3 = get_test_causaloid_deterministic();
     Vec::from_iter([q1, q2, q3])
 }
 
@@ -65,16 +65,6 @@ pub fn get_test_causaloid_deterministic_false() -> BaseCausaloid {
     Causaloid::new(3, causal_fn, description)
 }
 
-pub fn get_test_causaloid_probabilistic() -> BaseCausaloid {
-    let description = "tests nothing; always returns 0.0";
-
-    fn causal_fn(_effect: &PropagatingEffect) -> Result<PropagatingEffect, CausalityError> {
-        Ok(PropagatingEffect::Probabilistic(0.0))
-    }
-
-    Causaloid::new(5, causal_fn, description)
-}
-
 pub fn get_test_causaloid_contextual_link() -> BaseCausaloid {
     let description = "tests nothing; always returns a contetual link";
 
@@ -85,7 +75,38 @@ pub fn get_test_causaloid_contextual_link() -> BaseCausaloid {
     Causaloid::new(9, causal_fn, description)
 }
 
-pub fn get_test_causaloid() -> BaseCausaloid {
+pub fn get_test_causaloid_probabilistic() -> BaseCausaloid {
+    let id: IdentificationValue = 3;
+    let description = "tests whether data exceeds threshold of 0.55";
+
+    fn causal_fn(effect: &PropagatingEffect) -> Result<PropagatingEffect, CausalityError> {
+        let obs =
+            match effect {
+                // If it's the Numerical variant, extract the inner value.
+                PropagatingEffect::Numerical(val) => *val,
+
+                //  If it's the Probabilistic, extract the inner value.
+                PropagatingEffect::Probabilistic(val) => *val,
+                
+                // For any other type of effect, this function cannot proceed, so return an error.
+                _ => return Err(CausalityError(
+                    "Causal function expected Numerical effect but received a different variant."
+                        .into(),
+                )),
+            };
+
+        let threshold: NumericalValue = 0.55;
+        if !obs.ge(&threshold) {
+            Ok(PropagatingEffect::Probabilistic(0.0))
+        } else {
+            Ok(PropagatingEffect::Probabilistic(1.0))
+        }
+    }
+
+    Causaloid::new(id, causal_fn, description)
+}
+
+pub fn get_test_causaloid_deterministic() -> BaseCausaloid {
     let id: IdentificationValue = 1;
     let description = "tests whether data exceeds threshold of 0.55";
 

--- a/deep_causality/src/utils_test/test_utils.rs
+++ b/deep_causality/src/utils_test/test_utils.rs
@@ -75,16 +75,6 @@ pub fn get_test_causaloid_probabilistic() -> BaseCausaloid {
     Causaloid::new(5, causal_fn, description)
 }
 
-pub fn get_test_causaloid_halting() -> BaseCausaloid {
-    let description = "tests nothing; always returns Halting";
-
-    fn causal_fn(_effect: &PropagatingEffect) -> Result<PropagatingEffect, CausalityError> {
-        Ok(PropagatingEffect::Halting)
-    }
-
-    Causaloid::new(7, causal_fn, description)
-}
-
 pub fn get_test_causaloid_contextual_link() -> BaseCausaloid {
     let description = "tests nothing; always returns a contetual link";
 

--- a/deep_causality/src/utils_test/test_utils.rs
+++ b/deep_causality/src/utils_test/test_utils.rs
@@ -34,10 +34,16 @@ pub fn get_test_inf_vec() -> Vec<Inference> {
     Vec::from_iter([i1, i2])
 }
 
-pub fn get_test_causality_vec() -> BaseCausaloidVec {
+pub fn get_deterministic_test_causality_vec() -> BaseCausaloidVec {
     let q1 = get_test_causaloid_deterministic();
     let q2 = get_test_causaloid_deterministic();
     let q3 = get_test_causaloid_deterministic();
+    Vec::from_iter([q1, q2, q3])
+}
+pub fn get_probabilistic_test_causality_vec() -> BaseCausaloidVec {
+    let q1 = get_test_causaloid_probabilistic();
+    let q2 = get_test_causaloid_probabilistic();
+    let q3 = get_test_causaloid_probabilistic();
     Vec::from_iter([q1, q2, q3])
 }
 
@@ -87,7 +93,7 @@ pub fn get_test_causaloid_probabilistic() -> BaseCausaloid {
 
                 //  If it's the Probabilistic, extract the inner value.
                 PropagatingEffect::Probabilistic(val) => *val,
-                
+
                 // For any other type of effect, this function cannot proceed, so return an error.
                 _ => return Err(CausalityError(
                     "Causal function expected Numerical effect but received a different variant."

--- a/deep_causality/tests/extensions/causable/causable_arr_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_arr_tests.rs
@@ -46,16 +46,16 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -73,9 +73,9 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
 
@@ -85,9 +85,9 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
@@ -107,7 +107,6 @@ fn test_explain() {
     assert!(res.is_ok());
 
     let res = col.explain();
-    dbg!(&res);
     assert!(res.is_ok());
     let actual = col.explain().unwrap();
 

--- a/deep_causality/tests/extensions/causable/causable_arr_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_arr_tests.rs
@@ -64,7 +64,7 @@ fn test_evaluate_probabilistic_propagation() {
     let col = get_test_causality_array(false);
 
     let effect_success = PropagatingEffect::Probabilistic(0.99);
-    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All);
+    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
 
     let res_success = res.unwrap();
@@ -74,7 +74,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
@@ -86,14 +86,14 @@ fn test_evaluate_mixed_propagation() {
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }

--- a/deep_causality/tests/extensions/causable/causable_arr_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_arr_tests.rs
@@ -46,14 +46,14 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_success, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -64,7 +64,7 @@ fn test_evaluate_probabilistic_propagation() {
     let col = get_test_causality_array(false);
 
     let effect_success = PropagatingEffect::Probabilistic(0.99);
-    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
 
     let res_success = res.unwrap();
@@ -73,7 +73,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
@@ -85,7 +85,7 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
@@ -93,7 +93,7 @@ fn test_evaluate_mixed_propagation() {
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
+        .evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
@@ -103,7 +103,7 @@ fn test_explain() {
     let col = get_test_causality_array(true);
 
     let effect = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::All);
     assert!(res.is_ok());
 
     let res = col.explain();

--- a/deep_causality/tests/extensions/causable/causable_arr_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_arr_tests.rs
@@ -24,7 +24,7 @@ pub fn get_test_causality_array_mixed() -> [BaseCausaloid; 20] {
 
     // Combine a1 and a2
     a1.into_iter()
-        .chain(a2.into_iter())
+        .chain(a2)
         .collect::<Vec<_>>()
         .try_into()
         .unwrap()

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -14,9 +14,9 @@ type TestBTreeMap = BTreeMap<i8, BaseCausaloid>;
 // Helper function to create a standard test BTreeMap.
 fn get_test_causality_btree_map() -> TestBTreeMap {
     BTreeMap::from([
-        (1, get_test_causaloid()),
-        (2, get_test_causaloid()),
-        (3, get_test_causaloid()),
+        (1, get_test_causaloid_deterministic()),
+        (2, get_test_causaloid_deterministic()),
+        (3, get_test_causaloid_deterministic()),
     ])
 }
 
@@ -35,7 +35,7 @@ fn test_add() {
     let mut map = get_test_causality_btree_map();
     assert_eq!(3, map.len());
 
-    let q = get_test_causaloid();
+    let q = get_test_causaloid_deterministic();
     map.insert(4, q);
     assert_eq!(4, map.len());
 }
@@ -46,7 +46,7 @@ fn test_contains() {
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
-    let q = get_test_causaloid();
+    let q = get_test_causaloid_deterministic();
     map.insert(4, q);
     assert_eq!(4, map.len());
     assert!(map.contains_key(&4));

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -108,7 +108,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = map
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
@@ -116,7 +116,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = map
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
@@ -128,14 +128,14 @@ fn test_evaluate_mixed_propagation() {
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = map
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = map
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -87,16 +87,16 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All)
-        .unwrap();
+    let res = map.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map
-        .evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
+    let res = map.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -107,17 +107,17 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
 
@@ -127,16 +127,16 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -150,7 +150,9 @@ fn test_explain() {
     let expected = format!(
         "\n * {single_explanation}\n\n * {single_explanation}\n\n * {single_explanation}\n"
     );
-    let actual = map.explain().unwrap();
+    let res = map.explain();
+    assert!(res.is_ok());
+    let actual = res.unwrap();
     assert_eq!(expected, actual);
 }
 

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -12,11 +12,19 @@ use deep_causality::*;
 type TestBTreeMap = BTreeMap<i8, BaseCausaloid>;
 
 // Helper function to create a standard test BTreeMap.
-fn get_test_causality_btree_map() -> TestBTreeMap {
+fn get_test_causality_btree_map_deterministic() -> TestBTreeMap {
     BTreeMap::from([
         (1, get_test_causaloid_deterministic()),
         (2, get_test_causaloid_deterministic()),
         (3, get_test_causaloid_deterministic()),
+    ])
+}
+
+fn get_test_causality_btree_map_probabilistic() -> TestBTreeMap {
+    BTreeMap::from([
+        (1, get_test_causaloid_probabilistic()),
+        (2, get_test_causaloid_probabilistic()),
+        (3, get_test_causaloid_probabilistic()),
     ])
 }
 
@@ -32,7 +40,7 @@ fn activate_all_causes(map: &TestBTreeMap) {
 
 #[test]
 fn test_add() {
-    let mut map = get_test_causality_btree_map();
+    let mut map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.len());
 
     let q = get_test_causaloid_deterministic();
@@ -42,7 +50,7 @@ fn test_add() {
 
 #[test]
 fn test_contains() {
-    let mut map = get_test_causality_btree_map();
+    let mut map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
@@ -54,7 +62,7 @@ fn test_contains() {
 
 #[test]
 fn test_remove() {
-    let mut map = get_test_causality_btree_map();
+    let mut map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
@@ -65,7 +73,7 @@ fn test_remove() {
 
 #[test]
 fn test_get_all_items() {
-    let col = get_test_causality_btree_map();
+    let col = get_test_causality_btree_map_deterministic();
     let all_items = col.get_all_items();
 
     let exp_len = col.len();
@@ -75,7 +83,7 @@ fn test_get_all_items() {
 
 #[test]
 fn test_evaluate_deterministic_propagation() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -94,7 +102,7 @@ fn test_evaluate_deterministic_propagation() {
 
 #[test]
 fn test_evaluate_probabilistic_propagation() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_probabilistic();
 
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
@@ -115,7 +123,7 @@ fn test_evaluate_probabilistic_propagation() {
 
 #[test]
 fn test_evaluate_mixed_propagation() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -134,7 +142,7 @@ fn test_evaluate_mixed_propagation() {
 
 #[test]
 fn test_explain() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
     activate_all_causes(&map);
 
     let single_explanation = "Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)";
@@ -148,18 +156,18 @@ fn test_explain() {
 
 #[test]
 fn test_len() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.len());
 }
 
 #[test]
 fn test_is_empty() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
     assert!(!map.is_empty());
 }
 
 #[test]
 fn test_to_vec() {
-    let map = get_test_causality_btree_map();
+    let map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.to_vec().len());
 }

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -87,14 +87,14 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    let res = map.evaluate_deterministic(&effect_success, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    let res = map.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -107,7 +107,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_probabilistic(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
@@ -115,7 +115,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
@@ -127,14 +127,14 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_mixed(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));

--- a/deep_causality/tests/extensions/causable/causable_empty_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_empty_tests.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+use deep_causality::{AggregateLogic, BaseCausaloid, CausableReasoning, PropagatingEffect};
+
+#[test]
+fn test_get_all_items_empty() {
+    let col: [BaseCausaloid; 0] = [];
+    let exp_len = col.len();
+    assert_eq!(exp_len, 0);
+}
+
+#[test]
+fn test_evaluate_deterministic_propagation_empty() {
+    let col: [BaseCausaloid; 0] = [];
+    let exp_len = col.len();
+    assert_eq!(exp_len, 0);
+
+    let effect_fail = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_evaluate_probabilistic_propagation_empty() {
+    let col: [BaseCausaloid; 0] = [];
+    let exp_len = col.len();
+    assert_eq!(exp_len, 0);
+
+    let effect_fail = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_evaluate_probabilistic_mixed_empty() {
+    let col: [BaseCausaloid; 0] = [];
+    let exp_len = col.len();
+    assert_eq!(exp_len, 0);
+
+    let effect_fail = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_err());
+}

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -103,14 +103,14 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    let res = map.evaluate_deterministic(&effect_success, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    let res = map.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -123,7 +123,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_probabilistic(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
@@ -131,7 +131,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
@@ -143,7 +143,7 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = map.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_mixed(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     // All mixed cased evaluate
@@ -156,7 +156,7 @@ fn test_evaluate_mixed_propagation_err() {
 
     //
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = map.evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_err());
 }
 

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -28,14 +28,6 @@ fn get_mixed_test_causality_map() -> TestHashMap {
     ])
 }
 
-fn get_mixed_test_halting_causality_map() -> TestHashMap {
-    HashMap::from([
-        (1, get_test_causaloid_deterministic_true()),
-        (2, get_test_causaloid_deterministic_true()),
-        (3, get_test_causaloid_halting()),
-    ])
-}
-
 fn get_mixed_test_ctx_link_causality_map() -> TestHashMap {
     HashMap::from([
         (1, get_test_causaloid_deterministic_true()),
@@ -148,18 +140,6 @@ fn test_evaluate_mixed_propagation() {
         .unwrap();
     // This is false b/c the AggregateLogic fails i.e. not all causes evaluate
     assert_eq!(res_success, PropagatingEffect::Probabilistic(0.0));
-}
-
-#[test]
-fn test_evaluate_mixed_propagation_halted() {
-    let map = get_mixed_test_halting_causality_map();
-
-    // Case 2: One fails, chain becomes deterministically false.
-    let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = map
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
-    assert_eq!(res, PropagatingEffect::Halting);
 }
 
 #[test]

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -124,7 +124,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = map
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
@@ -132,7 +132,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = map
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
@@ -144,7 +144,7 @@ fn test_evaluate_mixed_propagation() {
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = map
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     // All mixed cased evaluate
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
@@ -156,7 +156,7 @@ fn test_evaluate_mixed_propagation_err() {
 
     //
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All);
+    let res_fail = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res_fail.is_err());
 }
 

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -12,11 +12,19 @@ use deep_causality::*;
 type TestHashMap = HashMap<i8, BaseCausaloid>;
 
 // Helper function to create a standard test HashMap.
-fn get_test_causality_map() -> TestHashMap {
+fn get_deterministic_test_causality_map() -> TestHashMap {
     HashMap::from([
         (1, get_test_causaloid_deterministic()),
         (2, get_test_causaloid_deterministic()),
         (3, get_test_causaloid_deterministic()),
+    ])
+}
+
+fn get_probabilistic_test_causality_map() -> TestHashMap {
+    HashMap::from([
+        (1, get_test_causaloid_probabilistic()),
+        (2, get_test_causaloid_probabilistic()),
+        (3, get_test_causaloid_probabilistic()),
     ])
 }
 
@@ -48,7 +56,7 @@ fn activate_all_causes(map: &TestHashMap) {
 
 #[test]
 fn test_add() {
-    let mut map = get_test_causality_map();
+    let mut map = get_deterministic_test_causality_map();
     assert_eq!(3, map.len());
 
     let q = get_test_causaloid_deterministic();
@@ -58,7 +66,7 @@ fn test_add() {
 
 #[test]
 fn test_contains() {
-    let mut map = get_test_causality_map();
+    let mut map = get_deterministic_test_causality_map();
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
@@ -70,7 +78,7 @@ fn test_contains() {
 
 #[test]
 fn test_remove() {
-    let mut map = get_test_causality_map();
+    let mut map = get_deterministic_test_causality_map();
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
@@ -81,7 +89,7 @@ fn test_remove() {
 
 #[test]
 fn test_get_all_items() {
-    let col = get_test_causality_map();
+    let col = get_deterministic_test_causality_map();
     let all_items = col.get_all_items();
 
     let exp_len = col.len();
@@ -91,7 +99,7 @@ fn test_get_all_items() {
 
 #[test]
 fn test_evaluate_deterministic_propagation() {
-    let map = get_test_causality_map();
+    let map = get_deterministic_test_causality_map();
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -110,7 +118,7 @@ fn test_evaluate_deterministic_propagation() {
 
 #[test]
 fn test_evaluate_probabilistic_propagation() {
-    let map = get_test_causality_map();
+    let map = get_probabilistic_test_causality_map();
 
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
@@ -138,8 +146,8 @@ fn test_evaluate_mixed_propagation() {
     let res_success = map
         .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
         .unwrap();
-    // This is false b/c the AggregateLogic fails i.e. not all causes evaluate
-    assert_eq!(res_success, PropagatingEffect::Probabilistic(0.0));
+    // All mixed cased evaluate
+    assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 }
 
 #[test]
@@ -154,7 +162,7 @@ fn test_evaluate_mixed_propagation_err() {
 
 #[test]
 fn test_explain() {
-    let map = get_test_causality_map();
+    let map = get_deterministic_test_causality_map();
     activate_all_causes(&map);
 
     let single_explanation = "Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)";
@@ -167,18 +175,18 @@ fn test_explain() {
 
 #[test]
 fn test_len() {
-    let map = get_test_causality_map();
+    let map = get_deterministic_test_causality_map();
     assert_eq!(3, map.len());
 }
 
 #[test]
 fn test_is_empty() {
-    let map = get_test_causality_map();
+    let map = get_deterministic_test_causality_map();
     assert!(!map.is_empty());
 }
 
 #[test]
 fn test_to_vec() {
-    let map = get_test_causality_map();
+    let map = get_deterministic_test_causality_map();
     assert_eq!(3, map.to_vec().len());
 }

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -103,16 +103,16 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All)
-        .unwrap();
+    let res = map.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map
-        .evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
+    let res = map.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -123,17 +123,17 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
 
@@ -143,9 +143,9 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = map
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = map.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     // All mixed cased evaluate
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 }
@@ -156,8 +156,8 @@ fn test_evaluate_mixed_propagation_err() {
 
     //
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
-    assert!(res_fail.is_err());
+    let res = map.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_err());
 }
 
 #[test]
@@ -166,7 +166,9 @@ fn test_explain() {
     activate_all_causes(&map);
 
     let single_explanation = "Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)";
-    let actual = map.explain().unwrap();
+    let res = map.explain();
+    assert!(res.is_ok());
+    let actual = res.unwrap();
 
     // HashMap iteration order is not guaranteed.
     // We check that the explanation for each of the 3 causes is present.

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -14,9 +14,9 @@ type TestHashMap = HashMap<i8, BaseCausaloid>;
 // Helper function to create a standard test HashMap.
 fn get_test_causality_map() -> TestHashMap {
     HashMap::from([
-        (1, get_test_causaloid()),
-        (2, get_test_causaloid()),
-        (3, get_test_causaloid()),
+        (1, get_test_causaloid_deterministic()),
+        (2, get_test_causaloid_deterministic()),
+        (3, get_test_causaloid_deterministic()),
     ])
 }
 
@@ -51,7 +51,7 @@ fn test_add() {
     let mut map = get_test_causality_map();
     assert_eq!(3, map.len());
 
-    let q = get_test_causaloid();
+    let q = get_test_causaloid_deterministic();
     map.insert(4, q);
     assert_eq!(4, map.len());
 }
@@ -62,7 +62,7 @@ fn test_contains() {
     assert_eq!(3, map.len());
     assert!(map.contains_key(&1));
 
-    let q = get_test_causaloid();
+    let q = get_test_causaloid_deterministic();
     map.insert(4, q);
     assert_eq!(4, map.len());
     assert!(map.contains_key(&4));

--- a/deep_causality/tests/extensions/causable/causable_modalities_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_modalities_tests.rs
@@ -1,0 +1,410 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use std::array;
+
+use deep_causality::utils_test::test_utils::*;
+use deep_causality::*;
+
+// Helper function to create a standard test array of deterministic causaloids.
+pub fn get_test_causality_array_deterministic(all_true: bool) -> [BaseCausaloid; 10] {
+    if all_true {
+        array::from_fn(|_| get_test_causaloid_deterministic_true())
+    } else {
+        array::from_fn(|_| get_test_causaloid_deterministic_false())
+    }
+}
+
+// Helper function to create a standard test array of probabilistic causaloids.
+// The causaloids will return 1.0 (true) or 0.0 (false) based on the input effect.
+pub fn get_test_causality_array_probabilistic() -> [BaseCausaloid; 10] {
+    array::from_fn(|_| get_test_causaloid_probabilistic())
+}
+
+// Helper function to create a mixed array of deterministic and probabilistic causaloids.
+// This version contains causaloids that will always evaluate to false.
+pub fn get_test_causality_array_mixed_with_failures() -> [BaseCausaloid; 20] {
+    let mut causaloids: Vec<BaseCausaloid> = Vec::with_capacity(20);
+    // 5 deterministic true
+    for _ in 0..5 {
+        causaloids.push(get_test_causaloid_deterministic_true());
+    }
+    // 5 deterministic false
+    for _ in 0..5 {
+        causaloids.push(get_test_causaloid_deterministic_false());
+    }
+    // 10 probabilistic
+    for _ in 0..10 {
+        causaloids.push(get_test_causaloid_probabilistic());
+    }
+    causaloids.try_into().unwrap()
+}
+
+// Helper function for a mixed array where all causaloids can succeed.
+pub fn get_test_causality_array_mixed_all_succeed() -> [BaseCausaloid; 15] {
+    let mut causaloids: Vec<BaseCausaloid> = Vec::with_capacity(15);
+    // 5 deterministic true
+    for _ in 0..5 {
+        causaloids.push(get_test_causaloid_deterministic_true());
+    }
+    // 10 probabilistic
+    for _ in 0..10 {
+        causaloids.push(get_test_causaloid_probabilistic());
+    }
+    causaloids.try_into().unwrap()
+}
+
+// --- Tests for evaluate_deterministic_propagation ---
+
+#[test]
+fn test_deterministic_propagation_all() {
+    let col = get_test_causality_array_deterministic(true);
+    let effect = PropagatingEffect::Numerical(0.99);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    let col = get_test_causality_array_deterministic(false);
+    let effect = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+#[test]
+fn test_deterministic_propagation_any() {
+    let col = get_test_causality_array_deterministic(true);
+    let effect = PropagatingEffect::Numerical(0.99);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    let col = get_test_causality_array_deterministic(false);
+    let effect = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // Mixed: one true, rest false
+    let mut mixed_col = get_test_causality_array_deterministic(false).to_vec();
+    mixed_col[0] = get_test_causaloid_deterministic_true();
+    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    assert_eq!(res.unwrap(), PropagatingEffect::Deterministic(true));
+}
+
+#[test]
+fn test_deterministic_propagation_none() {
+    let col = get_test_causality_array_deterministic(true);
+    let effect = PropagatingEffect::Numerical(0.99);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    let col = get_test_causality_array_deterministic(false);
+    let effect = PropagatingEffect::Numerical(0.1);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: one true, rest false
+    let mut mixed_col = get_test_causality_array_deterministic(false).to_vec();
+    mixed_col[0] = get_test_causaloid_deterministic_true();
+    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+#[test]
+fn test_deterministic_propagation_some() {
+    let effect = PropagatingEffect::Numerical(0.99);
+
+    // All true, Some(5) should be true
+    let col = get_test_causality_array_deterministic(true);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(5));
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // All false, Some(1) should be false
+    let col = get_test_causality_array_deterministic(false);
+    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(1));
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // Mixed: 5 true, 5 false, Some(5) should be true
+    let mut mixed_col = get_test_causality_array_deterministic(false).to_vec();
+
+    for item in mixed_col.iter_mut().take(5) {
+        *item = get_test_causaloid_deterministic_true();
+    }
+
+    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(5));
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: 5 true, 5 false, Some(6) should be false
+    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(6));
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+// --- Tests for evaluate_probabilistic_propagation ---
+
+#[test]
+fn test_probabilistic_propagation_all() {
+    let col = get_test_causality_array_probabilistic();
+    let effect = PropagatingEffect::Numerical(0.99); // Makes all causaloids return 1.0
+    let res = col.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Probabilistic(1.0));
+
+    let effect = PropagatingEffect::Numerical(0.1); // Makes all causaloids return 0.0
+    let res = col.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Probabilistic(0.0));
+
+    // Test with specific probabilities
+    fn causal_fn_half(_: &PropagatingEffect) -> Result<PropagatingEffect, CausalityError> {
+        Ok(PropagatingEffect::Probabilistic(0.5))
+    }
+    let p1 = Causaloid::new(1, causal_fn_half, "p=0.5");
+
+    fn causal_fn_quarter(_: &PropagatingEffect) -> Result<PropagatingEffect, CausalityError> {
+        Ok(PropagatingEffect::Probabilistic(0.25))
+    }
+    let p2 = Causaloid::new(2, causal_fn_quarter, "p=0.25");
+
+    let coll: Vec<BaseCausaloid> = vec![p1, p2];
+    let effect = PropagatingEffect::Numerical(0.0);
+    let res = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Probabilistic(0.125));
+}
+
+#[test]
+fn test_probabilistic_propagation_any() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns 1.0 (true > 0.5)
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns 0.0 (false <= 0.5)
+
+    // All false, Any should be false
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // All true, Any should be true
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: one true, rest false, Any should be true
+    let mut mixed_col = get_test_causality_array_probabilistic().to_vec();
+    mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
+    let res =
+        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+}
+
+#[test]
+fn test_probabilistic_propagation_none() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns 1.0 (true > 0.5)
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns 0.0 (false <= 0.5)
+
+    // All false, None should be true
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // All true, None should be false
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // Mixed: one true, rest false, None should be false
+    let mut mixed_col = get_test_causality_array_probabilistic().to_vec();
+    mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
+    let res =
+        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+#[test]
+fn test_probabilistic_propagation_some() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns 1.0 (true > 0.5)
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns 0.0 (false <= 0.5)
+
+    // All true, Some(5) should be true
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::Some(5), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // All false, Some(1) should be false
+    let col = get_test_causality_array_probabilistic();
+    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(1), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // Mixed: 5 true, 5 false, Some(5) should be true
+    let mut mixed_col = get_test_causality_array_probabilistic().to_vec();
+    for item in mixed_col.iter_mut().take(5) {
+        *item = get_test_causaloid_deterministic_true();
+    }
+    let res =
+        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(5), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: 5 true, 5 false, Some(6) should be false
+    let res =
+        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(6), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+// --- Tests for evaluate_mixed_propagation ---
+
+#[test]
+fn test_mixed_propagation_all_failure() {
+    let col = get_test_causality_array_mixed_with_failures();
+    let effect = PropagatingEffect::Numerical(0.55);
+    let res = col.evaluate_mixed_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+#[test]
+fn test_mixed_propagation_all_success() {
+    let col = get_test_causality_array_mixed_all_succeed();
+    let effect = PropagatingEffect::Numerical(0.99);
+    let res = col.evaluate_mixed_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+}
+
+#[test]
+fn test_mixed_propagation_any() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns true/1.0
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns false/0.0
+
+    // All false, Any should be true (due to deterministic true causaloids)
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // All true, Any should be true
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: 5 true, 5 false, 10 probabilistic (all true with effect_true), Any should be true
+    let mut mixed_col = get_test_causality_array_mixed_all_succeed().to_vec();
+    // Force one of the initially false deterministic causaloids to be true
+    mixed_col[1] = get_test_causaloid_deterministic_true();
+    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+}
+
+#[test]
+fn test_mixed_propagation_none() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns true/1.0
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns false/0.0
+
+    // All false, None should be false
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // All true, None should be false
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+
+    // Mixed: one true, rest false, None should be false
+    let mut mixed_col = get_test_causality_array_mixed_all_succeed().to_vec();
+    mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
+    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}
+
+#[test]
+fn test_mixed_propagation_some() {
+    let effect_true = PropagatingEffect::Numerical(0.99); // Causaloid returns true/1.0
+    let effect_false = PropagatingEffect::Numerical(0.1); // Causaloid returns false/0.0
+
+    // All true, Some(5) should be true
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::Some(5), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // All false, Some(1) should be true
+    let col = get_test_causality_array_mixed_all_succeed();
+    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(1), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: 5 true, 5 false, Some(5) should be true
+    let mut mixed_col = get_test_causality_array_mixed_all_succeed().to_vec();
+    for item in mixed_col.iter_mut().take(5) {
+        *item = get_test_causaloid_deterministic_true();
+    }
+    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(5), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(true));
+
+    // Mixed: 5 true, 5 false, Some(6) should be false
+    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(6), 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
+    assert_eq!(result, PropagatingEffect::Deterministic(false));
+}

--- a/deep_causality/tests/extensions/causable/causable_modalities_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_modalities_tests.rs
@@ -62,14 +62,14 @@ pub fn get_test_causality_array_mixed_all_succeed() -> [BaseCausaloid; 15] {
 fn test_deterministic_propagation_all() {
     let col = get_test_causality_array_deterministic(true);
     let effect = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::All);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     let col = get_test_causality_array_deterministic(false);
     let effect = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::All);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -79,14 +79,14 @@ fn test_deterministic_propagation_all() {
 fn test_deterministic_propagation_any() {
     let col = get_test_causality_array_deterministic(true);
     let effect = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::Any);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     let col = get_test_causality_array_deterministic(false);
     let effect = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::Any);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -94,7 +94,7 @@ fn test_deterministic_propagation_any() {
     // Mixed: one true, rest false
     let mut mixed_col = get_test_causality_array_deterministic(false).to_vec();
     mixed_col[0] = get_test_causaloid_deterministic_true();
-    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Any);
+    let res = mixed_col.evaluate_deterministic(&effect, &AggregateLogic::Any);
     assert_eq!(res.unwrap(), PropagatingEffect::Deterministic(true));
 }
 
@@ -102,14 +102,14 @@ fn test_deterministic_propagation_any() {
 fn test_deterministic_propagation_none() {
     let col = get_test_causality_array_deterministic(true);
     let effect = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::None);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
 
     let col = get_test_causality_array_deterministic(false);
     let effect = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::None);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -117,7 +117,7 @@ fn test_deterministic_propagation_none() {
     // Mixed: one true, rest false
     let mut mixed_col = get_test_causality_array_deterministic(false).to_vec();
     mixed_col[0] = get_test_causaloid_deterministic_true();
-    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::None);
+    let res = mixed_col.evaluate_deterministic(&effect, &AggregateLogic::None);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -129,14 +129,14 @@ fn test_deterministic_propagation_some() {
 
     // All true, Some(5) should be true
     let col = get_test_causality_array_deterministic(true);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(5));
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::Some(5));
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // All false, Some(1) should be false
     let col = get_test_causality_array_deterministic(false);
-    let res = col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(1));
+    let res = col.evaluate_deterministic(&effect, &AggregateLogic::Some(1));
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -148,13 +148,13 @@ fn test_deterministic_propagation_some() {
         *item = get_test_causaloid_deterministic_true();
     }
 
-    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(5));
+    let res = mixed_col.evaluate_deterministic(&effect, &AggregateLogic::Some(5));
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // Mixed: 5 true, 5 false, Some(6) should be false
-    let res = mixed_col.evaluate_deterministic_propagation(&effect, &AggregateLogic::Some(6));
+    let res = mixed_col.evaluate_deterministic(&effect, &AggregateLogic::Some(6));
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -166,13 +166,13 @@ fn test_deterministic_propagation_some() {
 fn test_probabilistic_propagation_all() {
     let col = get_test_causality_array_probabilistic();
     let effect = PropagatingEffect::Numerical(0.99); // Makes all causaloids return 1.0
-    let res = col.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Probabilistic(1.0));
 
     let effect = PropagatingEffect::Numerical(0.1); // Makes all causaloids return 0.0
-    let res = col.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Probabilistic(0.0));
@@ -190,7 +190,7 @@ fn test_probabilistic_propagation_all() {
 
     let coll: Vec<BaseCausaloid> = vec![p1, p2];
     let effect = PropagatingEffect::Numerical(0.0);
-    let res = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = coll.evaluate_probabilistic(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Probabilistic(0.125));
@@ -203,14 +203,14 @@ fn test_probabilistic_propagation_any() {
 
     // All false, Any should be false
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    let res = col.evaluate_probabilistic(&effect_false, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
 
     // All true, Any should be true
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::Any, 0.5);
+    let res = col.evaluate_probabilistic(&effect_true, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -218,8 +218,7 @@ fn test_probabilistic_propagation_any() {
     // Mixed: one true, rest false, Any should be true
     let mut mixed_col = get_test_causality_array_probabilistic().to_vec();
     mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
-    let res =
-        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    let res = mixed_col.evaluate_probabilistic(&effect_false, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -232,14 +231,14 @@ fn test_probabilistic_propagation_none() {
 
     // All false, None should be true
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    let res = col.evaluate_probabilistic(&effect_false, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // All true, None should be false
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::None, 0.5);
+    let res = col.evaluate_probabilistic(&effect_true, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -247,8 +246,7 @@ fn test_probabilistic_propagation_none() {
     // Mixed: one true, rest false, None should be false
     let mut mixed_col = get_test_causality_array_probabilistic().to_vec();
     mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
-    let res =
-        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    let res = mixed_col.evaluate_probabilistic(&effect_false, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -261,14 +259,14 @@ fn test_probabilistic_propagation_some() {
 
     // All true, Some(5) should be true
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_true, &AggregateLogic::Some(5), 0.5);
+    let res = col.evaluate_probabilistic(&effect_true, &AggregateLogic::Some(5), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // All false, Some(1) should be false
     let col = get_test_causality_array_probabilistic();
-    let res = col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(1), 0.5);
+    let res = col.evaluate_probabilistic(&effect_false, &AggregateLogic::Some(1), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -278,15 +276,13 @@ fn test_probabilistic_propagation_some() {
     for item in mixed_col.iter_mut().take(5) {
         *item = get_test_causaloid_deterministic_true();
     }
-    let res =
-        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(5), 0.5);
+    let res = mixed_col.evaluate_probabilistic(&effect_false, &AggregateLogic::Some(5), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // Mixed: 5 true, 5 false, Some(6) should be false
-    let res =
-        mixed_col.evaluate_probabilistic_propagation(&effect_false, &AggregateLogic::Some(6), 0.5);
+    let res = mixed_col.evaluate_probabilistic(&effect_false, &AggregateLogic::Some(6), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -298,7 +294,7 @@ fn test_probabilistic_propagation_some() {
 fn test_mixed_propagation_all_failure() {
     let col = get_test_causality_array_mixed_with_failures();
     let effect = PropagatingEffect::Numerical(0.55);
-    let res = col.evaluate_mixed_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
 
     let result = res.unwrap();
@@ -309,7 +305,7 @@ fn test_mixed_propagation_all_failure() {
 fn test_mixed_propagation_all_success() {
     let col = get_test_causality_array_mixed_all_succeed();
     let effect = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_mixed_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
 
     let result = res.unwrap();
@@ -323,14 +319,14 @@ fn test_mixed_propagation_any() {
 
     // All false, Any should be true (due to deterministic true causaloids)
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    let res = col.evaluate_mixed(&effect_false, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // All true, Any should be true
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::Any, 0.5);
+    let res = col.evaluate_mixed(&effect_true, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -339,7 +335,7 @@ fn test_mixed_propagation_any() {
     let mut mixed_col = get_test_causality_array_mixed_all_succeed().to_vec();
     // Force one of the initially false deterministic causaloids to be true
     mixed_col[1] = get_test_causaloid_deterministic_true();
-    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Any, 0.5);
+    let res = mixed_col.evaluate_mixed(&effect_false, &AggregateLogic::Any, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -352,14 +348,14 @@ fn test_mixed_propagation_none() {
 
     // All false, None should be false
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    let res = col.evaluate_mixed(&effect_false, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
 
     // All true, None should be false
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::None, 0.5);
+    let res = col.evaluate_mixed(&effect_true, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -367,7 +363,7 @@ fn test_mixed_propagation_none() {
     // Mixed: one true, rest false, None should be false
     let mut mixed_col = get_test_causality_array_mixed_all_succeed().to_vec();
     mixed_col[0] = get_test_causaloid_deterministic_true(); // Force one to be true
-    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::None, 0.5);
+    let res = mixed_col.evaluate_mixed(&effect_false, &AggregateLogic::None, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));
@@ -380,14 +376,14 @@ fn test_mixed_propagation_some() {
 
     // All true, Some(5) should be true
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_true, &AggregateLogic::Some(5), 0.5);
+    let res = col.evaluate_mixed(&effect_true, &AggregateLogic::Some(5), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // All false, Some(1) should be true
     let col = get_test_causality_array_mixed_all_succeed();
-    let res = col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(1), 0.5);
+    let res = col.evaluate_mixed(&effect_false, &AggregateLogic::Some(1), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
@@ -397,13 +393,13 @@ fn test_mixed_propagation_some() {
     for item in mixed_col.iter_mut().take(5) {
         *item = get_test_causaloid_deterministic_true();
     }
-    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(5), 0.5);
+    let res = mixed_col.evaluate_mixed(&effect_false, &AggregateLogic::Some(5), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(true));
 
     // Mixed: 5 true, 5 false, Some(6) should be false
-    let res = mixed_col.evaluate_mixed_propagation(&effect_false, &AggregateLogic::Some(6), 0.5);
+    let res = mixed_col.evaluate_mixed(&effect_false, &AggregateLogic::Some(6), 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
     assert_eq!(result, PropagatingEffect::Deterministic(false));

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -53,16 +53,16 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -73,17 +73,17 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
 
@@ -93,16 +93,16 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -113,7 +113,9 @@ fn test_explain() {
 
     let single_explanation = "\n * Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)\n";
     let expected = single_explanation.repeat(3);
-    let actual = col.explain().unwrap();
+    let res = col.explain();
+    assert!(res.is_ok());
+    let actual = res.unwrap();
     assert_eq!(expected, actual);
 }
 

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -74,7 +74,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = col
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
@@ -82,7 +82,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
@@ -94,14 +94,14 @@ fn test_evaluate_mixed_propagation() {
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -28,7 +28,7 @@ fn test_add() {
     let mut col = get_test_causality_vec_deque();
     assert_eq!(3, col.len());
 
-    let q = get_test_causaloid();
+    let q = get_test_causaloid_deterministic();
     col.push_back(q);
     assert_eq!(4, col.len());
 }

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -9,8 +9,12 @@ use deep_causality::utils_test::test_utils::*;
 use deep_causality::*;
 
 // Helper function to create a standard test VecDeque.
-fn get_test_causality_vec_deque() -> VecDeque<BaseCausaloid> {
-    VecDeque::from_iter(get_test_causality_vec())
+fn get_deterministic_test_causality_vec_deque() -> VecDeque<BaseCausaloid> {
+    VecDeque::from_iter(get_deterministic_test_causality_vec())
+}
+
+fn get_probabilistic_test_causality_vec_deque() -> VecDeque<BaseCausaloid> {
+    VecDeque::from_iter(get_probabilistic_test_causality_vec())
 }
 
 // Helper to activate all causes in a collection for testing purposes.
@@ -25,7 +29,7 @@ fn activate_all_causes(col: &VecDeque<BaseCausaloid>) {
 
 #[test]
 fn test_add() {
-    let mut col = get_test_causality_vec_deque();
+    let mut col = get_deterministic_test_causality_vec_deque();
     assert_eq!(3, col.len());
 
     let q = get_test_causaloid_deterministic();
@@ -35,7 +39,7 @@ fn test_add() {
 
 #[test]
 fn test_get_all_items() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
     let all_items = col.get_all_items();
 
     let exp_len = col.len();
@@ -45,7 +49,7 @@ fn test_get_all_items() {
 
 #[test]
 fn test_evaluate_deterministic_propagation() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -64,7 +68,7 @@ fn test_evaluate_deterministic_propagation() {
 
 #[test]
 fn test_evaluate_probabilistic_propagation() {
-    let col = get_test_causality_vec_deque();
+    let col = get_probabilistic_test_causality_vec_deque();
 
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
@@ -85,7 +89,7 @@ fn test_evaluate_probabilistic_propagation() {
 
 #[test]
 fn test_evaluate_mixed_propagation() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -104,7 +108,7 @@ fn test_evaluate_mixed_propagation() {
 
 #[test]
 fn test_explain() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
     activate_all_causes(&col);
 
     let single_explanation = "\n * Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)\n";
@@ -115,18 +119,18 @@ fn test_explain() {
 
 #[test]
 fn test_len() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
     assert_eq!(3, col.len());
 }
 
 #[test]
 fn test_is_empty() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
     assert!(!col.is_empty());
 }
 
 #[test]
 fn test_to_vec() {
-    let col = get_test_causality_vec_deque();
+    let col = get_deterministic_test_causality_vec_deque();
     assert_eq!(3, col.to_vec().len());
 }

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -53,14 +53,14 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_success, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -73,7 +73,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
@@ -81,7 +81,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
@@ -93,14 +93,14 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -42,16 +42,16 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All)
-        .unwrap();
+    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -62,17 +62,17 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
 
@@ -82,16 +82,16 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = col.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
 
@@ -102,7 +102,9 @@ fn test_explain() {
 
     let single_explanation = "\n * Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)\n";
     let expected = single_explanation.repeat(3);
-    let actual = col.explain().unwrap();
+    let res = col.explain();
+    assert!(res.is_ok());
+    let actual = res.unwrap();
     assert_eq!(expected, actual);
 }
 
@@ -139,6 +141,8 @@ fn test_evaluate_deterministic_propagation_error_non_deterministic_effect() {
 
     // Assert: This covers the error branch for non-deterministic effects.
     assert!(result.is_err());
+    let result = coll.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.contains(
@@ -164,12 +168,12 @@ fn test_evaluate_probabilistic_propagation_success() {
 
     // Act: Evaluate with probabilistic propagation.
     let effect = PropagatingEffect::Numerical(0.0);
-    let res = coll
-        .evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5)
-        .unwrap();
+    let res = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    assert!(res.is_ok());
+    let result = res.unwrap();
 
     // Assert: This covers the main logic branch, ensuring probabilities are multiplied.
-    assert_eq!(res, PropagatingEffect::Probabilistic(0.125));
+    assert_eq!(result, PropagatingEffect::Probabilistic(0.125));
 }
 
 #[test]

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -63,7 +63,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = col
-        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
 
@@ -71,7 +71,7 @@ fn test_evaluate_probabilistic_propagation() {
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
 }
@@ -83,14 +83,14 @@ fn test_evaluate_mixed_propagation() {
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
     let res_success = col
-        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
     let res_fail = col
-        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All)
+        .evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5)
         .unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
 }
@@ -165,7 +165,7 @@ fn test_evaluate_probabilistic_propagation_success() {
     // Act: Evaluate with probabilistic propagation.
     let effect = PropagatingEffect::Numerical(0.0);
     let res = coll
-        .evaluate_probabilistic_propagation(&effect, &AggregateLogic::All)
+        .evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5)
         .unwrap();
 
     // Assert: This covers the main logic branch, ensuring probabilities are multiplied.
@@ -181,7 +181,7 @@ fn test_evaluate_probabilistic_propagation_error_contextual_link() {
 
     // Act: Evaluate with probabilistic propagation.
     let effect = PropagatingEffect::Numerical(0.0);
-    let result = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All);
+    let result = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
 
     // Assert: This covers the error branch for invalid ContextualLink effects.
     assert!(result.is_err());

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -18,7 +18,7 @@ fn activate_all_causes(col: &BaseCausaloidVec) {
 
 #[test]
 fn test_add() {
-    let mut col = test_utils::get_test_causality_vec();
+    let mut col = test_utils::get_deterministic_test_causality_vec();
     assert_eq!(3, col.len());
 
     let q = test_utils::get_test_causaloid_deterministic();
@@ -28,7 +28,7 @@ fn test_add() {
 
 #[test]
 fn test_get_all_items() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
     let all_items = col.get_all_items();
 
     let exp_len = col.len();
@@ -38,7 +38,7 @@ fn test_get_all_items() {
 
 #[test]
 fn test_evaluate_deterministic_propagation() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -57,7 +57,7 @@ fn test_evaluate_deterministic_propagation() {
 
 #[test]
 fn test_evaluate_probabilistic_propagation() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_probabilistic_test_causality_vec();
 
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
@@ -78,7 +78,7 @@ fn test_evaluate_probabilistic_propagation() {
 
 #[test]
 fn test_evaluate_mixed_propagation() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
@@ -97,7 +97,7 @@ fn test_evaluate_mixed_propagation() {
 
 #[test]
 fn test_explain() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
     activate_all_causes(&col);
 
     let single_explanation = "\n * Causaloid: 1 'tests whether data exceeds threshold of 0.55' evaluated to: PropagatingEffect::Deterministic(true)\n";
@@ -108,19 +108,19 @@ fn test_explain() {
 
 #[test]
 fn test_len() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
     assert_eq!(3, col.len());
 }
 
 #[test]
 fn test_is_empty() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
     assert!(!col.is_empty());
 }
 
 #[test]
 fn test_to_vec() {
-    let col = test_utils::get_test_causality_vec();
+    let col = test_utils::get_deterministic_test_causality_vec();
     assert_eq!(3, col.to_vec().len());
 }
 
@@ -185,6 +185,4 @@ fn test_evaluate_probabilistic_propagation_error_contextual_link() {
 
     // Assert: This covers the error branch for invalid ContextualLink effects.
     assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("Encountered a ContextualLink in a probabilistic chain evaluation."));
 }

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -173,23 +173,6 @@ fn test_evaluate_probabilistic_propagation_success() {
 }
 
 #[test]
-fn test_evaluate_probabilistic_propagation_with_halting() {
-    // Setup: A collection with a probabilistic causaloid followed by a halting one.
-    let probabilistic_causaloid = test_utils::get_test_causaloid_probabilistic();
-    let halting_causaloid = test_utils::get_test_causaloid_halting();
-    let coll: Vec<BaseCausaloid> = vec![probabilistic_causaloid, halting_causaloid];
-
-    // Act: Evaluate with probabilistic propagation.
-    let effect = PropagatingEffect::Numerical(0.0);
-    let res = coll
-        .evaluate_probabilistic_propagation(&effect, &AggregateLogic::All)
-        .unwrap();
-
-    // Assert: This covers the Halting branch, which should take precedence.
-    assert_eq!(res, PropagatingEffect::Halting);
-}
-
-#[test]
 fn test_evaluate_probabilistic_propagation_error_contextual_link() {
     // Setup: A collection containing a ContextualLink causaloid, which is invalid for this function.
     let probabilistic_causaloid = test_utils::get_test_causaloid_probabilistic();

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -21,7 +21,7 @@ fn test_add() {
     let mut col = test_utils::get_test_causality_vec();
     assert_eq!(3, col.len());
 
-    let q = test_utils::get_test_causaloid();
+    let q = test_utils::get_test_causaloid_deterministic();
     col.push(q);
     assert_eq!(4, col.len());
 }

--- a/deep_causality/tests/extensions/causable/causable_vec_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_tests.rs
@@ -42,14 +42,14 @@ fn test_evaluate_deterministic_propagation() {
 
     // Case 1: All succeed, chain should be deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_deterministic_propagation(&effect_success, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_success, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain should be deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_deterministic_propagation(&effect_fail, &AggregateLogic::All);
+    let res = col.evaluate_deterministic(&effect_fail, &AggregateLogic::All);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -62,7 +62,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 1: All succeed (Deterministic(true) is treated as probability 1.0).
     // The cumulative probability should be 1.0.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_probabilistic_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Probabilistic(1.0));
@@ -70,7 +70,7 @@ fn test_evaluate_probabilistic_propagation() {
     // Case 2: One fails (Deterministic(false) is treated as probability 0.0).
     // The chain should short-circuit and return a cumulative probability of 0.0.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_probabilistic_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_probabilistic(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Probabilistic(0.0));
@@ -82,14 +82,14 @@ fn test_evaluate_mixed_propagation() {
 
     // Case 1: All succeed, chain remains deterministically true.
     let effect_success = PropagatingEffect::Numerical(0.99);
-    let res = col.evaluate_mixed_propagation(&effect_success, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect_success, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_success = res.unwrap();
     assert_eq!(res_success, PropagatingEffect::Deterministic(true));
 
     // Case 2: One fails, chain becomes deterministically false.
     let effect_fail = PropagatingEffect::Numerical(0.1);
-    let res = col.evaluate_mixed_propagation(&effect_fail, &AggregateLogic::All, 0.5);
+    let res = col.evaluate_mixed(&effect_fail, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let res_fail = res.unwrap();
     assert_eq!(res_fail, PropagatingEffect::Deterministic(false));
@@ -137,11 +137,11 @@ fn test_evaluate_deterministic_propagation_error_non_deterministic_effect() {
 
     // Act: Evaluate with deterministic propagation, which expects only deterministic effects.
     let effect = PropagatingEffect::Numerical(0.0);
-    let result = coll.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    let result = coll.evaluate_deterministic(&effect, &AggregateLogic::All);
 
     // Assert: This covers the error branch for non-deterministic effects.
     assert!(result.is_err());
-    let result = coll.evaluate_deterministic_propagation(&effect, &AggregateLogic::All);
+    let result = coll.evaluate_deterministic(&effect, &AggregateLogic::All);
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(
@@ -168,7 +168,7 @@ fn test_evaluate_probabilistic_propagation_success() {
 
     // Act: Evaluate with probabilistic propagation.
     let effect = PropagatingEffect::Numerical(0.0);
-    let res = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    let res = coll.evaluate_probabilistic(&effect, &AggregateLogic::All, 0.5);
     assert!(res.is_ok());
     let result = res.unwrap();
 
@@ -185,7 +185,7 @@ fn test_evaluate_probabilistic_propagation_error_contextual_link() {
 
     // Act: Evaluate with probabilistic propagation.
     let effect = PropagatingEffect::Numerical(0.0);
-    let result = coll.evaluate_probabilistic_propagation(&effect, &AggregateLogic::All, 0.5);
+    let result = coll.evaluate_probabilistic(&effect, &AggregateLogic::All, 0.5);
 
     // Assert: This covers the error branch for invalid ContextualLink effects.
     assert!(result.is_err());

--- a/deep_causality/tests/extensions/causable/mod.rs
+++ b/deep_causality/tests/extensions/causable/mod.rs
@@ -6,6 +6,7 @@
 mod causable_arr_tests;
 #[cfg(test)]
 mod causable_btree_map_tests;
+mod causable_empty_tests;
 #[cfg(test)]
 mod causable_map_tests;
 #[cfg(test)]

--- a/deep_causality/tests/extensions/causable/mod.rs
+++ b/deep_causality/tests/extensions/causable/mod.rs
@@ -9,6 +9,8 @@ mod causable_btree_map_tests;
 #[cfg(test)]
 mod causable_map_tests;
 #[cfg(test)]
+mod causable_modalities_tests;
+#[cfg(test)]
 mod causable_vec_deque_tests;
 #[cfg(test)]
 mod causable_vec_tests;

--- a/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
@@ -89,7 +89,7 @@ fn test_new_with_context() {
 fn test_collection_causaloid_evaluation() {
     let id: IdentificationValue = 1;
     let description = "tests whether data exceeds threshold of 0.55";
-    let causal_coll = test_utils::get_test_causality_vec();
+    let causal_coll = test_utils::get_deterministic_test_causality_vec();
 
     let causaloid = Causaloid::from_causal_collection(id, Arc::new(causal_coll), description);
     assert!(!causaloid.is_singleton());
@@ -109,7 +109,7 @@ fn test_collection_causaloid_evaluation() {
 fn test_from_causal_collection() {
     let id: IdentificationValue = 1;
     let description = "tests whether data exceeds threshold of 0.55";
-    let causal_coll = test_utils::get_test_causality_vec();
+    let causal_coll = test_utils::get_deterministic_test_causality_vec();
 
     let causaloid = Causaloid::from_causal_collection(id, Arc::new(causal_coll), description);
     assert!(!causaloid.is_singleton());
@@ -123,7 +123,7 @@ fn test_from_causal_collection() {
 fn test_from_causal_collection_with_context() {
     let id: IdentificationValue = 1;
     let description = "tests whether data exceeds threshold of 0.55";
-    let causal_coll = test_utils::get_test_causality_vec();
+    let causal_coll = test_utils::get_deterministic_test_causality_vec();
     let context = get_base_context();
 
     let causaloid = Causaloid::from_causal_collection_with_context(

--- a/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
@@ -291,23 +291,6 @@ fn test_debug() {
 }
 
 #[test]
-fn test_evaluate_collection_with_halting_effect() {
-    // Setup: A collection where a Halting causaloid appears before a 'true' one.
-    let halting_causaloid = test_utils::get_test_causaloid_halting();
-    let true_causaloid = test_utils::get_test_causaloid_deterministic_true();
-    let causal_coll = vec![halting_causaloid, true_causaloid];
-    let collection_causaloid =
-        Causaloid::from_causal_collection(100, Arc::new(causal_coll), "Halting Collection");
-
-    // Act
-    let effect = PropagatingEffect::Numerical(0.0);
-    let res = collection_causaloid.evaluate(&effect).unwrap();
-
-    // Assert: The Halting effect should short-circuit the evaluation.
-    assert_eq!(res, PropagatingEffect::Halting);
-}
-
-#[test]
 fn test_evaluate_collection_without_true_effect() {
     // Setup: A collection with only 'false' causaloids.
     let false_causaloid1 = test_utils::get_test_causaloid_deterministic_false();

--- a/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid/causaloid_tests.rs
@@ -236,7 +236,7 @@ fn test_causal_graph_explain() {
 
 #[test]
 fn test_explain() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     // Before evaluation, state is unknown.
     assert!(causaloid.explain().is_err());
 
@@ -251,7 +251,7 @@ fn test_explain() {
 
 #[test]
 fn test_evaluate_singleton() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let effect = PropagatingEffect::Numerical(0.78);
     let res = causaloid.evaluate(&effect).unwrap();
@@ -260,7 +260,7 @@ fn test_evaluate_singleton() {
 
 #[test]
 fn test_to_string() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     // Before evaluation, is_active returns an error, which the Display trait should handle.
     let expected_unevaluated = "Causaloid id: 1 \n Causaloid type: Singleton \n description: tests whether data exceeds threshold of 0.55";
     let actual_unevaluated = causaloid.to_string();
@@ -276,7 +276,7 @@ fn test_to_string() {
 
 #[test]
 fn test_debug() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     // Before evaluation, is_active returns an error, which the Debug trait should handle.
     let expected_unevaluated = "Causaloid id: 1 \n Causaloid type: Singleton \n description: tests whether data exceeds threshold of 0.55";
     let actual_unevaluated = format!("{causaloid:?}");
@@ -357,7 +357,7 @@ fn test_explain_collection_success() {
 fn test_explain_collection_with_sub_explain_error() {
     // Setup: A collection where one causaloid will not be evaluated due to short-circuiting.
     let true_causaloid = test_utils::get_test_causaloid_deterministic_true();
-    let unevaluated_causaloid = test_utils::get_test_causaloid(); // This one will remain unevaluated.
+    let unevaluated_causaloid = test_utils::get_test_causaloid_deterministic(); // This one will remain unevaluated.
 
     let causal_coll = vec![true_causaloid, unevaluated_causaloid];
     let collection_causaloid = Causaloid::from_causal_collection(

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_edges_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_edges_tests.rs
@@ -50,13 +50,13 @@ fn test_default() {
 #[test]
 fn test_add_edge() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let idx_a = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_a = g.contains_causaloid(idx_a);
     assert!(contains_a);
 
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let idx_b = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_b = g.contains_causaloid(idx_b);
     assert!(contains_b);
@@ -71,13 +71,13 @@ fn test_add_edge() {
 #[test]
 fn test_add_edg_with_weight() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let idx_a = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_a = g.contains_causaloid(idx_a);
     assert!(contains_a);
 
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let idx_b = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_b = g.contains_causaloid(idx_b);
     assert!(contains_b);
@@ -93,13 +93,13 @@ fn test_add_edg_with_weight() {
 #[test]
 fn test_remove_edge() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let idx_a = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_a = g.contains_causaloid(idx_a);
     assert!(contains_a);
 
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let idx_b = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains_b = g.contains_causaloid(idx_b);
     assert!(contains_b);

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_explaining_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_explaining_tests.rs
@@ -44,7 +44,7 @@ fn test_explain_all_causes_error_conditions() {
     assert_eq!(res, "The causal graph is empty.");
 
     // Test with a graph that has no root
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     g.add_causaloid(causaloid)
         .expect("Failed to add causaloid A");
     assert!(!g.is_empty());
@@ -89,7 +89,7 @@ fn test_explain_subgraph_from_cause_error_conditions() {
     );
 
     // Error: Start node does not exist
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     g.add_causaloid(causaloid).expect("Failed to add causaloid");
     g.freeze();
     let res = g.explain_subgraph_from_cause(99);

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_freeze_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_freeze_tests.rs
@@ -11,7 +11,7 @@ fn test_freeze_unfreeze() {
     let mut g = CausaloidGraph::new(0);
 
     // Add root causaloid
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     let root_index = g
         .add_root_causaloid(root_causaloid)
         .expect("Failed to add root index");
@@ -19,7 +19,7 @@ fn test_freeze_unfreeze() {
     assert!(contains_root);
 
     // Add causaloid A
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let idx_a = g.add_causaloid(causaloid).expect("Failed to add causaloid");
 
     g.freeze();
@@ -29,7 +29,7 @@ fn test_freeze_unfreeze() {
 
     g.unfreeze();
 
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let idx_b = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let res = g.add_edge(root_index, idx_b);
     assert!(res.is_ok());

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_nodes_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_nodes_tests.rs
@@ -18,7 +18,7 @@ fn get_causal_graph() -> BaseCausalGraph {
 #[test]
 fn test_add_root_causaloid() {
     let mut g = get_causal_graph();
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
 
     let root_index = g
         .add_root_causaloid(root_causaloid)
@@ -30,7 +30,7 @@ fn test_add_root_causaloid() {
 #[test]
 fn test_add_root_causaloid_err() {
     let mut g = get_causal_graph();
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
 
     let root_index = g
         .add_root_causaloid(root_causaloid.clone())
@@ -45,7 +45,7 @@ fn test_add_root_causaloid_err() {
 #[test]
 fn test_get_root_causaloid() {
     let mut g = get_causal_graph();
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
 
     let root_index = g
         .add_root_causaloid(root_causaloid)
@@ -62,7 +62,7 @@ fn test_get_root_causaloid() {
 #[test]
 fn test_get_root_index() {
     let mut g = get_causal_graph();
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
 
     let root_index = g
         .add_root_causaloid(root_causaloid)
@@ -81,7 +81,7 @@ fn test_get_last_index() {
     let res = g.get_last_index();
     assert!(res.is_err());
 
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
 
     let root_index = g
         .add_root_causaloid(root_causaloid)
@@ -105,7 +105,7 @@ fn test_get_last_index() {
 #[test]
 fn test_add_causaloid() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains = g.contains_causaloid(index);
@@ -115,7 +115,7 @@ fn test_add_causaloid() {
 #[test]
 fn test_contains_causaloid() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains = g.contains_causaloid(index);
@@ -125,7 +125,7 @@ fn test_contains_causaloid() {
 #[test]
 fn test_get_causaloid() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains = g.contains_causaloid(index);
@@ -143,7 +143,7 @@ fn test_get_causaloid() {
 #[test]
 fn test_remove_causaloid() {
     let mut g = get_causal_graph();
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     let contains = g.contains_causaloid(index);

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_all_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_all_tests.rs
@@ -48,24 +48,6 @@ fn test_graph_evaluate() {
     // The graph's evaluate returns Deterministic(true) because the sink node C becomes active.
     assert!(res.is_ok());
     assert_eq!(res.unwrap(), PropagatingEffect::Deterministic(true));
-
-    g.unfreeze();
-
-    let causaloid_halt = test_utils::get_test_causaloid_halting();
-    let idx_halt = g
-        .add_causaloid(causaloid_halt)
-        .expect("Failed to add causaloid halt");
-
-    g.add_edge(idx_c, idx_halt).expect("Failed to add edge");
-    g.freeze();
-
-    // Evaluate the graph using the Causable::evaluate method
-    let effect = PropagatingEffect::Numerical(0.99); // A value that will activate all nodes
-    let res = g.evaluate(&effect);
-
-    dbg!(&res);
-    assert!(res.is_ok());
-    assert_eq!(res.unwrap(), PropagatingEffect::Halting);
 }
 
 #[test]

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_all_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_all_tests.rs
@@ -11,28 +11,28 @@ fn test_graph_evaluate() {
     let mut g = CausaloidGraph::new(0);
 
     // Add root causaloid
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     let root_index = g
         .add_root_causaloid(root_causaloid)
         .expect("Failed to add root index");
     assert!(g.contains_causaloid(root_index));
 
     // Add causaloid A
-    let causaloid_a = test_utils::get_test_causaloid();
+    let causaloid_a = test_utils::get_test_causaloid_deterministic();
     let idx_a = g
         .add_causaloid(causaloid_a)
         .expect("Failed to add causaloid A");
     g.add_edge(root_index, idx_a).expect("Failed to add edge");
 
     // Add causaloid B
-    let causaloid_b = test_utils::get_test_causaloid();
+    let causaloid_b = test_utils::get_test_causaloid_deterministic();
     let idx_b = g
         .add_causaloid(causaloid_b)
         .expect("Failed to add causaloid B");
     g.add_edge(root_index, idx_b).expect("Failed to add edge");
 
     // Add causaloid C
-    let causaloid_c = test_utils::get_test_causaloid();
+    let causaloid_c = test_utils::get_test_causaloid_deterministic();
     let idx_c = g
         .add_causaloid(causaloid_c)
         .expect("Failed to add causaloid C");
@@ -67,7 +67,7 @@ fn test_graph_evaluate_error_conditions() {
 
     // Test case 2: Graph is not frozen
     let mut g = CausaloidGraph::new(0);
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     g.add_root_causaloid(root_causaloid).unwrap();
     // DO NOT call g.freeze()
 

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_shortest_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_shortest_tests.rs
@@ -54,10 +54,10 @@ fn test_shortest_path_error_conditions() {
     // Error: No path found between nodes
     let mut g_disconnected = CausaloidGraph::new(0);
     g_disconnected
-        .add_causaloid(test_utils::get_test_causaloid())
+        .add_causaloid(test_utils::get_test_causaloid_deterministic())
         .unwrap(); // index 0
     g_disconnected
-        .add_causaloid(test_utils::get_test_causaloid())
+        .add_causaloid(test_utils::get_test_causaloid_deterministic())
         .unwrap(); // index 1
     g_disconnected.freeze();
 

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_single_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_single_tests.rs
@@ -9,7 +9,7 @@ use deep_causality::*;
 #[test]
 fn test_evaluate_single_cause_success() {
     let mut g = CausaloidGraph::new(0);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
     g.freeze(); // Reasoning requires a frozen graph
     // Evaluate the node using the high-level graph API.

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_sub_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_sub_tests.rs
@@ -11,24 +11,24 @@ fn test_evaluate_subgraph_from_cause() {
     let mut g = CausaloidGraph::new(0);
 
     // Build a graph: root -> A, root -> B; A -> C
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     let root_index = g
         .add_root_causaloid(root_causaloid)
         .expect("Failed to add root index");
 
-    let causaloid_a = test_utils::get_test_causaloid();
+    let causaloid_a = test_utils::get_test_causaloid_deterministic();
     let idx_a = g
         .add_causaloid(causaloid_a)
         .expect("Failed to add causaloid A");
     g.add_edge(root_index, idx_a).expect("Failed to add edge");
 
-    let causaloid_b = test_utils::get_test_causaloid();
+    let causaloid_b = test_utils::get_test_causaloid_deterministic();
     let idx_b = g
         .add_causaloid(causaloid_b)
         .expect("Failed to add causaloid B");
     g.add_edge(root_index, idx_b).expect("Failed to add edge");
 
-    let causaloid_c = test_utils::get_test_causaloid();
+    let causaloid_c = test_utils::get_test_causaloid_deterministic();
     let idx_c = g
         .add_causaloid(causaloid_c)
         .expect("Failed to add causaloid C");
@@ -48,7 +48,7 @@ fn test_evaluate_subgraph_from_cause() {
 fn test_evaluate_subgraph_fails_if_not_frozen() {
     let effect = PropagatingEffect::Numerical(0.99);
     let mut g = CausaloidGraph::new(0);
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     let root_index = g.add_root_causaloid(root_causaloid).unwrap();
 
     // DO NOT call g.freeze()
@@ -67,7 +67,7 @@ fn test_evaluate_subgraph_fails_if_node_missing() {
     let mut g = CausaloidGraph::new(0); // An empty graph
 
     // Build a graph: root
-    let root_causaloid = test_utils::get_test_causaloid();
+    let root_causaloid = test_utils::get_test_causaloid_deterministic();
     let root_index = g
         .add_root_causaloid(root_causaloid)
         .expect("Failed to add root index");

--- a/deep_causality/tests/types/csm_types/csm_state_tests.rs
+++ b/deep_causality/tests/types/csm_types/csm_state_tests.rs
@@ -9,7 +9,7 @@ use deep_causality::utils_test::test_utils;
 
 #[test]
 fn test_new() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     assert!(causaloid.is_singleton());
     assert_eq!(1, causaloid.id());
     assert_eq!(
@@ -31,7 +31,7 @@ fn test_new() {
 fn test_eval() {
     let id = 42;
     let version = 1;
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     // Case 1: Evaluation results in Deterministic(false)
     let data_fail = PropagatingEffect::Numerical(0.23f64);
@@ -57,7 +57,7 @@ fn eval_with_data() {
     let version = 1;
     // The initial data in the state is often just a default.
     let initial_data = PropagatingEffect::None;
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     let cs = CausalState::new(id, version, initial_data, causaloid);
 
     // Evaluating with internal data (None) should fail the causaloid's check.
@@ -83,7 +83,7 @@ fn eval_with_data() {
 
 #[test]
 fn test_to_string() {
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
     assert!(causaloid.is_singleton());
     assert_eq!(1, causaloid.id());
     assert_eq!(

--- a/deep_causality/tests/types/csm_types/csm_tests.rs
+++ b/deep_causality/tests/types/csm_types/csm_tests.rs
@@ -44,7 +44,7 @@ fn test_new() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -60,7 +60,7 @@ fn test_is_empty() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -76,7 +76,7 @@ fn add_single_state() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid.clone());
     let ca = get_test_action();
@@ -100,7 +100,7 @@ fn add_single_state_err_already_exists() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid.clone());
     let ca = get_test_action();
@@ -124,7 +124,7 @@ fn update_single_state() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -138,7 +138,7 @@ fn update_single_state() {
     let version = 1;
     let data = PropagatingEffect::Numerical(0.7f64);
 
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -155,7 +155,7 @@ fn update_single_state_err_not_found() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -171,7 +171,7 @@ fn remove_single_state() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data.clone(), causaloid.clone());
     let ca = get_test_action();
@@ -199,7 +199,7 @@ fn remove_single_state_err_not_found() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -235,7 +235,7 @@ fn eval_all_states() {
     let id = 42;
     let version = 1;
     let data = test_utils::get_test_single_data(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -251,7 +251,7 @@ fn update_all_states() {
     let id = 42;
     let version = 1;
     let data = test_utils::get_test_single_data(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid.clone());
     let ca = get_test_action();
@@ -278,7 +278,7 @@ fn eval_single_state() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -312,7 +312,7 @@ fn eval_single_state_success_fires_action() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid(); // Returns Deterministic(true)
+    let causaloid = test_utils::get_test_causaloid_deterministic(); // Returns Deterministic(true)
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action(); // Succeeds
@@ -333,7 +333,7 @@ fn eval_single_state_success_inactive_no_action() {
     let version = 1;
     // Use data that makes the state inactive (0.23 < 0.55 threshold)
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid(); // Returns Deterministic(false)
+    let causaloid = test_utils::get_test_causaloid_deterministic(); // Returns Deterministic(false)
 
     let cs = CausalState::new(id, version, data, causaloid);
     // Use an action that would fail to prove it's not being called.
@@ -355,7 +355,7 @@ fn eval_single_state_error_not_found() {
     let id = 42;
     let version = 1;
     let data = PropagatingEffect::Numerical(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -401,7 +401,7 @@ fn eval_single_state_error_action_fails() {
     let version = 1;
     // Use data that makes the state active (0.60 > 0.55 threshold in test_causaloid)
     let data = PropagatingEffect::Numerical(0.60f64);
-    let causaloid = test_utils::get_test_causaloid(); // Returns Deterministic(true)
+    let causaloid = test_utils::get_test_causaloid_deterministic(); // Returns Deterministic(true)
 
     let cs = CausalState::new(id, version, data, causaloid);
     // Use an action that is designed to fail.
@@ -427,7 +427,7 @@ fn eval_all_states_success_inactive_state() {
     let version = 1;
     // Data that makes the state inactive (0.23 < 0.55 threshold)
     let data = test_utils::get_test_single_data(0.23f64);
-    let causaloid = test_utils::get_test_causaloid();
+    let causaloid = test_utils::get_test_causaloid_deterministic();
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action();
@@ -445,7 +445,7 @@ fn eval_all_states_success_active_state_fires_action() {
     let version = 1;
     // Data that makes the state active (0.6 > 0.55 threshold)
     let data = PropagatingEffect::Numerical(0.60f64);
-    let causaloid = test_utils::get_test_causaloid(); // Returns Deterministic(true)
+    let causaloid = test_utils::get_test_causaloid_deterministic(); // Returns Deterministic(true)
 
     let cs = CausalState::new(id, version, data, causaloid);
     let ca = get_test_action(); // Succeeds
@@ -484,7 +484,7 @@ fn eval_all_states_error_action_fails() {
     let version = 1;
     // Use data that makes the state active (0.60 > 0.55 threshold)
     let data = PropagatingEffect::Numerical(0.60f64);
-    let causaloid = test_utils::get_test_causaloid(); // Returns Deterministic(true)
+    let causaloid = test_utils::get_test_causaloid_deterministic(); // Returns Deterministic(true)
 
     let cs = CausalState::new(id, version, data, causaloid);
     // Use an action that is designed to fail.

--- a/deep_causality/tests/types/model_types/model/model_assumptions_tests.rs
+++ b/deep_causality/tests/types/model_types/model/model_assumptions_tests.rs
@@ -12,7 +12,7 @@ fn test_assumptions_no_assumptions_err() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);
@@ -41,7 +41,7 @@ fn test_assumptions_no_data_err() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = Some(Arc::new(vec![test_utils::get_test_assumption()]));
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(
@@ -73,7 +73,7 @@ fn test_assumptions_assumption_err() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = Some(Arc::new(vec![test_utils::get_test_assumption_error()]));
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = None;
 
     let model = Model::new(
@@ -107,7 +107,7 @@ fn test_verify_assumptions_failed() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = Some(Arc::new(vec![test_utils::get_test_assumption_false()]));
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(
@@ -140,7 +140,7 @@ fn test_verify_assumptions_success() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = Some(Arc::new(vec![test_utils::get_test_assumption()]));
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(

--- a/deep_causality/tests/types/model_types/model/model_tests.rs
+++ b/deep_causality/tests/types/model_types/model/model_tests.rs
@@ -13,7 +13,7 @@ fn test_new() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);
@@ -27,7 +27,7 @@ fn test_id() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);
@@ -41,7 +41,7 @@ fn test_author() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);
@@ -56,7 +56,7 @@ fn test_description() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);
@@ -72,7 +72,7 @@ fn test_causaloid() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(
@@ -97,7 +97,7 @@ fn test_context() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(
@@ -124,7 +124,7 @@ fn test_assumptions() {
     let author = "John Doe";
     let description = "This is a test model";
     let assumptions = None;
-    let causaloid = Arc::new(test_utils::get_test_causaloid());
+    let causaloid = Arc::new(test_utils::get_test_causaloid_deterministic());
     let context = Some(Arc::new(test_utils::get_test_context()));
 
     let model = Model::new(id, author, description, assumptions, causaloid, context);

--- a/deep_causality/tests/types/reasoning_types/propagating_effect_tests.rs
+++ b/deep_causality/tests/types/reasoning_types/propagating_effect_tests.rs
@@ -45,12 +45,6 @@ fn test_is_contextual_link() {
 }
 
 #[test]
-fn test_is_halting() {
-    let effect = PropagatingEffect::Halting;
-    assert!(effect.is_halting());
-}
-
-#[test]
 fn test_as_bool() {
     let effect1 = PropagatingEffect::Deterministic(true);
     assert_eq!(effect1.as_bool(), Some(true));
@@ -108,9 +102,6 @@ fn test_display() {
         format!("{effect3}"),
         "PropagatingEffect::ContextualLink(1, 2)"
     );
-
-    let effect4 = PropagatingEffect::Halting;
-    assert_eq!(format!("{effect4}"), "PropagatingEffect::Halting");
 }
 
 #[test]
@@ -132,9 +123,6 @@ fn test_debug() {
         format!("{effect3:?}"),
         "PropagatingEffect::ContextualLink(1, 2)"
     );
-
-    let effect4 = PropagatingEffect::Halting;
-    assert_eq!(format!("{effect4:?}"), "PropagatingEffect::Halting");
 }
 
 #[test]
@@ -218,13 +206,6 @@ fn test_partial_eq() {
     let effect15 = PropagatingEffect::Graph(Arc::clone(&graph2)); // Different Arc, same content
     assert_eq!(effect13, effect14); // Should be equal due to Arc::ptr_eq
     assert_ne!(effect13, effect15); // Should be not equal due to Arc::ptr_eq
-
-    // Halting variant
-    let effect16 = PropagatingEffect::Halting;
-    let effect17 = PropagatingEffect::Halting;
-    let effect18 = PropagatingEffect::Deterministic(false);
-    assert_eq!(effect16, effect17);
-    assert_ne!(effect16, effect18);
 
     // RelayTo variant
     let effect19 = PropagatingEffect::RelayTo(1, Box::new(PropagatingEffect::Deterministic(true)));


### PR DESCRIPTION
### **User description**
## Describe your changes

Implemented Configurable Reasoning Modalities to Causal Collections. 

## Issue ticket number and link

Enhance CausableReasoning Trait with Configurable Reasoning Modalities #274

Closes https://github.com/deepcausality-rs/deep_causality/issues/274

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented configurable reasoning modalities for causal collections

- Added threshold-based probabilistic and mixed propagation evaluation

- Refactored causable reasoning into separate modular implementations

- Updated test utilities to support deterministic and probabilistic causaloids


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CausableReasoning Trait"] --> B["Deterministic Module"]
  A --> C["Probabilistic Module"]
  A --> D["Mixed Module"]
  B --> E["Boolean Logic Evaluation"]
  C --> F["Threshold-based Conversion"]
  D --> G["Hybrid Evaluation"]
  H["Test Utilities"] --> I["Deterministic Causaloids"]
  H --> J["Probabilistic Causaloids"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>causable_reasoning.rs</strong><dd><code>Refactored reasoning trait with modular delegation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-5269d3424367cc1608e0df5e667f9a5e86fd902b3bf60214c6adf0db04e2817f">+48/-126</a></td>

</tr>

<tr>
  <td><strong>causable_reasoning_deterministic.rs</strong><dd><code>Added deterministic reasoning module with logic evaluation</code></dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-0270da7490dbfde4b16cfe9d4676c30b990d12d4bafc25e0b289c8cb313f8e05">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causable_reasoning_probabilistic.rs</strong><dd><code>Added probabilistic reasoning with threshold conversion</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-64a75f18f9776ac5b0632c74d818722edfadf42556ab4c5c833b11b52ac158ff">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_reasoning_mixed.rs</strong><dd><code>Added mixed reasoning for hybrid effect types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-e2b44fde2180cfc66f63794e40cdaaff474fc8dc902d895878f4d40b1600ca76">+108/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable.rs</strong><dd><code>Removed halting effect handling from causaloid evaluation</code></dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-4b28f2017ee8a4a5264538dfb5611784cd6c25fabc03d9948096185ff37927b2">+7/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>graph_reasoning.rs</strong><dd><code>Removed halting effect handling from graph reasoning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-f57e2fcd6b50f381e0f21251216ec315d320f835680c65465b1af26372204afa">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>test_utils.rs</strong><dd><code>Enhanced test utilities with deterministic and probabilistic </code><br><code>causaloids</code></dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-a6a8209626c5ec08b2ed7c152aa0e83c477a5ff288ac583c8dfac3dc628b46bb">+38/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_vec_tests.rs</strong><dd><code>Updated tests with threshold parameters and new utilities</code></dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-8c199c9ab0697da9a6730978d8ae6b13af99ae9a29c7aec8c24ae1c5332a36c8">+16/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_map_tests.rs</strong><dd><code>Updated map tests with new reasoning parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-c1b8197224abe2990985789313b2e145a049cbf1eeda6a6dc56fb55ced330175">+28/-40</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_btree_map_tests.rs</strong><dd><code>Updated BTreeMap tests with threshold-based evaluation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-ec53f08dc64a9389d4f8dfcac95e3b1d56041435d132932b5bccea354987a4dd">+29/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_vec_deque_tests.rs</strong><dd><code>Updated VecDeque tests with new reasoning approach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-e4b2f7510119f691656c3fead1493c3860bb13e96080a4776e6301dc6cd8f44e">+20/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causable_arr_tests.rs</strong><dd><code>Updated array tests with mixed causaloid support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-25faecd981b93542c3fcabdf9c095e4a930c66ca1be92c69ed0f976000414c9f">+34/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>csm_tests.rs</strong><dd><code>Updated CSM tests to use deterministic causaloids</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-466f33b9c24952f38e00060005885e767abfe3d4685ec34e43da590f1bcc250e">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>causaloid_tests.rs</strong><dd><code>Updated causaloid tests with new test utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-0fbcb0d27fae0ff6fd6820af45d5a9d431a1e293257ef565dfe5251411ef0f30">+8/-25</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>debug.rs</strong><dd><code>Separated debug implementation from display trait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-bc960e6c1c0f063cdf2848e1eba4e4fd9ac92347a79774373927e4304d1281d4">+2/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>display.rs</strong><dd><code>Added separate display trait implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-919d4f2e3999e0a9508a7c66eba7f0b1b05c5a036f216c1608e78e684af89db1">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Added module declarations for new reasoning implementations</code></dd></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-6458ede30f2061bbde536aa2182007a871dfcc14783f30c444ca37b565cb14f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>causable.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-870696f108d91d578abdb9583621be16a079d129551a62c818503f935d452644">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-76b87b74549bf0f28d301085261a2d4c9236d42a18afb014aac6790257003e65">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>debug.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-c7ae59fb1de28978b3783362ecca9b826504cc8ac1efaf2fb886fa9041b76edd">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-4f75a9885227415341b5468c0e9d9a538fa2fd828dba1ac15554e2a747357da8">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>partial_eq.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-e89a0f45826c7bcf9edbdf7fdc53d7d69af725020cee8f3c01db823ca705f5a5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_edges_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-d2baff00ee251e1494e47649c10ae76c86242468d20103b91f2a3f8f73e4f1ca">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_explaining_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-b6072ad5a1fc6f3ce279184387c8c78a5ecf6b5f21f3473905f6e9f4272b38db">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_freeze_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-b92a801af35d92dea440bace610f1711978db35275fcf712c568179cd57ccbcf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_nodes_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-cbd221e364c0a9387aad5a4c2b7f5843eba0c60004ff3e1de40b073248e1bb94">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_reasoning_all_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-a3d6fcb26c6542933e8caca40b9cadd9c783b3441ff420ab96b330472beb14a5">+5/-23</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_reasoning_shortest_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-42fe6c03cd4a173824b2f195d8f64820e439dd59483a8a082ca7cd78c9c839b6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_reasoning_single_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-53b02dcfd6b0cca281d9cc379b4dd4dc475e7c46d06f831658ed3523a113fbeb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>causality_graph_reasoning_sub_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-e6966d8d9889cfffaed4888f084457095921e0a709faa314bb61533b459936be">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>csm_state_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-e0de14e9bdedcbaaae0f563d91dd49b93d0f4a18447a0852c81c2c3dbed0e785">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model_assumptions_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-243eb7a9e6d642ea8c5746a9712c8e2f13b3474572a2229767473713501d0850">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-0fa4d835c2a107e7f7ea54b52be307cbcecf972e47d763c4a1997feb9462dc45">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>propagating_effect_tests.rs</strong></td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/278/files#diff-f89ced2391d6f2c9e655286eae82043042b0ee0384dbf0e439b4ad11aaffeb79">+0/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

