### PR TITLE
Potential fix for code scanning alert no. 269: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -5,6 +5,9 @@ name: Check
 
 on: [ pull_request, push ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/269](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/269)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access by default.  
For this workflow, the minimal required permission is:

- `contents: read`

Best single fix (without changing functionality): in `.github/workflows/rust_check.yml`, insert a top-level `permissions` section after the `on` trigger and before `env` (or anywhere at top level). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a top-level `permissions` block to `.github/workflows/rust_check.yml` to enforce least-privilege (`contents: read`) for all jobs and resolve code scanning alert 269. This limits the default `GITHUB_TOKEN` to read-only and does not change workflow behavior.

<sup>Written for commit 168b74a7942765ed23285d307b756fb12d48ed7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

