### PR TITLE
feat(deep_causality): Implemented Adaptive Reasoning

### DIFF
--- a/deep_causality/src/traits/causable_collection/collection_reasoning/mod.rs
+++ b/deep_causality/src/traits/causable_collection/collection_reasoning/mod.rs
@@ -6,11 +6,6 @@ mod collection_reasoning_deterministic;
 mod collection_reasoning_mixed;
 mod collection_reasoning_probabilistic;
 
-/*
- * SPDX-License-Identifier: MIT
- * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
- */
-
 use crate::{
     AggregateLogic, Causable, CausableCollectionAccessor, CausalityError, IdentificationValue,
     NumericalValue, PropagatingEffect,

--- a/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
+++ b/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
@@ -71,7 +71,7 @@ where
     /// * `Ok(PropagatingEffect)`: The final `PropagatingEffect` from the last successfully evaluated node
     ///   in the main traversal path. `Deterministic(false)` now propagates and does not implicitly halt propagation.
     ///   Only a `Causaloid` returning a `CausalityError` will abort the traversal.
-    /// * `Err(CausalityError)` if the graph is not frozen, a node is missing, or an evaluation fails.
+    /// * `Err(CausalityError)` if the graph is not frozen, a node is missing, a RelayTo target cannot be found or an evaluation fails.
     fn evaluate_subgraph_from_cause(
         &self,
         start_index: usize,
@@ -124,6 +124,14 @@ where
                     // If a RelayTo effect is returned, clear the queue and add the target_index
                     // with the inner_effect as the new starting point for traversal.
                     queue.clear();
+
+                    // Validate target_index before proceeding
+                    if !self.contains_causaloid(target_index) {
+                        return Err(CausalityError(format!(
+                            "RelayTo target causaloid with index {target_index} not found in graph."
+                        )));
+                    }
+
                     if !visited[target_index] {
                         visited[target_index] = true;
                         queue.push_back((target_index, *inner_effect));

--- a/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
+++ b/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
@@ -47,6 +47,20 @@ where
     /// the output effect of a parent node becomes the input effect for its child node.
     /// The traversal continues as long as no `CausalityError` is returned.
     ///
+    /// ## Adaptive Reasoning
+    ///
+    /// If a `Causaloid` returns a `PropagatingEffect::RelayTo(target_index, inner_effect)`,
+    /// the BFS traversal dynamically jumps to  `target_index`, and `inner_effect` becomes
+    /// the new input for the relayed path. This enables *adaptive reasoning* conditional to the deciding
+    /// causaloid. To illustrate adaptive reasoning, an example clinical patent risk model may operate
+    /// very differently for patients with normal blood pressure compared to high blood pressure patients.
+    /// Therefore, two highly specialized models are defined and a dedicated dispatch causaloid.
+    /// The dispatch causaloid analyses blood pressure and then, conditional on its finding, dispatches
+    /// further reasoning to the matching model i.e. a dedicated sub-graph. Ensure that all possible
+    /// values of  target_index exists in the graph before implementing adaptive reasoning.
+    /// For more details, see section 5.10.3 Adaptive Reasoning in The EPP reference paper:
+    /// https://github.com/deepcausality-rs/papers/blob/main/effect_propagation_process/epp.pdf
+    ///
     /// # Arguments
     ///
     /// * `start_index` - The index of the node to start the traversal from.
@@ -100,13 +114,33 @@ where
             // This ensures the function returns the effect of the last node on the path.
             last_propagated_effect = result_effect.clone();
 
-            // Only a CausalityError returned from cause.evaluate() will abort the traversal.
-            let children = self.get_graph().outbound_edges(current_index)?;
-            for child_index in children {
-                if !visited[child_index] {
-                    visited[child_index] = true;
-                    // Pass the result_effect of the current node to its children.
-                    queue.push_back((child_index, result_effect.clone()));
+            match result_effect {
+                // Adaptive reasoning:
+                // The Causaloid itself determines the next step in the reasoning process
+                // conditional on its reasoning outcome. Based on its own internal logic,
+                // a Causaloid then dynamically dispatches the flow of causality
+                // to another Causaloid in the graph, enabling adaptive reasoning.
+                PropagatingEffect::RelayTo(target_index, inner_effect) => {
+                    // If a RelayTo effect is returned, clear the queue and add the target_index
+                    // with the inner_effect as the new starting point for traversal.
+                    queue.clear();
+                    if !visited[target_index] {
+                        visited[target_index] = true;
+                        queue.push_back((target_index, *inner_effect));
+                    }
+                    // Update last_propagated_effect to reflect the effect of the relayed node.
+                    // This is already handled by the line above: last_propagated_effect = result_effect.clone();
+                }
+                _ => {
+                    // Only a CausalityError returned from cause.evaluate() will abort the traversal.
+                    let children = self.get_graph().outbound_edges(current_index)?;
+                    for child_index in children {
+                        if !visited[child_index] {
+                            visited[child_index] = true;
+                            // Pass the result_effect of the current node to its children.
+                            queue.push_back((child_index, result_effect.clone()));
+                        }
+                    }
                 }
             }
         }
@@ -121,6 +155,15 @@ where
     /// one causaloid becomes the input for the next causaloid in the path. If any node
     /// fails evaluation or returns a non-propagating effect that prunes the path, the reasoning stops.
     ///
+    /// If a `Causaloid` returns a `PropagatingEffect::RelayTo(target_index, inner_effect)`,
+    /// the shortest path traversal is immediately interrupted, and the `RelayTo` effect
+    /// is returned to the caller, signaling a dynamic redirection. The runtime behavior differs
+    /// from `evaluate_subgraph_from_cause` because a shortest path is assumed to be a fixed path
+    /// and thus RelayTo is not supposed to happen in the middle of the path. Therefore, the
+    /// call-site must handle the occurrence i.e. when its a known final effect.
+    /// For more details, see section 5.10.3 Adaptive Reasoning in The EPP reference paper:
+    /// https://github.com/deepcausality-rs/papers/blob/main/effect_propagation_process/epp.pdf
+    ///
     /// # Arguments
     ///
     /// * `start_index` - The index of the start cause.
@@ -130,6 +173,7 @@ where
     /// # Returns
     ///
     /// * `Ok(PropagatingEffect)`: The final `PropagatingEffect` from the last evaluated node on the path.
+    ///   If a `RelayTo` effect is encountered, that effect is returned immediately.
     /// * `Err(CausalityError)` if the path cannot be found or an evaluation fails.
     fn evaluate_shortest_path_between_causes(
         &self,
@@ -164,8 +208,14 @@ where
             // Evaluate the current cause with the effect propagated from the previous node.
             // Then, overwrite the current_effect with the result of the evaluation, which then
             // serves as the input for the next node.
-            // Only a CausalityError returned from cause.evaluate() will abort the traversal.
+            // For normal traversal, a CausalityError returned from cause.evaluate() will abort the traversal.
             current_effect = cause.evaluate(&current_effect)?;
+
+            // If a RelayTo effect is returned, stop the shortest path traversal and return it
+            // because it braks the assumption of a fixed shortest path.
+            if let PropagatingEffect::RelayTo(_, _) = current_effect {
+                return Ok(current_effect);
+            }
         }
 
         // If the loop completes, all nodes on the path were successfully evaluated.

--- a/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
+++ b/deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs
@@ -212,7 +212,7 @@ where
             current_effect = cause.evaluate(&current_effect)?;
 
             // If a RelayTo effect is returned, stop the shortest path traversal and return it
-            // because it braks the assumption of a fixed shortest path.
+            // because it breaks the assumption of a fixed shortest path.
             if let PropagatingEffect::RelayTo(_, _) = current_effect {
                 return Ok(current_effect);
             }

--- a/deep_causality/src/types/reasoning_types/propagating_effect/mod.rs
+++ b/deep_causality/src/types/reasoning_types/propagating_effect/mod.rs
@@ -41,8 +41,9 @@ pub enum PropagatingEffect {
     Map(HashMap<IdentificationValue, Box<PropagatingEffect>>),
     /// A graph of effects, for passing complex relational data.
     Graph(Arc<EffectGraph>),
-    /// A dispatch command that directs a reasoning engine to jump to a specific
-    /// next causaloid with the specified id (`usize`) and provide it with the encapsulated effect as its new input.
+    /// A dispatch command that directs the reasoning engine to dynamically jump to a specific
+    /// causaloid within the graph. The `usize` is the target causaloid's index, and the `Box<PropagatingEffect>`
+    /// is the effect to be passed as input to that target causaloid. This enables adaptive reasoning.
     RelayTo(usize, Box<PropagatingEffect>),
 }
 

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_adaptive_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_adaptive_tests.rs
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use deep_causality::utils_test::test_utils;
+use deep_causality::*;
+
+#[test]
+fn test_evaluate_subgraph_from_cause_with_relay_to_simple() {
+    // Graph: Root (0) -> A (1) -> B (2) -> C (3)
+    // A will relay to C
+    let mut g = CausaloidGraph::new(0);
+
+    let root_causaloid = test_utils::get_test_causaloid_deterministic_true();
+    let root_index = g.add_root_causaloid(root_causaloid).unwrap();
+
+    // Causaloid A: Relays to C (index 3) with a specific effect
+    let causaloid_a_id = 10;
+    let causaloid_a_description = "Causaloid A relays to node 3 with Numerical(100.0)";
+    let causaloid_a_fn =
+        |_effect: &PropagatingEffect| -> Result<PropagatingEffect, CausalityError> {
+            Ok(PropagatingEffect::RelayTo(
+                3,
+                //
+                Box::new(PropagatingEffect::Deterministic(false)),
+            ))
+        };
+    let causaloid_a = Causaloid::new(causaloid_a_id, causaloid_a_fn, causaloid_a_description);
+    let idx_a = g.add_causaloid(causaloid_a).unwrap();
+
+    // Causaloid B: Standard causaloid, should be skipped
+    let causaloid_b = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_b = g.add_causaloid(causaloid_b).unwrap();
+
+    // Causaloid C: Standard causaloid, should be the final evaluated node
+    let causaloid_c = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_c = g.add_causaloid(causaloid_c).unwrap();
+
+    // Link the graph: Root -> A -> B -> C
+    g.add_edge(root_index, idx_a).unwrap();
+    g.add_edge(idx_a, idx_b).unwrap();
+    g.add_edge(idx_b, idx_c).unwrap();
+
+    g.freeze();
+
+    let initial_effect = PropagatingEffect::Deterministic(true);
+    let res = g.evaluate_subgraph_from_cause(root_index, &initial_effect);
+
+    dbg!(&res);
+    assert!(res.is_ok());
+    // Expected: Root (true) -> A (Relay to C with Deterministic(false))
+    // C (input  Deterministic(false)) -> Deterministic(true) (C just inverts the input)
+    assert_eq!(res.unwrap(), PropagatingEffect::Deterministic(true));
+}
+
+#[test]
+fn test_evaluate_subgraph_from_cause_with_relay_to_visited_node() {
+    // Graph: Root (0) -> A (1) -> B (2)
+    // B will relay back to Root (0)
+    let mut g = CausaloidGraph::new(0);
+
+    let root_causaloid = test_utils::get_test_causaloid_deterministic_true();
+    let root_index = g.add_root_causaloid(root_causaloid).unwrap();
+
+    let causaloid_a = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_a = g.add_causaloid(causaloid_a).unwrap();
+
+    // Causaloid B: Relays back to Root (index 0)
+    let causaloid_b_id = 11;
+    let causaloid_b_description = "Causaloid B relays to node 0 with Numerical(50.0)";
+    let causaloid_b_fn =
+        |_effect: &PropagatingEffect| -> Result<PropagatingEffect, CausalityError> {
+            Ok(PropagatingEffect::RelayTo(
+                0,
+                Box::new(PropagatingEffect::Numerical(50.0)),
+            ))
+        };
+    let causaloid_b = Causaloid::new(causaloid_b_id, causaloid_b_fn, causaloid_b_description);
+    let idx_b = g.add_causaloid(causaloid_b).unwrap();
+
+    // Link the graph: Root -> A -> B
+    g.add_edge(root_index, idx_a).unwrap();
+    g.add_edge(idx_a, idx_b).unwrap();
+
+    g.freeze();
+
+    let initial_effect = PropagatingEffect::Deterministic(true);
+    let res = g.evaluate_subgraph_from_cause(root_index, &initial_effect);
+
+    assert!(res.is_ok());
+    // Expected: Root (true) -> A (false) -> B (Relay to Root with Numerical(50.0))
+    // The traversal should jump back to Root, but since Root is already visited, it won't be re-added.
+    // The last propagated effect will be the RelayTo effect from B.
+    assert_eq!(
+        res.unwrap(),
+        PropagatingEffect::RelayTo(0, Box::new(PropagatingEffect::Numerical(50.0)))
+    );
+}
+
+#[test]
+fn test_evaluate_shortest_path_between_causes_with_relay_interrupt() {
+    // Graph: Root (0) -> A (1) -> B (2) -> C (3)
+    // A will relay, interrupting the shortest path from Root to C
+    let mut g = CausaloidGraph::new(0);
+
+    let root_causaloid = test_utils::get_test_causaloid_deterministic_true();
+    let root_index = g.add_root_causaloid(root_causaloid).unwrap();
+
+    // Causaloid A: Relays to C (index 3) with a specific effect
+    let causaloid_a_id = 12;
+    let causaloid_a_description = "Causaloid A relays to node 3 with Numerical(200.0)";
+    let causaloid_a_fn =
+        |_effect: &PropagatingEffect| -> Result<PropagatingEffect, CausalityError> {
+            Ok(PropagatingEffect::RelayTo(
+                3,
+                Box::new(PropagatingEffect::Numerical(200.0)),
+            ))
+        };
+    let causaloid_a = Causaloid::new(causaloid_a_id, causaloid_a_fn, causaloid_a_description);
+    let idx_a = g.add_causaloid(causaloid_a).unwrap();
+
+    // Causaloid B: Standard causaloid, should not be reached
+    let causaloid_b = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_b = g.add_causaloid(causaloid_b).unwrap();
+
+    // Causaloid C: Standard causaloid
+    let causaloid_c = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_c = g.add_causaloid(causaloid_c).unwrap();
+
+    // Link the graph: Root -> A -> B -> C
+    g.add_edge(root_index, idx_a).unwrap();
+    g.add_edge(idx_a, idx_b).unwrap();
+    g.add_edge(idx_b, idx_c).unwrap();
+
+    g.freeze();
+
+    let initial_effect = PropagatingEffect::Deterministic(true);
+    // Attempt to find shortest path from Root (0) to C (3)
+    let res = g.evaluate_shortest_path_between_causes(root_index, idx_c, &initial_effect);
+
+    assert!(res.is_ok());
+    // Expected: The RelayTo effect from A should interrupt the path and be returned.
+    assert_eq!(
+        res.unwrap(),
+        PropagatingEffect::RelayTo(3, Box::new(PropagatingEffect::Numerical(200.0)))
+    );
+}
+
+#[test]
+fn test_evaluate_shortest_path_between_causes_with_relay_at_end() {
+    // Graph: Root (0) -> A (1) -> B (2)
+    // B will relay, as the last node on the shortest path
+    let mut g = CausaloidGraph::new(0);
+
+    let root_causaloid = test_utils::get_test_causaloid_deterministic_true();
+    let root_index = g.add_root_causaloid(root_causaloid).unwrap();
+
+    let causaloid_a = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx_a = g.add_causaloid(causaloid_a).unwrap();
+
+    // Causaloid B: Relays to Root (index 0)
+    let causaloid_b_id = 13;
+    let causaloid_b_description = "Causaloid B relays to node 0 with Numerical(50.0)";
+    let causaloid_b_fn =
+        |_effect: &PropagatingEffect| -> Result<PropagatingEffect, CausalityError> {
+            Ok(PropagatingEffect::RelayTo(
+                0,
+                Box::new(PropagatingEffect::Numerical(50.0)),
+            ))
+        };
+    let causaloid_b = Causaloid::new(causaloid_b_id, causaloid_b_fn, causaloid_b_description);
+    let idx_b = g.add_causaloid(causaloid_b).unwrap();
+
+    // Link the graph: Root -> A -> B
+    g.add_edge(root_index, idx_a).unwrap();
+    g.add_edge(idx_a, idx_b).unwrap();
+
+    g.freeze();
+
+    let initial_effect = PropagatingEffect::Deterministic(true);
+    // Attempt to find shortest path from Root (0) to B (2)
+    let res = g.evaluate_shortest_path_between_causes(root_index, idx_b, &initial_effect);
+
+    assert!(res.is_ok());
+    // Expected: The RelayTo effect from B should be returned.
+    assert_eq!(
+        res.unwrap(),
+        PropagatingEffect::RelayTo(0, Box::new(PropagatingEffect::Numerical(50.0)))
+    );
+}

--- a/deep_causality/tests/types/causal_types/causaloid_graph/mod.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/mod.rs
@@ -12,6 +12,8 @@ mod causality_graph_freeze_tests;
 #[cfg(test)]
 mod causality_graph_nodes_tests;
 #[cfg(test)]
+mod causality_graph_reasoning_adaptive_tests;
+#[cfg(test)]
 mod causality_graph_reasoning_all_tests;
 #[cfg(test)]
 mod causality_graph_reasoning_imbalanced_tests;


### PR DESCRIPTION
### **User description**
This pull request finalizes the implementation of   adaptive reasoning within `DeepCausality` and added related tests to ensure the robustness  of the codebase.

## Describe your changes

**Corrected Effect Propagation:** The
      `evaluate_subgraph_from_cause` and
      `evaluate_shortest_path_between_causes` methods now
      correctly propagate `PropagatingEffect`s sequentially.
      The output of a parent causaloid is now consistently
      used as the input for its children, ensuring accurate
      causal flow through the graph.

 **Robust Adaptive Reasoning:** The
      `PropagatingEffect::RelayTo` variant is fully supported.
      When encountered. 

These changes are vital for `DeepCausality`'s ability to
      model complex, dynamic systems. By ensuring precise 
      effect propagation and robust adaptive reasoning, the 
      framework gains significant capabilities for building 
      intelligent systems that can dynamically adjust their 
      causal logic. The refactored tests provide clear, 
      verifiable examples of this advanced functionality, 
      contributing to the overall stability and 
      maintainability of the library.

## Issue ticket number and link

Implement Adaptive Reasoning: https://github.com/deepcausality-rs/deep_causality/issues/282 
closes https://github.com/deepcausality-rs/deep_causality/issues/282

## Code checklist before requesting a review

- [x] have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented adaptive reasoning with `PropagatingEffect::RelayTo` support

- Enhanced effect propagation in subgraph and shortest path evaluation

- Added comprehensive test coverage for adaptive reasoning scenarios

- Updated documentation with clinical example and reference links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Causaloid Evaluation"] --> B{"RelayTo Effect?"}
  B -->|Yes| C["Clear Queue & Jump to Target"]
  B -->|No| D["Continue Normal Traversal"]
  C --> E["Adaptive Reasoning Path"]
  D --> F["Sequential Effect Propagation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Enhanced graph reasoning with adaptive RelayTo support</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/src/traits/causable_graph/graph_reasoning/mod.rs

<ul><li>Added adaptive reasoning support for <code>PropagatingEffect::RelayTo</code> in <br>subgraph evaluation<br> <li> Enhanced shortest path evaluation to handle RelayTo interruption<br> <li> Added comprehensive documentation with clinical example<br> <li> Implemented dynamic queue clearing and target jumping logic</ul>


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/283/files#diff-670cc5101a7348169f52a5c57f5ad39e70eaf17483f3109c917826e6fe32594c">+58/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Updated RelayTo documentation for adaptive reasoning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/src/types/reasoning_types/propagating_effect/mod.rs

<ul><li>Updated <code>RelayTo</code> variant documentation for clarity<br> <li> Clarified adaptive reasoning purpose and usage</ul>


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/283/files#diff-4f75a9885227415341b5468c0e9d9a538fa2fd828dba1ac15554e2a747357da8">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>causality_graph_reasoning_adaptive_tests.rs</strong><dd><code>Comprehensive adaptive reasoning test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_adaptive_tests.rs

<ul><li>Added comprehensive test suite for adaptive reasoning scenarios<br> <li> Tests RelayTo behavior in subgraph and shortest path evaluation<br> <li> Covers edge cases like visited nodes and path interruption<br> <li> Validates proper effect propagation with RelayTo variants</ul>


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/283/files#diff-fdc1d0b37b663086353570b40c785096de101d1f4b2c98bc52cb1b8463a54642">+191/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Added adaptive reasoning test module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deep_causality/tests/types/causal_types/causaloid_graph/mod.rs

- Added module declaration for adaptive reasoning tests


</details>


  </td>
  <td><a href="https://github.com/deepcausality-rs/deep_causality/pull/283/files#diff-fa61a78213094cac031fdde106798da93a8d91d915b24e5c6a98268a4ba1ac2d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

