### PR TITLE
web: Polished layout and updated front page.

### DIFF
--- a/openspec/changes/add-cubical-complexes/.openspec.yaml
+++ b/openspec/changes/add-cubical-complexes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-18

--- a/openspec/changes/add-cubical-complexes/design.md
+++ b/openspec/changes/add-cubical-complexes/design.md
@@ -1,0 +1,138 @@
+## Context
+
+`deep_causality_topology` already contains the algebraic primitives needed for cubical complexes: `LatticeCell<D>` encodes elementary cubes as `(position, orientation_bitmask)` and computes signed boundary chains; `Lattice<D>` implements `CWComplex` with periodic/open boundaries, boundary matrices, and Betti numbers. What is missing is integration: `Manifold` — the type that carries field data and exposes the differential / comonadic operators — is hard-wired to `SimplicialComplex<C>`. The trait that should provide the abstraction (`CWComplex`) uses `Box<dyn Iterator>`, which both blocks generic propagation through `Manifold` and violates the project's static-dispatch rule (AGENTS.md §"Static Dispatch"). Naming is also non-textbook: practitioners and the original issue (#487) speak of "cubical complexes," not "lattices."
+
+Stakeholders:
+- Service Radar team: needs cubical complexes for spatial sensor fusion (LIDAR / RF / UWB voxel grids).
+- DeepCausality maintainers: must preserve simplicial behavior and existing tests bit-for-bit.
+
+Constraints (from AGENTS.md):
+- No `unsafe`, no `dyn` / trait objects, no macros in lib code, no new external dependencies, surgical diffs, tests mirror src tree, Bazel BUILD files kept in sync, one type per module.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A single static-dispatch trait (`ChainComplex`) describing any CW-style complex, satisfied by both simplicial and cubical complexes.
+- `Manifold` generic over `ChainComplex`, so `Manifold<CubicalComplex<D>, F>` is a first-class citizen alongside `Manifold<SimplicialComplex<C>, F>`.
+- Cubical complex surfaced under textbook naming (`CubicalComplex` / `CubicalCell`).
+- A neighborhood strategy trait (`Neighborhood<K>`) that is generic where it can be (chain-complex-native primitives) and grid-specific where it must be (Von Neumann / Moore / KRing).
+- Existing simplicial behavior and tests untouched — no regressions, no diff outside the genericization seam.
+- Worked example demonstrating voxel-grid sensor-fusion-style usage end to end.
+
+**Non-Goals**
+
+- Hodge ⋆ on non-unit or irregular cubical metrics (defer to a follow-up — the unit-cube case ships).
+- Sparse cubical-complex storage (set-of-active-cubes). Current dense `Lattice<D>` shape suffices; sparse variant needs benchmarking before design.
+- GPU paths for cubical differential operators.
+- Hex, triangular, or other non-cubical CW complexes.
+- Re-exporting old names (`Lattice`, `LatticeCell`, `CWComplex`) as `pub use` aliases. Clean rename, no shims.
+- Behavior change in the comonad iteration order or cursor semantics.
+
+## Decisions
+
+### D1. Replace `CWComplex` with `ChainComplex` using GAT iterators
+
+**Decision:** Rename the trait, replace `fn cells(&self, k) -> Box<dyn Iterator<...>>` with an associated `type CellIter<'a>: Iterator<Item = Self::CellType> where Self: 'a` and a method `fn cells(&self, k: usize) -> Self::CellIter<'_>`. Add `fn coboundary_matrix(&self, k: usize) -> CsrMatrix<i8>` to the trait surface.
+
+**Why:** `Box<dyn Iterator>` allocates and erases the iterator type, blocking inlining and monomorphization. AGENTS.md mandates static dispatch. GATs (stable since Rust 1.65) give exactly the abstraction shape we need with zero overhead. Adding `coboundary_matrix` to the trait makes Manifold's differential code generic without reaching into the concrete complex's storage.
+
+**Alternatives considered:**
+- *Keep `Box<dyn Iterator>`*: rejected — violates static-dispatch rule, hurts hot paths.
+- *Return `impl Iterator` directly*: not yet stable in trait method positions in all forms we need across lifetimes; GAT is the explicit, portable shape.
+- *Concrete enum iterator (`CellIterEnum<Simplex, CubicalCell<D>>`)*: rejected — closes the trait to user-defined complexes, defeats extensibility.
+
+### D2. `Manifold<K: ChainComplex, F>` instead of `Manifold<C, D>`
+
+**Decision:** Replace today's `Manifold<C, D> { complex: SimplicialComplex<C>, data: CausalTensor<D>, ... }` with `Manifold<K: ChainComplex, F> { complex: K, data: CausalTensor<F>, ... }`. Provide `pub type SimplicialManifold<C, F> = Manifold<SimplicialComplex<C>, F>` for ergonomics.
+
+**Why:** The type already takes two parameters but uses them awkwardly (`C` is the simplex coordinate constraint, `D` is the field data type). Lifting `K` to the first slot expresses the actual abstraction. The alias keeps existing-style call sites short.
+
+**Alternatives considered:**
+- *Parallel `CubicalManifold` type*: rejected — duplicates the entire differential stack (`exterior_cpu`, `codifferential_cpu`, `hodge_cpu`, `laplacian_cpu`), violates AGENTS.md §"Surgical Diffs" and §"Keep the Solution Simple."
+- *Trait object `Box<dyn ChainComplex>` inside `Manifold`*: rejected — `dyn` forbidden.
+
+### D3. Move coboundary access behind the trait
+
+**Decision:** Today `Manifold` reads `self.complex.coboundary_operators[k]` directly ([exterior_cpu.rs:42](deep_causality_topology/src/types/manifold/differential/exterior_cpu.rs#L42)). The new `ChainComplex::coboundary_matrix(k)` becomes the single access path. `SimplicialComplex` keeps its precomputed cache and returns a reference to it from the trait method. `CubicalComplex` computes `boundary_matrix(k+1).transpose()` on demand (or memoizes lazily — implementation detail, not trait contract).
+
+**Why:** Decouples Manifold from any single complex's storage layout. Lets each complex choose its own caching policy.
+
+**Alternatives considered:**
+- *Force every complex to pre-store coboundaries*: rejected — wastes memory for complexes built from huge synthetic grids where most strata are never queried.
+- *Move the cache into `Manifold`*: rejected — duplicates state already held by `SimplicialComplex`, and breaks the invariant that a complex is self-describing.
+
+### D4. Rename `Lattice` → `CubicalComplex`, `LatticeCell` → `CubicalCell`. No back-compat aliases.
+
+**Decision:** Move `src/types/lattice/` → `src/types/cubical_complex/`. Rename all dependent items in lock-step: `dual_lattice` → `dual_cubical_complex`, `hkt_lattice` → `hkt_cubical_complex`. The `gauge_field_lattice/` submodule retains its name (it models gauge fields *on* a lattice in the physics sense — "lattice gauge theory" is the established term and would be wrong to rename).
+
+**Why:** AGENTS.md §"Code Conventions" and the user's explicit instruction: textbook alignment is required. Issue #487 uses "cubical complexes" verbatim. `pub use Lattice = CubicalComplex` would carry the old vocabulary into perpetuity for no benefit; per AGENTS.md preference for clean removal over back-compat shims, omit them.
+
+**Alternatives considered:**
+- *Keep `Lattice` and add `pub type CubicalComplex<const D: usize> = Lattice<D>`*: rejected by user instruction.
+- *Rename and ship `pub use Lattice = CubicalComplex` for one release*: rejected — pollutes the namespace, AGENTS.md prefers clean diffs.
+
+### D5. `Neighborhood<K>` is a static-dispatch strategy trait, generic where principled, grid-specific where honest
+
+**Decision:** Introduce
+
+```rust
+pub trait Neighborhood<K: ChainComplex> {
+    type Iter<'a>: Iterator<Item = CellId> where K: 'a;
+    fn neighbors<'a>(&self, complex: &'a K, cell: CellId) -> Self::Iter<'a>;
+}
+```
+
+Concrete zero-sized strategies:
+
+| Strategy | Implemented for | Definition |
+|---|---|---|
+| `FaceAdjacent` | any `K: ChainComplex` | k-cells sharing a (k−1)-face with target, derived from ∂ |
+| `CofaceAdjacent` | any `K: ChainComplex` | (k+1)-cells containing target as a face, derived from δ |
+| `VonNeumann` | `CubicalComplex<D>` only | grid face-adjacency on top-dimensional cells (popcount/coordinate fast path) |
+| `Moore` | `CubicalComplex<D>` only | all cells sharing ≥1 vertex with target (3^D − 1 around a top cube) |
+| `KRing<const K: usize>` | `CubicalComplex<D>` only | Chebyshev distance ≤ K from target |
+
+Users add custom strategies (anisotropic LIDAR cones, half-space RF) by implementing `Neighborhood<K>` for their own zero-sized types.
+
+**Why this split:** `FaceAdjacent` / `CofaceAdjacent` are defined purely via ∂ and δ, so they extend to any chain complex without metric assumptions. `Moore` and `KRing` rely on the regular-grid coordinate structure and Chebyshev metric — there is no principled extension to arbitrary simplicial complexes. Forcing one definition over both would either (a) invent a meaningless simplicial Moore, or (b) leak grid concepts into the trait. We refuse both.
+
+**Alternatives considered:**
+- *Marker types on `Manifold<K, F, N>` baked at type level*: rejected — too rigid; users routinely want different neighborhoods per operation on the same manifold.
+- *Runtime enum `enum NeighborhoodKind { VonNeumann, Moore, KRing(usize), FaceAdjacent, CofaceAdjacent }`*: rejected — runtime branch, can't express user-defined strategies, violates static-dispatch preference.
+- *Two methods `extend_face` / `extend_moore` on Manifold*: rejected — non-extensible, doesn't compose.
+
+### D6. Comonad iteration stays cursor-based; neighborhood is queried inside the user closure
+
+**Decision:** `CoMonad::extend` continues to iterate the cursor over every cell and pass the full `Manifold` view to the user's closure (today's behavior, [hkt_manifold/mod.rs:168-193](deep_causality_topology/src/extensions/hkt_manifold/mod.rs#L168-L193)). Add a helper `Manifold::neighbors<N: Neighborhood<K>>(&self, n: N, cell: CellId) -> N::Iter<'_>` so the closure can pick a neighborhood at the point of use.
+
+**Why:** This is the textbook cellular-automaton CoKleisli pattern. Iteration order is complex-agnostic; neighborhood choice is operation-agnostic. Decoupling them is the whole reason the comonad abstraction is useful.
+
+### D7. `ReggeGeometry` on cubes — unit-edge case only
+
+**Decision:** Keep `ReggeGeometry<C>` simplicial-flavored. Add a parallel `CubicalMetric<D>` (or a `MetricKind` enum at the `Manifold` level) that, for the unit-edge case, returns `1.0` for every edge length and short-circuits volume computations to integer lattice volumes. Non-uniform / scaled / curved cubical metrics are deferred.
+
+**Why:** Sensor-fusion users overwhelmingly want unit-spacing voxel grids in v1. Building a full irregular-cubical Regge metric now would balloon the diff and isn't needed to close #487. Documenting the deferral makes the v2 contract clean.
+
+**Alternatives considered:**
+- *Genericize `ReggeGeometry` over the cell type*: doable but expensive; defer until non-uniform cubical metrics are actually needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Manifold genericization is a wide mechanical refactor across `manifold/{api,differential,topology,geometry,covariance,constructors,getters}` — ~10 files.** → *Mitigation:* Land Part A (trait refactor) first with zero behavior change so the diff is reviewable in isolation. Part B then only changes type signatures, not logic. Keep simplicial tests unmodified; their passing is the regression gate.
+- **[Risk] GAT iterators in trait methods have sharper lifetime/variance constraints than `Box<dyn Iterator>`.** Some call sites may need lifetime annotations they didn't before. → *Mitigation:* Audit during Part A; the failure mode is a compile error, not silent behavior change.
+- **[Risk] Rename is a public API break for downstream crates.** `deep_causality_topology` is consumed by several monorepo crates. → *Mitigation:* Run `make build` after the rename; fix downstream import sites in the same change set. AGENTS.md tolerates this — the monorepo is co-versioned.
+- **[Risk] `CubicalComplex<D>` carrying its dimension as a const generic propagates `D` into `Manifold<CubicalComplex<D>, F>` — every caller writes the dimension at the type level.** → *Mitigation:* Accept it. The alternative (runtime dimension) would erase static guarantees and break existing `Lattice<D>` users. Provide pre-baked constructors for `D = 2, 3, 4` (already present on `Lattice`).
+- **[Risk] `Manifold::neighbors` returns `impl Iterator` with a borrow on `self.complex`, which can complicate borrow checking inside the comonad closure** (the closure also reads `self.data`). → *Mitigation:* The strategy returns cell IDs only — the closure then indexes `self.data` separately. No overlapping borrows of the same field.
+- **[Trade-off] Moore and KRing being cubical-only means a user mixing simplicial and cubical pipelines must pick neighborhood strategies per-complex.** This is the *correct* design — the asymmetry is in the math, not the API.
+- **[Trade-off] Deferring sparse cubical storage means high-resolution voxel grids (e.g., 1024³) will allocate a dense `CubicalComplex<3>` shape descriptor even if 99% of cubes are empty.** The descriptor itself is small (shape + periodicity) — what's dense is the boundary-matrix construction. For sensor fusion this may be unacceptable at scale; document it explicitly and open a follow-up.
+
+## Migration Plan
+
+- **Within this change set:** All three Parts (A, B, C) land in one PR with three task groups. Each task group leaves `make build && make test` green for the whole monorepo.
+- **Downstream:** `deep_causality` and any other consumer of topology types updates imports in the same change. No deprecation window — the rename is atomic.
+- **Rollback:** Revert the merge commit. No data migration is involved (library types only).
+
+## Open Questions
+
+None remaining. The neighborhood vocabulary (D5), the rename policy (D4), and the sequencing (one change set, three task groups) were settled with the user before this design was written.

--- a/openspec/changes/add-cubical-complexes/proposal.md
+++ b/openspec/changes/add-cubical-complexes/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+GitHub issue #487 asks for cubical complexes to support efficient spatial sensor fusion (LIDAR / RF / UWB / voxel grids), driven by Service Radar's adoption of DeepCausality for topological network analysis. The substrate already exists in `deep_causality_topology` as `Lattice<const D: usize>` with `LatticeCell<D>`, periodic/open boundaries, boundary matrices and Betti numbers — but it is **inaccessible from `Manifold`**, carries non-textbook naming, and is plumbed through a chain-complex trait (`CWComplex`) that violates the project's static-dispatch rule. As a result, no user can put field data on a cubical grid and run the differential/comonadic machinery the simplicial path already has. This change unblocks #487 by completing the missing plumbing, not by inventing a new primitive.
+
+## What Changes
+
+**Part A — Static-dispatch chain-complex trait (pure refactor, no behavior change)**
+
+- **BREAKING (internal trait surface only):** Rename `CWComplex` → `ChainComplex` to align with algebraic-topology textbook terminology.
+- **BREAKING:** Replace `fn cells(&self, k) -> Box<dyn Iterator<...>>` with a GAT-backed `type CellIter<'a>` returning `impl Iterator`. Eliminates `dyn` per AGENTS.md static-dispatch rule.
+- Add `fn coboundary_matrix(&self, k: usize) -> CsrMatrix<i8>` to the trait contract so the differential stack can be written generically.
+- Implement `ChainComplex` for `SimplicialComplex` (today it has equivalent methods but does not wear the trait).
+- Update existing `Lattice<D>` impl to the new trait surface.
+
+**Part B — Genericize `Manifold` over `ChainComplex`**
+
+- **BREAKING (public type signature):** `Manifold<C, D>` (where the complex was hard-coded to `SimplicialComplex<C>`) becomes `Manifold<K: ChainComplex, F>` where `K` is the underlying complex and `F` is field data.
+- Add type alias `pub type SimplicialManifold<C, F> = Manifold<SimplicialComplex<C>, F>` for ergonomic continuity; existing call sites that used `Manifold<C, D>` migrate to the alias.
+- Move pre-computed coboundary operators out of `SimplicialComplex` storage or expose them through the trait, so `manifold/differential/*` (exterior derivative, codifferential, Hodge ⋆, Laplacian) read through `K: ChainComplex` instead of reaching into `self.complex.coboundary_operators[k]`.
+- Re-implement the `ManifoldWitness` HKT extensions (`Functor`/`CoMonad` for `Manifold`) against the generic complex parameter.
+- `ReggeGeometry`: keep the simplicial implementation; add a trivial cubical metric for `Lattice<D>` (unit edges / scalar spacing) so `Manifold<Lattice<D>, F>` is constructible. Non-uniform cubical metrics are deferred.
+
+**Part C — Cubical-complex surfacing and neighborhood strategy (the user-visible feature)**
+
+- **BREAKING (rename):** Rename `Lattice<const D: usize>` → `CubicalComplex<const D: usize>` and `LatticeCell<D>` → `CubicalCell<D>` to match textbook usage and the issue's terminology. The `types/lattice/` directory moves to `types/cubical_complex/`. Dependent modules (`gauge_field_lattice`, `dual_lattice`, `hkt_lattice`, `specialized`) are renamed in lock-step. No `pub use` aliases for the old names — the project prefers clean removal over back-compat shims.
+- Introduce `Neighborhood<K>` strategy trait with a single method returning `impl Iterator<Item = CellId>`. Zero-sized concrete strategies, all static dispatch:
+  - Generic over any `ChainComplex`: `FaceAdjacent` (via ∂), `CofaceAdjacent` (via δ).
+  - `CubicalComplex<D>` only: `VonNeumann`, `Moore`, `KRing<const K: usize>`.
+  - Users can implement `Neighborhood<K>` for their own strategies (anisotropic LIDAR cones, half-space RF) without forking the crate.
+- Add a `Manifold` helper `fn neighbors<N: Neighborhood<K>>(&self, n: N, cell: CellId) -> impl Iterator<...>` so the comonad's `extend` closure can query neighborhoods uniformly.
+- Add `examples/cubical_heat_diffusion.rs` showing voxel-grid construction, boundary, and Moore-neighborhood heat diffusion via `CoMonad::extend`.
+
+**Not in scope (deferred to follow-up issues)**
+
+- Hodge ⋆ on non-unit / non-regular cubes (irregular cubical metrics).
+- Sparse cubical complex (set-of-active-cubes) vs the current implicit-dense `CubicalComplex<D>`. Sensor fusion likely wants sparse; needs benchmarking first.
+- Hex / triangular / other CW complex kinds.
+- GPU paths for cubical Hodge / Laplacian (current `*_cpu.rs` naming already implies a future GPU split).
+
+## Capabilities
+
+### New Capabilities
+
+- `chain-complex-trait`: Static-dispatch trait describing any CW complex (simplicial, cubical, or user-defined) in terms of cells, boundary, coboundary, and Betti numbers. Replaces the dyn-based `CWComplex` trait.
+- `cubical-complex`: First-class cubical complex type (renamed from `Lattice`) with elementary cubes, periodic/open boundaries, boundary/coboundary matrices, and dense + future-sparse storage. Implements `chain-complex-trait`.
+- `neighborhood-strategy`: Static-dispatch trait family for cell neighborhood queries. Provides chain-complex-generic primitives (`FaceAdjacent`, `CofaceAdjacent`) and cubical-only strategies (`VonNeumann`, `Moore`, `KRing`). Consumed by the comonadic `extend` operation.
+
+### Modified Capabilities
+
+- `manifold`: Becomes generic over any `chain-complex-trait` implementor instead of hard-wired to `SimplicialComplex`. Differential operators (exterior derivative, codifferential, Hodge ⋆, Laplacian) and the `CoMonad` impl are reworked to read through the trait. Existing simplicial behavior preserved via `SimplicialManifold<C, F>` alias.
+- `simplicial-complex`: Implements `chain-complex-trait`. Pre-cached coboundary operators are exposed through the trait surface instead of via direct field access from `Manifold`.
+
+## Impact
+
+**Affected crate:** `deep_causality_topology` (sole crate touched).
+
+**Affected modules:**
+- `src/traits/cw_complex.rs` — trait redesign and rename.
+- `src/traits/mod.rs` — re-export rename.
+- `src/types/lattice/` → `src/types/cubical_complex/` — directory move + type rename + downstream module renames (`gauge_field_lattice`, `dual_lattice`, `specialized`).
+- `src/types/manifold/**` — genericization (largest mechanical diff: ~10 files under `api/`, `differential/`, `topology/`, `geometry/`, `covariance/`, `constructors/`).
+- `src/types/simplicial_complex/topology/` — `ChainComplex` impl.
+- `src/extensions/hkt_manifold/` — re-parameterize witness over `K: ChainComplex`.
+- `src/extensions/hkt_lattice/` → `src/extensions/hkt_cubical_complex/`.
+- `src/types/` — new `neighborhood/` module for the strategy trait and concrete strategies.
+- `tests/**` — mirror all structural moves; update `tests/BUILD.bazel`.
+- `examples/` — new `cubical_heat_diffusion.rs`.
+- `BUILD.bazel`, `Cargo.toml` — no new external dependencies; only module path updates.
+
+**External API impact:**
+- Public renames: `Lattice<D>` → `CubicalComplex<D>`, `LatticeCell<D>` → `CubicalCell<D>`, `CWComplex` → `ChainComplex`. No `pub use` aliases.
+- Public type signature change: `Manifold<C, D>` → `Manifold<K, F>`. `SimplicialManifold<C, F>` alias provided.
+- Downstream crates depending on `deep_causality_topology`'s renamed types must update imports.
+
+**Constraints honored:**
+- No `unsafe` introduced.
+- No `dyn` / trait objects; static dispatch throughout.
+- No macros in lib code.
+- No new external dependencies.
+- Tests mirror src structure and are registered in `tests/mod.rs` + `tests/BUILD.bazel`.
+- No `pub use` back-compat shims for renamed items (per AGENTS.md preference for clean diffs).
+
+**Sequencing inside the change** (single OpenSpec change, three task groups in `tasks.md`):
+1. Part A (chain-complex trait refactor) — must land first; no behavior change.
+2. Part B (Manifold genericization) — depends on Part A; existing simplicial tests must continue to pass unchanged.
+3. Part C (cubical surfacing + neighborhood strategies + example) — depends on Part B; this is the change that actually closes #487.

--- a/openspec/changes/add-cubical-complexes/specs/chain-complex-trait/spec.md
+++ b/openspec/changes/add-cubical-complexes/specs/chain-complex-trait/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: ChainComplex trait replaces CWComplex with static dispatch
+
+The crate `deep_causality_topology` SHALL expose a public trait `ChainComplex` that describes any CW-style complex (simplicial, cubical, or user-defined) using only static dispatch. The trait MUST NOT use `Box<dyn Iterator>` or any other trait object in its method signatures. The pre-existing trait `CWComplex` SHALL be removed; no `pub use CWComplex = ChainComplex` alias is provided.
+
+#### Scenario: ChainComplex uses GAT iterator
+
+- **WHEN** a downstream crate implements `ChainComplex` for a concrete type
+- **THEN** the trait requires an associated `type CellIter<'a>: Iterator<Item = Self::CellType> where Self: 'a`
+- **AND** the method `fn cells(&self, k: usize) -> Self::CellIter<'_>` returns the iterator by value, not boxed
+
+#### Scenario: No dyn Iterator in public API
+
+- **WHEN** the crate is built with `cargo build -p deep_causality_topology`
+- **AND** the test suite is built with `cargo test -p deep_causality_topology`
+- **THEN** `grep -RIn "dyn Iterator" src/traits/` returns no matches in the `ChainComplex` definition or its impls
+
+### Requirement: ChainComplex exposes boundary and coboundary uniformly
+
+`ChainComplex` SHALL require methods to retrieve both the boundary matrix ∂_k and the coboundary matrix δ_k for any grade k, so that downstream code (notably `Manifold`'s differential operators) can read them without reaching into any concrete complex's storage layout.
+
+#### Scenario: Boundary and coboundary are first-class trait methods
+
+- **WHEN** a generic function `fn f<K: ChainComplex>(k: &K)` is written
+- **THEN** it can call `k.boundary_matrix(grade)` and `k.coboundary_matrix(grade)` returning `CsrMatrix<i8>`
+- **AND** the call compiles without referencing any concrete complex type
+
+#### Scenario: SimplicialComplex satisfies the trait via its cached operators
+
+- **WHEN** `SimplicialComplex<C>` implements `ChainComplex`
+- **THEN** `coboundary_matrix(k)` returns the matrix from its pre-existing `coboundary_operators` cache
+- **AND** the cached values are bit-for-bit identical to those used today by `manifold/differential/exterior_cpu.rs`
+
+#### Scenario: CubicalComplex satisfies the trait without a pre-computed cache
+
+- **WHEN** `CubicalComplex<D>` implements `ChainComplex`
+- **THEN** `coboundary_matrix(k)` returns a matrix algebraically equal to `boundary_matrix(k+1).transpose()`
+- **AND** the implementation MAY memoize lazily but MUST NOT require the caller to pre-populate it
+
+### Requirement: ChainComplex preserves topological queries
+
+`ChainComplex` SHALL retain the queries already provided by `CWComplex`: cell count per grade, maximum dimension, and k-th Betti number.
+
+#### Scenario: Topological queries preserved on Lattice rename
+
+- **WHEN** `CubicalComplex<3>::torus([4, 4, 4])` is constructed
+- **THEN** `num_cells(k)`, `max_dim()`, and `betti_number(k)` return the same values that today's `Lattice<3>::cubic_torus(4)` returns for every k in `0..=3`

--- a/openspec/changes/add-cubical-complexes/specs/cubical-complex/spec.md
+++ b/openspec/changes/add-cubical-complexes/specs/cubical-complex/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: CubicalComplex is the public textbook name
+
+The crate `deep_causality_topology` SHALL expose `CubicalComplex<const D: usize>` and `CubicalCell<const D: usize>` as the public types representing a D-dimensional cubical complex and its elementary cubes respectively. The previous names `Lattice` and `LatticeCell` SHALL be removed from the public surface. No `pub use Lattice = CubicalComplex` aliases are provided.
+
+#### Scenario: Public names match textbook usage
+
+- **WHEN** a user writes `use deep_causality_topology::CubicalComplex;`
+- **THEN** the import resolves
+- **AND** `use deep_causality_topology::Lattice;` fails to compile with an unresolved-import error
+
+#### Scenario: Cell type renamed in lock-step
+
+- **WHEN** a user writes `use deep_causality_topology::CubicalCell;`
+- **THEN** the import resolves to the type previously known as `LatticeCell`
+- **AND** the type retains its `Cell` trait impl, `boundary()` method, `vertices()` method, and bitmask-based orientation encoding unchanged
+
+### Requirement: CubicalComplex implements ChainComplex
+
+`CubicalComplex<D>` SHALL implement the `ChainComplex` trait, exposing static-dispatch cell iteration, boundary and coboundary matrices, max dimension, and Betti numbers.
+
+#### Scenario: Iteration is static dispatch
+
+- **WHEN** a generic function `fn f<K: ChainComplex>(k: &K)` is called with `&CubicalComplex<3>::torus([8, 8, 8])`
+- **THEN** `k.cells(2)` yields each 2-cell exactly once without boxing
+- **AND** the count equals `k.num_cells(2)`
+
+#### Scenario: Boundary on a cube matches LatticeCell semantics
+
+- **WHEN** the boundary matrix `boundary_matrix(2)` is constructed for `CubicalComplex<2>::square_open(3)`
+- **THEN** for every 2-cell, its column has nonzero entries exactly at the four 1-cells produced by `CubicalCell::boundary()`, with matching signs
+
+#### Scenario: Periodic boundaries preserved
+
+- **WHEN** `CubicalComplex<2>::square_torus(4)` is constructed
+- **THEN** `betti_number(0) == 1`, `betti_number(1) == 2`, `betti_number(2) == 1` (the homology of a 2-torus)
+
+### Requirement: Module layout follows textbook naming
+
+The source layout SHALL move from `src/types/lattice/` to `src/types/cubical_complex/`, and the HKT extension SHALL move from `src/extensions/hkt_lattice/` to `src/extensions/hkt_cubical_complex/`. Internal submodules referencing the old name (`dual_lattice`, `specialized`) SHALL be renamed for consistency. The physics-specific submodule `gauge_field_lattice` retains its name because "lattice gauge theory" is the established physics term and renaming would be semantically wrong.
+
+#### Scenario: Bazel BUILD files updated
+
+- **WHEN** `bazel build //deep_causality_topology/...` is run
+- **THEN** the build succeeds with the new module paths
+- **AND** `tests/BUILD.bazel` references `cubical_complex/` rather than `lattice/`
+
+#### Scenario: Test tree mirrors source tree
+
+- **WHEN** an engineer looks for tests covering `CubicalComplex`
+- **THEN** they find them under `tests/types/cubical_complex/` with file names matching source files plus the `_tests` suffix
+- **AND** every test file is registered in its parent `mod.rs` with `#[cfg(test)]`

--- a/openspec/changes/add-cubical-complexes/specs/manifold/spec.md
+++ b/openspec/changes/add-cubical-complexes/specs/manifold/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Manifold is generic over any ChainComplex
+
+`Manifold` SHALL be generic over the underlying chain complex. Its type signature SHALL be `Manifold<K: ChainComplex, F>` where `K` is the complex and `F` is the field data type. The previous signature `Manifold<C, D>` (where the complex was hard-wired to `SimplicialComplex<C>`) SHALL be removed.
+
+#### Scenario: Manifold can wrap a simplicial complex
+
+- **WHEN** the user constructs `SimplicialManifold::<C, f64>::new(simplex, data, None)` where `SimplicialManifold<C, F> = Manifold<SimplicialComplex<C>, F>`
+- **THEN** the construction succeeds
+- **AND** all simplicial-specific tests that pass today continue to pass without modification
+
+#### Scenario: Manifold can wrap a cubical complex
+
+- **WHEN** the user constructs `Manifold::<CubicalComplex<3>, f64>::new(complex, data, Some(metric))`
+- **THEN** the construction succeeds
+- **AND** the resulting value carries the cubical complex, field tensor, optional metric, and a cursor
+
+### Requirement: Differential operators read the complex through the trait
+
+The methods that compute exterior derivative, codifferential, Hodge ⋆, and Laplacian on a `Manifold<K, F>` SHALL access the underlying complex's boundary and coboundary operators only through the `ChainComplex` trait. They SHALL NOT pattern-match on the concrete complex type or read complex-specific fields directly.
+
+#### Scenario: Exterior derivative is generic
+
+- **WHEN** the exterior derivative of a 1-form is computed on `Manifold<SimplicialComplex<C>, f64>` and on `Manifold<CubicalComplex<2>, f64>`
+- **THEN** both computations succeed
+- **AND** for the simplicial case the result equals today's `manifold/differential/exterior_cpu.rs` output bit-for-bit
+
+#### Scenario: No direct field access on concrete complex
+
+- **WHEN** the codebase is scanned with `grep -RIn "complex.coboundary_operators" src/types/manifold/`
+- **THEN** there are no matches outside the trait-impl boundary
+
+### Requirement: Comonad iteration is unchanged, neighborhood is queried inside the closure
+
+`CoMonad::extend` on `Manifold<K, F>` SHALL continue to iterate the cursor over every cell (preserving today's order and cursor semantics) and pass the manifold view to the user's closure. A new helper `Manifold::neighbors<N: Neighborhood<K>>(&self, n: N, cell: CellId) -> N::Iter<'_>` SHALL be added so that the closure can pick a neighborhood strategy at the point of use.
+
+#### Scenario: extend preserves iteration order
+
+- **WHEN** `<ManifoldWitness<K> as CoMonad<...>>::extend(&m, f)` is called
+- **THEN** the closure `f` is invoked once for each cell index `i` in `0..m.data.len()` in ascending order, each time with `m.cursor = i`
+
+#### Scenario: Neighborhood query inside extend closure
+
+- **WHEN** the user writes a closure `|view| view.neighbors(Moore, view.cursor()).map(|c| view.data_at(c)).sum::<f64>()`
+- **AND** passes it to `CoMonad::extend` on `Manifold<CubicalComplex<3>, f64>`
+- **THEN** every output cell holds the sum of its 26 Moore neighbors' input values
+
+### Requirement: ReggeGeometry on cubical complexes supports the unit-edge case
+
+`Manifold<CubicalComplex<D>, F>` SHALL accept a metric for the unit-edge case (every edge has length 1.0). Non-uniform / scaled / curved cubical metrics are out of scope for this change and SHALL be tracked in a separate follow-up issue.
+
+#### Scenario: Unit-edge cubical metric
+
+- **WHEN** the user constructs `Manifold::with_metric(CubicalComplex::<3>::cubic_torus(4), data, unit_metric)`
+- **THEN** every edge length used by volume / Hodge computations is `1.0`
+- **AND** the construction succeeds without invoking the (unimplemented) irregular cubical metric path
+
+#### Scenario: Simplicial Regge geometry untouched
+
+- **WHEN** existing simplicial Regge-geometry tests are run
+- **THEN** they pass without modification — the simplicial path is not refactored as part of this change

--- a/openspec/changes/add-cubical-complexes/specs/neighborhood-strategy/spec.md
+++ b/openspec/changes/add-cubical-complexes/specs/neighborhood-strategy/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Neighborhood strategy trait uses static dispatch
+
+The crate `deep_causality_topology` SHALL expose a public trait `Neighborhood<K: ChainComplex>` that describes how to enumerate the neighbors of a cell in a complex of type `K`. The trait MUST NOT use `dyn` or `Box<dyn ...>`. Concrete strategy implementors SHALL be zero-sized types where the strategy carries no data, so that the cost of passing one to a generic function monomorphizes to nothing.
+
+#### Scenario: Strategy is a zero-sized parameter
+
+- **WHEN** the user calls `manifold.neighbors(VonNeumann, cell_id)` on a `Manifold<CubicalComplex<3>, F>`
+- **THEN** `std::mem::size_of::<VonNeumann>()` is `0`
+- **AND** the call compiles and yields the 6 face-adjacent 3-cells around `cell_id` on a `CubicalComplex<3>`
+
+#### Scenario: User-defined strategies plug in without forking the crate
+
+- **WHEN** a downstream user declares `struct HalfSpace { plane: u8 }` and implements `Neighborhood<CubicalComplex<3>>` for it
+- **THEN** `manifold.neighbors(HalfSpace { plane: 2 }, cell_id)` compiles and runs against the user-defined strategy
+
+### Requirement: Chain-complex-generic strategies are derived from boundary and coboundary
+
+`FaceAdjacent` and `CofaceAdjacent` SHALL be implemented as `Neighborhood<K>` for every `K: ChainComplex`. Their definitions SHALL depend only on `K::boundary_matrix` and `K::coboundary_matrix` respectively, so that they extend to any complex satisfying the trait.
+
+#### Scenario: FaceAdjacent on a simplicial complex
+
+- **WHEN** `FaceAdjacent` is used on a `SimplicialManifold<C, F>` to query neighbors of a 2-simplex σ
+- **THEN** the returned iterator yields every other 2-simplex τ such that σ and τ share a 1-simplex (edge)
+
+#### Scenario: FaceAdjacent on a cubical complex coincides with Von Neumann on top cells
+
+- **WHEN** `FaceAdjacent` and `VonNeumann` are each applied to the same top-dimensional cube on `CubicalComplex<3>`
+- **THEN** the two iterators yield the same set of cells (order not required to match)
+
+### Requirement: Grid-specific strategies are only implemented for CubicalComplex
+
+`VonNeumann`, `Moore`, and `KRing<const K: usize>` SHALL be implemented as `Neighborhood<CubicalComplex<D>>` only. They SHALL NOT be implemented for `SimplicialComplex`. This asymmetry is intentional: Moore and KRing rely on the regular-grid coordinate structure and Chebyshev metric, which have no principled simplicial analogue.
+
+#### Scenario: Moore on a 3D cube yields 26 neighbors
+
+- **WHEN** `Moore` is applied to an interior top-cell of `CubicalComplex<3>::cubic_open(8)`
+- **THEN** the iterator yields exactly 26 cells (3³ − 1)
+
+#### Scenario: KRing on a 2D grid uses Chebyshev distance
+
+- **WHEN** `KRing::<2>` is applied to an interior top-cell of `CubicalComplex<2>::square_open(20)`
+- **THEN** the iterator yields exactly 24 cells (5² − 1)
+- **AND** every yielded cell has Chebyshev distance at most 2 from the source cell
+
+#### Scenario: Moore is not implementable on SimplicialComplex
+
+- **WHEN** a user attempts to call `simplicial_manifold.neighbors(Moore, cell_id)`
+- **THEN** the code fails to compile because `Moore` does not implement `Neighborhood<SimplicialComplex<C>>`
+
+### Requirement: Periodic and open boundary conditions are respected
+
+For `CubicalComplex<D>` with periodic boundaries, neighborhood strategies SHALL wrap across the boundary. For open boundaries, neighbors that would lie outside the shape SHALL be omitted.
+
+#### Scenario: Von Neumann on a torus wraps
+
+- **WHEN** `VonNeumann` is applied to a corner top-cell of `CubicalComplex<2>::square_torus(4)`
+- **THEN** the iterator yields 4 neighbors, including cells from the opposite edges
+
+#### Scenario: Von Neumann on an open grid omits out-of-bounds
+
+- **WHEN** `VonNeumann` is applied to a corner top-cell of `CubicalComplex<2>::square_open(4)`
+- **THEN** the iterator yields exactly 2 neighbors (the two in-bounds face-adjacent cells)

--- a/openspec/changes/add-cubical-complexes/specs/simplicial-complex/spec.md
+++ b/openspec/changes/add-cubical-complexes/specs/simplicial-complex/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: SimplicialComplex implements ChainComplex
+
+`SimplicialComplex<C>` SHALL implement the `ChainComplex` trait. The implementation SHALL preserve today's caching strategy: the pre-computed `boundary_operators` and `coboundary_operators` collections continue to live on the complex and are returned through the trait methods. No structural change to `SimplicialComplex`'s storage is required.
+
+#### Scenario: Boundary matrix returned from cache
+
+- **WHEN** `<SimplicialComplex<C> as ChainComplex>::boundary_matrix(k)` is called
+- **THEN** the returned `CsrMatrix<i8>` is the value already cached in `boundary_operators[k]`
+- **AND** the cached value is bit-for-bit identical to what today's code reads
+
+#### Scenario: Coboundary matrix returned from cache
+
+- **WHEN** `<SimplicialComplex<C> as ChainComplex>::coboundary_matrix(k)` is called
+- **THEN** the returned `CsrMatrix<i8>` is the value already cached in `coboundary_operators[k]`
+
+#### Scenario: Cell iteration is static dispatch
+
+- **WHEN** `<SimplicialComplex<C> as ChainComplex>::cells(k)` is called
+- **THEN** the returned iterator's type is the concrete `SimplicialComplex` cell iterator, not a `Box<dyn Iterator>`
+- **AND** the iterator yields every k-simplex exactly once
+
+### Requirement: SimplicialComplex public surface is unchanged
+
+The rename of `CWComplex` to `ChainComplex` and the genericization of `Manifold` SHALL NOT change the public surface of `SimplicialComplex<C>` itself. Existing constructors, getters, and methods on `SimplicialComplex` SHALL remain bit-for-bit identical.
+
+#### Scenario: Existing simplicial tests pass unchanged
+
+- **WHEN** `cargo test -p deep_causality_topology` is run after the change
+- **THEN** every pre-existing test under `tests/types/simplicial_complex/` passes without source modification

--- a/openspec/changes/add-cubical-complexes/tasks.md
+++ b/openspec/changes/add-cubical-complexes/tasks.md
@@ -1,0 +1,57 @@
+## 1. Part A — Static-dispatch ChainComplex trait (pure refactor, no behavior change)
+
+- [ ] 1.1 Rename `src/traits/cw_complex.rs` → `src/traits/chain_complex.rs`; rename trait `CWComplex` → `ChainComplex` and marker trait `Cell` is left as-is.
+- [ ] 1.2 Replace `fn cells(&self, k: usize) -> Box<dyn Iterator<Item = Self::CellType> + '_>` with associated `type CellIter<'a>: Iterator<Item = Self::CellType> where Self: 'a;` and `fn cells(&self, k: usize) -> Self::CellIter<'_>`.
+- [ ] 1.3 Add `fn coboundary_matrix(&self, k: usize) -> CsrMatrix<i8>` to the `ChainComplex` trait contract.
+- [ ] 1.4 Update `src/traits/mod.rs` to export `ChainComplex` and remove `CWComplex`; update root `lib.rs` re-exports.
+- [ ] 1.5 Update `Lattice<D>`'s impl in `src/types/lattice/mod.rs` to the new trait surface: introduce a concrete `LatticeCellIter<'a, D>` (already exists as `LatticeCellIterator`) as `type CellIter<'a>`, drop the `Box::new`, add `coboundary_matrix(k)` returning `boundary_matrix(k+1).transpose()` (memoized lazily — `RefCell<HashMap<usize, CsrMatrix<i8>>>` if simple; otherwise recompute).
+- [ ] 1.6 Implement `ChainComplex` for `SimplicialComplex<C>` in `src/types/simplicial_complex/topology/` (new file `chain_complex_impl.rs`). `coboundary_matrix(k)` returns a clone of `self.coboundary_operators[k]`. `cells(k)` returns the concrete simplicial-cell iterator.
+- [ ] 1.7 Migrate every existing call site of `CWComplex` to `ChainComplex` (audit with `grep -RIn "CWComplex" src/ tests/`); confirm no `Box<dyn Iterator>` remains in topology trait surfaces.
+- [ ] 1.8 Update `tests/traits/cw_complex_tests.rs` → `chain_complex_tests.rs`; register in `tests/traits/mod.rs` and `tests/BUILD.bazel`. Add a test that asserts `size_of` of the returned iterator from `cells(k)` is non-zero and not heap-allocated (use a static-dispatch sanity check: pass `K: ChainComplex` to a generic helper).
+- [ ] 1.9 Run `cargo build -p deep_causality_topology` and `cargo test -p deep_causality_topology`; both must pass with zero behavior change.
+- [ ] 1.10 Run `make format && make fix` and verify no clippy warnings introduced.
+
+## 2. Part B — Genericize Manifold over ChainComplex
+
+- [ ] 2.1 In `src/types/manifold/mod.rs`, change the struct from `Manifold<C, D>` with `complex: SimplicialComplex<C>` to `Manifold<K: ChainComplex, F>` with `complex: K`, `data: CausalTensor<F>`, `metric: Option<ReggeGeometry<K>>` (or `Option<Box<...>>` only if forced — prefer trait-generic metric; see 2.5), `cursor: usize`.
+- [ ] 2.2 Add public type alias `pub type SimplicialManifold<C, F> = Manifold<SimplicialComplex<C>, F>;` in `src/types/manifold/mod.rs`; re-export from `lib.rs`.
+- [ ] 2.3 Update every file under `src/types/manifold/{api,constructors,covariance,display,geometry,getters,utils,differential,topology}/` to take `K: ChainComplex` instead of the concrete `SimplicialComplex<C>`. Mechanical sed-style edits — no logic change.
+- [ ] 2.4 In `src/types/manifold/differential/exterior_cpu.rs`, replace `&self.complex.coboundary_operators[k]` with `self.complex.coboundary_matrix(k)`. Repeat for `codifferential_cpu.rs`, `hodge_cpu.rs`, `laplacian_cpu.rs` — all reads of pre-cached boundary/coboundary go through trait methods.
+- [ ] 2.5 Resolve `ReggeGeometry<K>` genericization: either (a) keep `ReggeGeometry` simplicial and introduce a `MetricKind<K>` enum at the `Manifold` level holding `Simplicial(ReggeGeometry<...>)` or `Cubical(CubicalMetric<D>)`, or (b) genericize `ReggeGeometry<K: ChainComplex>` directly. Pick (a) — it isolates the diff. Create `src/types/cubical_metric/mod.rs` carrying the unit-edge cubical metric (constant edge length `1.0`).
+- [ ] 2.6 Update `src/extensions/hkt_manifold/mod.rs` to re-parameterize `ManifoldWitness` and the `Functor`/`CoMonad` impls over `K: ChainComplex` instead of `C: Satisfies<NoConstraint>`. Iteration order and cursor semantics MUST remain identical.
+- [ ] 2.7 Update every existing import/use of `Manifold<C, D>` to `SimplicialManifold<C, D>` across `deep_causality_topology` and any downstream monorepo crate (`grep -RIn "Manifold<" .`).
+- [ ] 2.8 Update test files under `tests/types/manifold/` to use `SimplicialManifold`; do not rename test files (the underlying type is still being exercised).
+- [ ] 2.9 Add an assertion test that `grep -RIn "complex.coboundary_operators" src/types/manifold/` returns zero matches — encoded as a Bazel `genrule` test or a Rust `build.rs` guard if the repo already has that pattern; otherwise document the check in `tests/types/manifold/no_direct_field_access_tests.rs` as a `cargo test` integration that scans the source.
+- [ ] 2.10 Run `cargo build -p deep_causality_topology && cargo test -p deep_causality_topology` — every pre-existing simplicial test must pass unchanged.
+- [ ] 2.11 Run `make build` to confirm no downstream monorepo crate breaks (this is where the import migration in 2.7 is verified end-to-end).
+- [ ] 2.12 Run `make format && make fix`.
+
+## 3. Part C — Cubical surfacing, Neighborhood strategy, and example
+
+- [ ] 3.1 Move `src/types/lattice/` → `src/types/cubical_complex/` (file moves via `git mv`); rename `lattice_cell.rs` → `cubical_cell.rs`, `dual_lattice.rs` → `dual_cubical_complex.rs`. Inner type renames: `Lattice<D>` → `CubicalComplex<D>`, `LatticeCell<D>` → `CubicalCell<D>`, `LatticeCellIterator` → `CubicalCellIterator`. Update `mod.rs` declarations.
+- [ ] 3.2 Leave `src/types/gauge/gauge_field_lattice/` untouched — "lattice gauge theory" is the established physics term.
+- [ ] 3.3 Move `src/extensions/hkt_lattice/` → `src/extensions/hkt_cubical_complex/`; rename the witness type accordingly. Update `src/extensions/mod.rs`.
+- [ ] 3.4 Update `src/lib.rs` public exports: add `pub use crate::types::cubical_complex::{CubicalComplex, CubicalCell};` and remove `Lattice`/`LatticeCell` exports. No `pub use` aliases.
+- [ ] 3.5 Move `tests/types/lattice/` → `tests/types/cubical_complex/`; rename test files in lock-step (e.g. `lattice_cell_tests.rs` → `cubical_cell_tests.rs`); update every `mod` declaration in `tests/types/mod.rs` and the new `tests/types/cubical_complex/mod.rs`; ensure `#[cfg(test)]` is preserved.
+- [ ] 3.6 Update `tests/BUILD.bazel`, `BUILD.bazel`, and `Cargo.toml` (if it lists module paths) to the new directory names.
+- [ ] 3.7 Create `src/traits/neighborhood.rs` defining `pub trait Neighborhood<K: ChainComplex>` with associated `type Iter<'a>: Iterator<Item = CellId> where K: 'a;` and `fn neighbors<'a>(&self, complex: &'a K, cell: CellId) -> Self::Iter<'a>;`. The `CellId` type alias lives next to the trait (likely `pub type CellId = usize;` — confirm from current code).
+- [ ] 3.8 Create `src/types/neighborhood/` module with one file per strategy: `face_adjacent.rs`, `coface_adjacent.rs`, `von_neumann.rs`, `moore.rs`, `k_ring.rs`. Each strategy is a unit struct (e.g. `pub struct VonNeumann;`).
+- [ ] 3.9 Implement `Neighborhood<K>` generically for `FaceAdjacent` and `CofaceAdjacent` over any `K: ChainComplex` using `boundary_matrix` / `coboundary_matrix`. Concrete iterator types (no `dyn`).
+- [ ] 3.10 Implement `Neighborhood<CubicalComplex<D>>` for `VonNeumann`, `Moore`, and `KRing<const K: usize>` with grid-coordinate fast paths. Respect periodic vs open boundaries (consult `CubicalComplex::periodic`). Do NOT implement these for `SimplicialComplex`.
+- [ ] 3.11 Add `Manifold::neighbors<N: Neighborhood<K>>(&self, n: N, cell: CellId) -> N::Iter<'_>` in `src/types/manifold/api/neighbors.rs`; export via `mod.rs`.
+- [ ] 3.12 Write tests under `tests/traits/neighborhood_tests.rs` and `tests/types/neighborhood/{face_adjacent,coface_adjacent,von_neumann,moore,k_ring}_tests.rs`. Cover: zero-sized assertion (`assert_eq!(size_of::<VonNeumann>(), 0)`); Moore-26 on 3D open; KRing<2>-24 on 2D open; Von Neumann wrap on torus; Von Neumann omit on open boundary; `FaceAdjacent == VonNeumann` on top cells of a cube; compile-fail test (via `compile_fail` doctest or `trybuild`) that `Moore` does not implement `Neighborhood<SimplicialComplex<_>>`.
+- [ ] 3.13 Register all new test files in their `tests/<dir>/mod.rs` with `#[cfg(test)]` and in `tests/BUILD.bazel`.
+- [ ] 3.14 Create `examples/cubical_heat_diffusion.rs`: build a `CubicalComplex<2>::square_open(32)`, wrap in a `Manifold` with initial heat = 1.0 at the center cell and 0.0 elsewhere, run 10 steps of `CoMonad::extend` using `Moore` neighborhood and an explicit Euler heat-equation stencil, print a 32×32 ASCII heatmap each step.
+- [ ] 3.15 Register the example in `Cargo.toml` (`[[example]]`) and `BUILD.bazel`.
+- [ ] 3.16 Update `docs/TOPOLOGY.md`: add a "Cubical Complexes" section mirroring the existing "Simplicial Complex" section; document `Neighborhood<K>` and the strategy split (generic vs grid-only); document `SimplicialManifold` alias and the `Manifold<K, F>` generic signature.
+- [ ] 3.17 Run `cargo build -p deep_causality_topology && cargo test -p deep_causality_topology && cargo run --example cubical_heat_diffusion -p deep_causality_topology`; all must succeed.
+- [ ] 3.18 Run `make format && make fix && make build && make test` for the whole monorepo (three or more crates touched). All must pass.
+
+## 4. Final verification
+
+- [ ] 4.1 Confirm `grep -RIn "CWComplex\|Lattice\b\|LatticeCell" deep_causality_topology/src deep_causality_topology/tests` returns zero matches (sole permitted exception: the physics-named `gauge_field_lattice` submodule).
+- [ ] 4.2 Confirm `grep -RIn "Box<dyn Iterator" deep_causality_topology/src/traits/ deep_causality_topology/src/types/cubical_complex/ deep_causality_topology/src/types/simplicial_complex/topology/` returns zero matches.
+- [ ] 4.3 Confirm `grep -RIn "complex.coboundary_operators\[" deep_causality_topology/src/types/manifold/` returns zero matches.
+- [ ] 4.4 Confirm `cargo check -p deep_causality_topology --all-features` is clean.
+- [ ] 4.5 Prepare a commit message (do NOT commit — per AGENTS.md golden rule, user commits) summarizing Parts A, B, C and referencing issue #487; surface it for the user to copy.
+- [ ] 4.6 Surface a follow-up issue draft for: (a) Hodge ⋆ on non-unit / irregular cubical metrics; (b) sparse `CubicalComplex` storage for high-resolution voxel grids; (c) GPU paths for cubical differential operators.

--- a/website/web/src/components/examples/ExampleDetail.astro
+++ b/website/web/src/components/examples/ExampleDetail.astro
@@ -48,7 +48,7 @@ const sourceHref = source ? `${repoBase}/${source}` : undefined;
 </article>
 
 <style>
-  .ex-detail { max-width: var(--w-page); margin: 0 auto; padding: var(--space-7) var(--space-4); }
+  .ex-detail { max-width: var(--w-prose); margin: 0 auto; padding: var(--space-7) var(--space-4); }
   @media (min-width: 720px) { .ex-detail { padding: var(--space-9) var(--space-5); } }
   .ex-head { display: flex; flex-direction: column; gap: var(--space-3); margin-bottom: var(--space-7); max-width: 60ch; }
   .eyebrow {

--- a/website/web/src/pages/index.astro
+++ b/website/web/src/pages/index.astro
@@ -12,11 +12,11 @@ import SectionDivider from '../components/home/SectionDivider.astro';
   <SiteHeader />
   <Hero />
   <SectionDivider />
+  <PillarRow />
+  <SectionDivider />
   <ExampleGrid />
   <SectionDivider />
   <WhyDeepCausality />
-  <SectionDivider />
-  <PillarRow />
   <SectionDivider />
   <JoinCommunity />
 </BaseLayout>


### PR DESCRIPTION

## Describe your changes

Polished layout and updated front page.

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [ x] All tests are passing when running make test?
- [ x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an OpenSpec for adding cubical complexes to `deep_causality_topology`, and polishes the website front page for clearer reading and section flow.

- **New Features**
  - Added OpenSpec change set for cubical complexes: design, proposal, specs for `ChainComplex`, `CubicalComplex`, `Manifold` genericization, `Neighborhood` strategies, and task plan.

- **Refactors**
  - Tweaked `ExampleDetail.astro` width to use `--w-prose` for better readability.
  - Reordered home sections in `index.astro`: moved `PillarRow` above `ExampleGrid` and adjusted dividers.

<sup>Written for commit 34fefd2faa85ff2396390d5b118beec89bb6429d. Summary will update on new commits. <a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/549?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

