### PR TITLE
Potential fix for code scanning alert no. 257: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,9 @@ name: Tests
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/257](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/257)

Add an explicit top-level `permissions` block in `.github/workflows/run_tests.yml` so all jobs in this workflow use least-privilege token scopes by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` and before `env:` is a clean location):
  - `permissions:`
  - `contents: read`

Why this works:
- `actions/checkout` requires `contents: read`.
- Build/test/cache steps do not require repository write privileges.
- Applying at workflow root avoids duplicating settings per job and covers future jobs unless overridden.

No imports, methods, or dependency changes are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a top-level `permissions` block with `contents: read` in `.github/workflows/run_tests.yml` to resolve code scanning alert 257 and set least-privilege defaults for the workflow. No functional changes to tests or build steps.

<sup>Written for commit 1b2a72ee52fc701d4067b064ef7b200db32129cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

