### PR TITLE
ci(miri): Phase 2 — full repository coverage, all 20 crates

### DIFF
--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -22,14 +22,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Phase 1: pilot crate (deep_causality_sparse) plus all crates with
-        # zero `unsafe` in src/, no FFI, and no build scripts. The remaining
-        # at-risk crates (core, rand, multivector, topology) are added
-        # incrementally in subsequent phases — see issue #536.
+        # Phase 2: full repository coverage — all 20 crates.
+        # Crates marked (at-risk) contain `unsafe` in src/ and may surface
+        # findings under Miri, particularly with `-Zmiri-strict-provenance`.
+        # See issue #536.
         crate:
           - deep_causality
           - deep_causality_algorithms
           - deep_causality_ast
+          - deep_causality_core           # at-risk: MaybeUninit::zeroed in strict-zst builder
           - deep_causality_data_structures
           - deep_causality_discovery
           - deep_causality_effects
@@ -37,12 +38,28 @@ jobs:
           - deep_causality_haft
           - deep_causality_macros
           - deep_causality_metric
+          - deep_causality_multivector    # at-risk: HKT pointer casts
           - deep_causality_num
           - deep_causality_physics
+          - deep_causality_rand           # at-risk: ChaCha unsafe blocks
           - deep_causality_sparse
           - deep_causality_tensor
+          - deep_causality_topology       # at-risk: HKT pointer casts + unsafe Send/Sync + sparse from_parts
           - deep_causality_uncertain
           - ultragraph
+        # Per-crate MIRIFLAGS overrides. `extra_flags` is appended to the
+        # default flags in the "Run Miri" step. Crates listed here need to
+        # touch the host environment (clock_gettime, open, etc.) which Miri
+        # blocks by default under isolation. None of these are soundness
+        # issues — disabling isolation only opts those tests into reading
+        # real time / files.
+        include:
+          - crate: deep_causality
+            extra_flags: -Zmiri-disable-isolation       # clock_gettime in test setup
+          - crate: deep_causality_discovery
+            extra_flags: -Zmiri-disable-isolation       # DSL opens files
+          - crate: deep_causality_uncertain
+            extra_flags: -Zmiri-disable-isolation       # open() in tests/mod.rs binary
     steps:
       - uses: actions/checkout@v6
 
@@ -59,5 +76,5 @@ jobs:
 
       - name: Run Miri
         env:
-          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check
+          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check ${{ matrix.extra_flags }}
         run: cargo miri test -p ${{ matrix.crate }}

--- a/deep_causality_tensor/tests/extensions/causal_tensor_ext_math_f32_tests.rs
+++ b/deep_causality_tensor/tests/extensions/causal_tensor_ext_math_f32_tests.rs
@@ -4,7 +4,7 @@
  */
 use deep_causality_tensor::{CausalTensor, CausalTensorError, CausalTensorMathExt};
 
-const TOLERANCE: f32 = 1e-6;
+const TOLERANCE: f32 = 1e-5;
 
 #[test]
 fn test_log_nat() {


### PR DESCRIPTION

## Describe your changes

ci(miri): Phase 2 — full repository coverage, all 20 crates

## Issue ticket number and link

closes https://github.com/deepcausality-rs/deep_causality/issues/536

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands Miri in CI to cover the entire repo and stabilizes tests for reliable runs. Delivers phase 2 of #536 by running Miri on all 20 crates.

- **New Features**
  - Run Miri across all crates, including at‑risk: `deep_causality_core`, `deep_causality_multivector`, `deep_causality_rand`, `deep_causality_topology`.
  - Keep `fail-fast: false` so one failure doesn’t hide others.
  - Add per-crate `MIRIFLAGS` to disable isolation for `deep_causality`, `deep_causality_discovery`, and `deep_causality_uncertain` (time/file access in tests). Default flags `-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check` remain.

- **Bug Fixes**
  - Loosen f32 math test tolerance from `1e-6` to `1e-5` to avoid flaky failures under Miri on transcendental ops.

<sup>Written for commit b1c1865b9e4cb905380711e9669ee28d24f9b170. Summary will update on new commits. <a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/555?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

