### PR TITLE
Potential fix for code scanning alert no. 260: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust_deps.yml
+++ b/.github/workflows/rust_deps.yml
@@ -5,6 +5,9 @@ name: Unused Deps
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/260](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/260)

To fix this, add an explicit `permissions` block to the workflow so all jobs default to least privilege.  
For this workflow, the best minimal permission is:

- `contents: read`

Place it at the workflow root (after `on:` or before `env:`), which applies to all jobs unless overridden. This preserves existing behavior while documenting and enforcing intended token scope. No imports, methods, or dependencies are needed since this is YAML config.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses code scanning alert 260 by adding a root-level `permissions` block to `.github/workflows/rust_deps.yml`, defaulting all jobs to least privilege with `contents: read`.

<sup>Written for commit d56a2574dd23ccbd4f70fe616c0531278f33f641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

