### PR TITLE
Potential fix for code scanning alert no. 256: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust_coverage.yaml
+++ b/.github/workflows/rust_coverage.yaml
@@ -5,6 +5,9 @@ name: Code Coverage
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/256](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/256)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for checkout and typical coverage upload usage in this file, while preserving current behavior.

**Where to change:** `.github/workflows/rust_coverage.yaml`, near the top-level keys (after `on:` and before `jobs:`).  
**What to add:**  
```yaml
permissions:
  contents: read
```
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit permissions block to the code coverage workflow to default the `GITHUB_TOKEN` to least privilege. Sets `permissions: contents: read` in `.github/workflows/rust_coverage.yaml` to resolve code scanning alert 256 without changing behavior.

<sup>Written for commit 8349785b9218c7ca16723f826f742ebb475c37b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

