### PR TITLE
Potential fix for code scanning alert no. 261: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust_fmt.yml
+++ b/.github/workflows/rust_fmt.yml
@@ -5,6 +5,9 @@ name: Fmt
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/261](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/261)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained regardless of repo/org defaults.  
Best fix here (without changing functionality) is to define it at the workflow root, since there is only one job and it keeps policy clear and centralized.

**File to change:** `.github/workflows/rust_fmt.yml`  
**Change:** insert at top-level (after `on` is a clear location):

```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit root-level `permissions` block to `.github/workflows/rust_fmt.yml` to restrict `GITHUB_TOKEN` and resolve Code Scanning alert 261. Sets `permissions: contents: read` with no changes to workflow behavior.

<sup>Written for commit 90078ea755361480c4a3a5a0ad57aec391723408. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

