### PR TITLE
Potential fix for code scanning alert no. 259: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -5,6 +5,9 @@ name: Lint
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/deepcausality-rs/deep_causality/security/code-scanning/259](https://github.com/deepcausality-rs/deep_causality/security/code-scanning/259)

Add an explicit top-level `permissions` block to `.github/workflows/rust-lint.yml` so all jobs in this workflow receive least-privilege token access by default.

Best fix without changing functionality:
- In `.github/workflows/rust-lint.yml`, insert a workflow-level block right after the trigger (`on`) and before `env`:
  - `permissions:`
  - `contents: read`
- This is sufficient for this lint workflow, which needs repository read access for checkout and analysis but no write scopes.
- No imports, methods, or additional definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a top‑level `permissions` block to `.github/workflows/rust-lint.yml` to give all jobs read‑only token access and resolve code scanning alert 259. Sets `permissions: contents: read` without changing workflow behavior.

<sup>Written for commit 49d77cf384007c884a28c6619ad953d22de38b55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

