### PR TITLE
ci(miri): Phase 1 — expand matrix to 16 safe crates

### DIFF
--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -22,11 +22,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Phase 0 pilot: validate plumbing on a single small crate with a
-        # well-defined unsafe primitive (`SparseMatrix::from_parts`).
-        # Additional crates are added in subsequent phases — see issue #536.
+        # Phase 1: pilot crate (deep_causality_sparse) plus all crates with
+        # zero `unsafe` in src/, no FFI, and no build scripts. The remaining
+        # at-risk crates (core, rand, multivector, topology) are added
+        # incrementally in subsequent phases — see issue #536.
         crate:
+          - deep_causality
+          - deep_causality_algorithms
+          - deep_causality_ast
+          - deep_causality_data_structures
+          - deep_causality_discovery
+          - deep_causality_effects
+          - deep_causality_ethos
+          - deep_causality_haft
+          - deep_causality_macros
+          - deep_causality_metric
+          - deep_causality_num
+          - deep_causality_physics
           - deep_causality_sparse
+          - deep_causality_tensor
+          - deep_causality_uncertain
+          - ultragraph
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION

## Describe your changes

ci(miri): Phase 1 — expand matrix to 16 safe crates

Adds all 14 crates with zero `unsafe` in src/ (plus deep_causality_tensor,
whose HKT issue is type-correctness rather than UB) to the Miri matrix.
The pilot crate deep_causality_sparse is retained.


## Issue ticket number and link

see issue #536.

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the Miri CI matrix to 16 crates to increase UB coverage, per issue #536. It now runs on all crates with no `unsafe` in `src/`, adds `deep_causality_tensor`, and keeps the pilot `deep_causality_sparse`; the at-risk crates (`core`, `rand`, `multivector`, `topology`) will follow in later phases.

<sup>Written for commit c6d1218df94dc7d226e9f70106f1dadc404dd019. Summary will update on new commits. <a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

