### PR TITLE
feat(deep_causality_topology): Added Cubical Regge Calculus 

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"88e9dcdc-1df9-4696-8883-23786b962fb2","pid":44198,"procStart":"Fri May 22 04:58:34 2026","acquiredAt":1779426452204}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"88e9dcdc-1df9-4696-8883-23786b962fb2","pid":44198,"procStart":"Fri May 22 04:58:34 2026","acquiredAt":1779426452204}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,17 @@ Only when multiple crate (3 or more) have changed at once, you run:
 
 To rebuild and test the entire repo
 
+## Code testing
+
+You aim for one hundred percent test coverage of all added or edited code files.
+The only exception is if, for some reason, some code is impossible to reach. Then you skip testing that dead code.
+
+If tests find any bug, you fix the implementation so that the test pass. Because the testing exists to ensure that the API is correct, and if the API is not correct, you fix the API so that the test is passing.
+
+Never ever fix any test to make a broken or incorrect API pass a bogus test. Never.
+
+If you encounter a severe bug that requires refactoring beyond the first level implementation, and you suspect a large blast radius of breaking changes, ask the user how to proceed.
+
 ## Code structure
 
 Each crate adheres to the following base structure

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ structures; DeepCausality contributes **dynamic, adaptive, and emergent** causal
 programmable deontic layer for verifiable safety. DeepCausality is hosted as a sandbox project at
 the [Linux Foundation for Data & AI](https://landscape.lfai.foundation/).
 
+## Support
+
+Dynamic causality can be daunting at first, and if you need more support for a larger or commercial project, please feel free to reach out to the [Center of Dynamic Causality](https://www.causalcenter.com/contact/) that backs the Deep Causality project.
+
 ## Getting Started
 
 ```bash

--- a/deep_causality/tests/extensions/causable/causable_arr_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_arr_tests.rs
@@ -78,3 +78,25 @@ fn test_to_vec() {
     let col = get_test_causality_array_bool_out();
     assert_eq!(10, col.to_vec().len());
 }
+
+#[test]
+fn test_is_empty_false() {
+    let col = get_test_causality_array_bool_out();
+    assert!(!col.is_empty());
+}
+
+#[test]
+fn test_is_empty_true() {
+    let col: [BaseCausaloid<NumericalValue, bool>; 0] = [];
+    assert!(col.is_empty());
+    assert_eq!(0, col.len());
+    assert_eq!(0, col.to_vec().len());
+    assert!(col.get_item_by_id(0).is_none());
+    assert_eq!(0, col.get_all_items().len());
+}
+
+#[test]
+fn test_get_item_by_id_none() {
+    let col = get_test_causality_array_bool_out();
+    assert!(col.get_item_by_id(9999).is_none());
+}

--- a/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_btree_map_tests.rs
@@ -130,3 +130,19 @@ fn test_to_vec() {
     let map = get_test_causality_btree_map_deterministic();
     assert_eq!(3, map.to_vec().len());
 }
+
+#[test]
+fn test_get_item_by_id_none() {
+    let map = get_test_causality_btree_map_deterministic();
+    assert!(map.get_item_by_id(9999).is_none());
+}
+
+#[test]
+fn test_empty_btree_map_accessors() {
+    let map: TestBTreeMap = BTreeMap::new();
+    assert!(map.is_empty());
+    assert_eq!(0, map.len());
+    assert_eq!(0, map.to_vec().len());
+    assert_eq!(0, map.get_all_items().len());
+    assert!(map.get_item_by_id(0).is_none());
+}

--- a/deep_causality/tests/extensions/causable/causable_map_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_map_tests.rs
@@ -161,3 +161,19 @@ fn test_to_vec() {
     let map = get_deterministic_test_causality_map();
     assert_eq!(3, map.to_vec().len());
 }
+
+#[test]
+fn test_get_item_by_id_none() {
+    let map = get_deterministic_test_causality_map();
+    assert!(map.get_item_by_id(9999).is_none());
+}
+
+#[test]
+fn test_empty_hash_map() {
+    let map: TestHashMap = HashMap::new();
+    assert!(map.is_empty());
+    assert_eq!(0, map.len());
+    assert_eq!(0, map.to_vec().len());
+    assert_eq!(0, map.get_all_items().len());
+    assert!(map.get_item_by_id(0).is_none());
+}

--- a/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_vec_deque_tests.rs
@@ -132,3 +132,20 @@ fn test_to_vec() {
         get_deterministic_test_causality_vec_deque();
     assert_eq!(3, col.to_vec().len());
 }
+
+#[test]
+fn test_get_item_by_id_none() {
+    let col: VecDeque<BaseCausaloid<NumericalValue, bool>> =
+        get_deterministic_test_causality_vec_deque();
+    assert!(col.get_item_by_id(9999).is_none());
+}
+
+#[test]
+fn test_empty_vec_deque() {
+    let col: VecDeque<BaseCausaloid<NumericalValue, bool>> = VecDeque::new();
+    assert!(col.is_empty());
+    assert_eq!(0, col.len());
+    assert_eq!(0, col.to_vec().len());
+    assert_eq!(0, col.get_all_items().len());
+    assert!(col.get_item_by_id(0).is_none());
+}

--- a/deep_causality_effects/Cargo.toml
+++ b/deep_causality_effects/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 readme = "README.md"
 description = "DEPRECATED. Retired crate; the name is effectively free for reuse. See README."
 repository = "https://github.com/deepcausality/deep_causality.rs"
-keywords = ["causality", "deprecated"]
+keywords = ["deprecated"]
 authors = ["Marvin Hansen <marvin.hansen@gmail.com>"]
 
 [dependencies]

--- a/deep_causality_num/tests/algebra/algebra_tests.rs
+++ b/deep_causality_num/tests/algebra/algebra_tests.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use deep_causality_num::{AddSemigroup, EuclideanDomain, MulSemigroup};
+use deep_causality_num::{AddSemigroup, Algebra, EuclideanDomain, Module, MulSemigroup};
 
 /// Test that semigroup traits are implemented for integers.
 #[test]
@@ -69,6 +69,94 @@ fn test_euclidean_fn() {
     assert_eq!(EuclideanDomain::euclidean_fn(&0i32), 0u32);
 
     assert_eq!(EuclideanDomain::euclidean_fn(&42u64), 42u64);
+}
+
+/// Exercise EuclideanDomain trait methods on every signed integer type.
+#[test]
+fn test_euclidean_signed_all_types() {
+    // i8
+    assert_eq!(EuclideanDomain::euclidean_fn(&-5i8), 5u8);
+    assert_eq!(EuclideanDomain::div_euclid(&17i8, &5i8), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17i8, &5i8), 2);
+    assert_eq!(EuclideanDomain::gcd(&12i8, &8i8), 4);
+    assert_eq!(EuclideanDomain::lcm(&4i8, &6i8), 12);
+
+    // i16
+    assert_eq!(EuclideanDomain::euclidean_fn(&-5i16), 5u16);
+    assert_eq!(EuclideanDomain::div_euclid(&17i16, &5i16), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17i16, &5i16), 2);
+    assert_eq!(EuclideanDomain::gcd(&12i16, &8i16), 4);
+    assert_eq!(EuclideanDomain::lcm(&4i16, &6i16), 12);
+
+    // i64
+    assert_eq!(EuclideanDomain::euclidean_fn(&-5i64), 5u64);
+    assert_eq!(EuclideanDomain::div_euclid(&17i64, &5i64), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17i64, &5i64), 2);
+    assert_eq!(EuclideanDomain::gcd(&12i64, &8i64), 4);
+    assert_eq!(EuclideanDomain::lcm(&4i64, &6i64), 12);
+
+    // i128
+    assert_eq!(EuclideanDomain::euclidean_fn(&-5i128), 5u128);
+    assert_eq!(EuclideanDomain::div_euclid(&17i128, &5i128), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17i128, &5i128), 2);
+    assert_eq!(EuclideanDomain::gcd(&12i128, &8i128), 4);
+    assert_eq!(EuclideanDomain::lcm(&4i128, &6i128), 12);
+
+    // isize
+    assert_eq!(EuclideanDomain::euclidean_fn(&-5isize), 5usize);
+    assert_eq!(EuclideanDomain::div_euclid(&17isize, &5isize), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17isize, &5isize), 2);
+    assert_eq!(EuclideanDomain::gcd(&12isize, &8isize), 4);
+    assert_eq!(EuclideanDomain::lcm(&4isize, &6isize), 12);
+}
+
+/// Exercise EuclideanDomain trait methods on every unsigned integer type.
+#[test]
+fn test_euclidean_unsigned_all_types() {
+    // u8
+    assert_eq!(EuclideanDomain::euclidean_fn(&5u8), 5u8);
+    assert_eq!(EuclideanDomain::div_euclid(&17u8, &5u8), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17u8, &5u8), 2);
+    assert_eq!(EuclideanDomain::gcd(&12u8, &8u8), 4);
+    assert_eq!(EuclideanDomain::lcm(&4u8, &6u8), 12);
+
+    // u16
+    assert_eq!(EuclideanDomain::euclidean_fn(&5u16), 5u16);
+    assert_eq!(EuclideanDomain::div_euclid(&17u16, &5u16), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17u16, &5u16), 2);
+    assert_eq!(EuclideanDomain::gcd(&12u16, &8u16), 4);
+    assert_eq!(EuclideanDomain::lcm(&4u16, &6u16), 12);
+
+    // u128
+    assert_eq!(EuclideanDomain::euclidean_fn(&5u128), 5u128);
+    assert_eq!(EuclideanDomain::div_euclid(&17u128, &5u128), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17u128, &5u128), 2);
+    assert_eq!(EuclideanDomain::gcd(&12u128, &8u128), 4);
+    assert_eq!(EuclideanDomain::lcm(&4u128, &6u128), 12);
+
+    // usize
+    assert_eq!(EuclideanDomain::euclidean_fn(&5usize), 5usize);
+    assert_eq!(EuclideanDomain::div_euclid(&17usize, &5usize), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17usize, &5usize), 2);
+    assert_eq!(EuclideanDomain::gcd(&12usize, &8usize), 4);
+    assert_eq!(EuclideanDomain::lcm(&4usize, &6usize), 12);
+}
+
+/// Cover the Module::scale and Module::scale_mut blanket-impl helpers.
+#[test]
+fn test_module_scale_helpers() {
+    let mut x: f64 = 3.0;
+    let scaled = <f64 as Module<f64>>::scale(&x, 4.0);
+    assert_eq!(scaled, 12.0);
+    <f64 as Module<f64>>::scale_mut(&mut x, 2.0);
+    assert_eq!(x, 6.0);
+}
+
+/// Cover the Algebra::sqr default helper.
+#[test]
+fn test_algebra_sqr() {
+    let x: f64 = 5.0;
+    assert_eq!(<f64 as Algebra<f64>>::sqr(&x), 25.0);
 }
 
 /// Test GCD properties.

--- a/deep_causality_num/tests/algebra/domain_euclidean_tests.rs
+++ b/deep_causality_num/tests/algebra/domain_euclidean_tests.rs
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use deep_causality_num::EuclideanDomain;
+
+// ---------- Signed integer impls ----------
+
+#[test]
+fn test_i8_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&-7i8), 7u8);
+    assert_eq!(EuclideanDomain::euclidean_fn(&7i8), 7u8);
+    assert_eq!(EuclideanDomain::div_euclid(&17i8, &5), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&-17i8, &5), 3);
+    assert_eq!(EuclideanDomain::gcd(&12i8, &8), 4);
+    assert_eq!(EuclideanDomain::lcm(&4i8, &6), 12);
+}
+
+#[test]
+fn test_i16_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&-123i16), 123u16);
+    assert_eq!(EuclideanDomain::div_euclid(&1000i16, &7), 142);
+    assert_eq!(EuclideanDomain::rem_euclid(&-1000i16, &7), 1);
+    assert_eq!(EuclideanDomain::gcd(&100i16, &75), 25);
+    assert_eq!(EuclideanDomain::lcm(&6i16, &9), 18);
+}
+
+#[test]
+fn test_i64_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&-1_000_000i64), 1_000_000u64);
+    assert_eq!(EuclideanDomain::div_euclid(&100i64, &7), 14);
+    assert_eq!(EuclideanDomain::rem_euclid(&-100i64, &7), 5);
+    assert_eq!(EuclideanDomain::gcd(&252i64, &105), 21);
+    assert_eq!(EuclideanDomain::lcm(&21i64, &6), 42);
+}
+
+#[test]
+fn test_i128_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&-42i128), 42u128);
+    assert_eq!(EuclideanDomain::div_euclid(&100i128, &7), 14);
+    assert_eq!(EuclideanDomain::rem_euclid(&-100i128, &7), 5);
+    assert_eq!(EuclideanDomain::gcd(&252i128, &105), 21);
+    assert_eq!(EuclideanDomain::lcm(&5i128, &7), 35);
+}
+
+#[test]
+fn test_isize_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&-9isize), 9usize);
+    assert_eq!(EuclideanDomain::div_euclid(&20isize, &6), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&-20isize, &6), 4);
+    assert_eq!(EuclideanDomain::gcd(&54isize, &24), 6);
+    assert_eq!(EuclideanDomain::lcm(&4isize, &10), 20);
+}
+
+// ---------- Unsigned integer impls ----------
+
+#[test]
+fn test_u8_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&7u8), 7u8);
+    assert_eq!(EuclideanDomain::div_euclid(&17u8, &5), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&17u8, &5), 2);
+    assert_eq!(EuclideanDomain::gcd(&12u8, &8), 4);
+    assert_eq!(EuclideanDomain::lcm(&4u8, &6), 12);
+}
+
+#[test]
+fn test_u16_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&500u16), 500u16);
+    assert_eq!(EuclideanDomain::div_euclid(&1000u16, &7), 142);
+    assert_eq!(EuclideanDomain::rem_euclid(&1000u16, &7), 6);
+    assert_eq!(EuclideanDomain::gcd(&100u16, &75), 25);
+    assert_eq!(EuclideanDomain::lcm(&6u16, &9), 18);
+}
+
+#[test]
+fn test_u128_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&42u128), 42u128);
+    assert_eq!(EuclideanDomain::div_euclid(&100u128, &7), 14);
+    assert_eq!(EuclideanDomain::rem_euclid(&100u128, &7), 2);
+    assert_eq!(EuclideanDomain::gcd(&252u128, &105), 21);
+    assert_eq!(EuclideanDomain::lcm(&5u128, &7), 35);
+}
+
+#[test]
+fn test_usize_euclidean() {
+    assert_eq!(EuclideanDomain::euclidean_fn(&9usize), 9usize);
+    assert_eq!(EuclideanDomain::div_euclid(&20usize, &6), 3);
+    assert_eq!(EuclideanDomain::rem_euclid(&20usize, &6), 2);
+    assert_eq!(EuclideanDomain::gcd(&54usize, &24), 6);
+    assert_eq!(EuclideanDomain::lcm(&4usize, &10), 20);
+}
+
+// ---------- gcd/lcm edge cases ----------
+
+#[test]
+fn test_gcd_self_and_zero_unsigned() {
+    // gcd(a, 0) = a
+    assert_eq!(EuclideanDomain::gcd(&15u32, &0u32), 15);
+    // gcd(0, b) = b
+    assert_eq!(EuclideanDomain::gcd(&0u32, &21u32), 21);
+    // gcd(a, a) = a
+    assert_eq!(EuclideanDomain::gcd(&13u64, &13u64), 13);
+}
+
+#[test]
+fn test_lcm_both_zero_branches() {
+    // Both inputs zero -> zero (covers the early-return is_zero branch).
+    assert_eq!(EuclideanDomain::lcm(&0i64, &0i64), 0);
+    // One side zero on unsigned
+    assert_eq!(EuclideanDomain::lcm(&0u16, &5u16), 0);
+    assert_eq!(EuclideanDomain::lcm(&5u16, &0u16), 0);
+}

--- a/deep_causality_num/tests/algebra/field_real_f32_tests.rs
+++ b/deep_causality_num/tests/algebra/field_real_f32_tests.rs
@@ -116,6 +116,16 @@ fn test_division_algebra_f32() {
 }
 
 #[test]
+fn test_is_nan_inf_finite_traits() {
+    assert!(<f32 as RealField>::is_nan(f32::NAN));
+    assert!(!<f32 as RealField>::is_nan(1.0));
+    assert!(<f32 as RealField>::is_infinite(f32::INFINITY));
+    assert!(!<f32 as RealField>::is_infinite(1.0));
+    assert!(<f32 as RealField>::is_finite(1.0));
+    assert!(!<f32 as RealField>::is_finite(f32::INFINITY));
+}
+
+#[test]
 fn test_constants() {
     let f: f32 = RealField::pi();
     assert_eq!(f, core::f32::consts::PI);

--- a/deep_causality_num/tests/algebra/field_real_f64_tests.rs
+++ b/deep_causality_num/tests/algebra/field_real_f64_tests.rs
@@ -121,6 +121,16 @@ fn test_division_algebra_f64() {
 }
 
 #[test]
+fn test_is_nan_inf_finite_traits() {
+    assert!(<f64 as RealField>::is_nan(f64::NAN));
+    assert!(!<f64 as RealField>::is_nan(1.0));
+    assert!(<f64 as RealField>::is_infinite(f64::INFINITY));
+    assert!(!<f64 as RealField>::is_infinite(1.0));
+    assert!(<f64 as RealField>::is_finite(1.0));
+    assert!(!<f64 as RealField>::is_finite(f64::INFINITY));
+}
+
+#[test]
 fn test_constants() {
     let f: f64 = RealField::pi();
     assert_eq!(f, core::f64::consts::PI);

--- a/deep_causality_num/tests/algebra/mod.rs
+++ b/deep_causality_num/tests/algebra/mod.rs
@@ -5,6 +5,8 @@
 #[cfg(test)]
 mod algebra_tests;
 #[cfg(test)]
+mod domain_euclidean_tests;
+#[cfg(test)]
 mod field_real_f32_tests;
 #[cfg(test)]
 mod field_real_f64_tests;

--- a/deep_causality_num/tests/complex/quaternion_number/arithmetic_assign_tests.rs
+++ b/deep_causality_num/tests/complex/quaternion_number/arithmetic_assign_tests.rs
@@ -51,3 +51,17 @@ fn test_div_assign() {
     let expected_k = Quaternion::new(0.0, 0.0, 0.0, 1.0);
     assert_eq!(q, expected_k);
 }
+
+#[test]
+fn test_mul_assign_scalar() {
+    let mut q = Quaternion::new(1.0, 2.0, 3.0, 4.0);
+    q *= 2.0_f64;
+    assert_eq!(q, Quaternion::new(2.0, 4.0, 6.0, 8.0));
+}
+
+#[test]
+fn test_div_scalar() {
+    let q = Quaternion::new(2.0, 4.0, 6.0, 8.0);
+    let r = q / 2.0_f64;
+    assert_eq!(r, Quaternion::new(1.0, 2.0, 3.0, 4.0));
+}

--- a/deep_causality_num/tests/float_double/double_algebra_tests.rs
+++ b/deep_causality_num/tests/float_double/double_algebra_tests.rs
@@ -269,7 +269,9 @@ fn test_divisionalgebra_inverse_identity() {
 
 #[test]
 fn test_realfield_is_nan() {
-    assert!(<Float106 as RealField>::is_nan(<Float106 as RealField>::nan()));
+    assert!(<Float106 as RealField>::is_nan(
+        <Float106 as RealField>::nan()
+    ));
     assert!(!<Float106 as RealField>::is_nan(Float106::from_f64(1.0)));
 }
 
@@ -277,7 +279,9 @@ fn test_realfield_is_nan() {
 fn test_realfield_is_infinite() {
     let inf: Float106 = <Float106 as deep_causality_num::Float>::infinity();
     assert!(<Float106 as RealField>::is_infinite(inf));
-    assert!(!<Float106 as RealField>::is_infinite(Float106::from_f64(1.0)));
+    assert!(!<Float106 as RealField>::is_infinite(Float106::from_f64(
+        1.0
+    )));
 }
 
 #[test]
@@ -286,4 +290,3 @@ fn test_realfield_is_finite() {
     let inf: Float106 = <Float106 as deep_causality_num::Float>::infinity();
     assert!(!<Float106 as RealField>::is_finite(inf));
 }
-

--- a/deep_causality_num/tests/float_double/double_algebra_tests.rs
+++ b/deep_causality_num/tests/float_double/double_algebra_tests.rs
@@ -262,3 +262,28 @@ fn test_divisionalgebra_inverse_identity() {
     let product = x * inv;
     assert!((product.hi() - 1.0).abs() < EPSILON);
 }
+
+// =============================================================================
+// RealField classification traits
+// =============================================================================
+
+#[test]
+fn test_realfield_is_nan() {
+    assert!(<Float106 as RealField>::is_nan(<Float106 as RealField>::nan()));
+    assert!(!<Float106 as RealField>::is_nan(Float106::from_f64(1.0)));
+}
+
+#[test]
+fn test_realfield_is_infinite() {
+    let inf: Float106 = <Float106 as deep_causality_num::Float>::infinity();
+    assert!(<Float106 as RealField>::is_infinite(inf));
+    assert!(!<Float106 as RealField>::is_infinite(Float106::from_f64(1.0)));
+}
+
+#[test]
+fn test_realfield_is_finite() {
+    assert!(<Float106 as RealField>::is_finite(Float106::from_f64(1.0)));
+    let inf: Float106 = <Float106 as deep_causality_num::Float>::infinity();
+    assert!(!<Float106 as RealField>::is_finite(inf));
+}
+

--- a/deep_causality_num/tests/float_double/double_arithmetic_tests.rs
+++ b/deep_causality_num/tests/float_double/double_arithmetic_tests.rs
@@ -253,3 +253,87 @@ fn test_add_owned_ref() {
     let result = a + &b;
     assert!((result.hi() - 5.0).abs() < EPSILON);
 }
+
+// =============================================================================
+// Additional Reference Ops Coverage
+// =============================================================================
+
+#[test]
+fn test_sub_ref_owned() {
+    let a = Float106::from_f64(5.0);
+    let b = Float106::from_f64(2.0);
+    let result = &a - b;
+    assert!((result.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_sub_owned_ref() {
+    let a = Float106::from_f64(5.0);
+    let b = Float106::from_f64(2.0);
+    let result = a - &b;
+    assert!((result.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_mul_ref_owned() {
+    let a = Float106::from_f64(3.0);
+    let b = Float106::from_f64(4.0);
+    let result = &a * b;
+    assert!((result.hi() - 12.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_mul_owned_ref() {
+    let a = Float106::from_f64(3.0);
+    let b = Float106::from_f64(4.0);
+    let result = a * &b;
+    assert!((result.hi() - 12.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_div_ref_owned() {
+    let a = Float106::from_f64(12.0);
+    let b = Float106::from_f64(4.0);
+    let result = &a / b;
+    assert!((result.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_div_owned_ref() {
+    let a = Float106::from_f64(12.0);
+    let b = Float106::from_f64(4.0);
+    let result = a / &b;
+    assert!((result.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_rem_ref_ref() {
+    let a = Float106::from_f64(7.0);
+    let b = Float106::from_f64(3.0);
+    let result = &a % &b;
+    assert!((result.hi() - 1.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_rem_ref_owned() {
+    let a = Float106::from_f64(7.0);
+    let b = Float106::from_f64(3.0);
+    let result = &a % b;
+    assert!((result.hi() - 1.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_rem_owned_ref() {
+    let a = Float106::from_f64(7.0);
+    let b = Float106::from_f64(3.0);
+    let result = a % &b;
+    assert!((result.hi() - 1.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_rem_f64_lhs() {
+    let a = 7.0_f64;
+    let b = Float106::from_f64(3.0);
+    let result = a % b;
+    assert!((result.hi() - 1.0).abs() < EPSILON);
+}

--- a/deep_causality_num/tests/float_double/double_float_tests.rs
+++ b/deep_causality_num/tests/float_double/double_float_tests.rs
@@ -389,3 +389,381 @@ fn test_clamp_via_float() {
     let result = Float::clamp(x, min, max);
     assert!((result.hi() - 10.0).abs() < EPSILON);
 }
+
+// =============================================================================
+// Edge Case / Branch Coverage
+// =============================================================================
+
+#[test]
+fn test_clamp_below_min() {
+    let x = Float106::from_f64(-5.0);
+    let min = Float106::from_f64(0.0);
+    let max = Float106::from_f64(10.0);
+    let result = Float::clamp(x, min, max);
+    assert!((result.hi() - 0.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_clamp_in_range() {
+    let x = Float106::from_f64(3.0);
+    let min = Float106::from_f64(0.0);
+    let max = Float106::from_f64(10.0);
+    let result = Float::clamp(x, min, max);
+    assert!((result.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_signum_nan() {
+    let x = <Float106 as Float>::nan();
+    assert!(Float::signum(x).is_nan());
+}
+
+#[test]
+fn test_signum_neg_zero_lo() {
+    // hi == 0 && lo < 0 path
+    let x = Float106::new(0.0, -1.0e-30);
+    assert!((Float::signum(x).hi() - (-1.0)).abs() < EPSILON);
+}
+
+#[test]
+fn test_abs_neg_zero_lo() {
+    // hi == 0 && lo < 0 → negate path
+    let x = Float106::new(0.0, -1.0e-30);
+    let r = Float::abs(x);
+    assert!(r.lo() >= 0.0);
+}
+
+#[test]
+fn test_powf_zero_positive_exponent() {
+    let x = Float106::from_f64(0.0);
+    let n = Float106::from_f64(2.0);
+    assert_eq!(Float::powf(x, n).hi(), 0.0);
+}
+
+#[test]
+fn test_powf_zero_nonpositive_exponent() {
+    let x = Float106::from_f64(0.0);
+    let n = Float106::from_f64(-1.0);
+    assert!(Float::powf(x, n).is_infinite());
+}
+
+#[test]
+fn test_powf_negative_base_nan() {
+    let x = Float106::from_f64(-2.0);
+    let n = Float106::from_f64(0.5);
+    assert!(Float::powf(x, n).is_nan());
+}
+
+#[test]
+fn test_sqrt_negative_nan() {
+    let x = Float106::from_f64(-1.0);
+    assert!(Float::sqrt(x).is_nan());
+}
+
+#[test]
+fn test_sqrt_zero() {
+    let x = Float106::from_f64(0.0);
+    assert_eq!(Float::sqrt(x).hi(), 0.0);
+}
+
+#[test]
+fn test_exp_nan() {
+    let x = <Float106 as Float>::nan();
+    assert!(Float::exp(x).is_nan());
+}
+
+#[test]
+fn test_exp_overflow_to_infinity() {
+    let x = Float106::from_f64(1000.0);
+    assert!(Float::exp(x).is_infinite());
+}
+
+#[test]
+fn test_exp_underflow_to_zero() {
+    let x = Float106::from_f64(-1000.0);
+    assert_eq!(Float::exp(x).hi(), 0.0);
+}
+
+#[test]
+fn test_ln_zero_returns_neg_infinity() {
+    let x = Float106::from_f64(0.0);
+    let r = Float::ln(x);
+    assert!(r.is_infinite() && Float::is_sign_negative(r));
+}
+
+#[test]
+fn test_ln_negative_nan() {
+    let x = Float106::from_f64(-1.0);
+    assert!(Float::ln(x).is_nan());
+}
+
+#[test]
+fn test_max_nan_first() {
+    let nan = <Float106 as Float>::nan();
+    let y = Float106::from_f64(2.0);
+    assert!((Float::max(nan, y).hi() - 2.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_max_nan_second() {
+    let x = Float106::from_f64(2.0);
+    let nan = <Float106 as Float>::nan();
+    assert!((Float::max(x, nan).hi() - 2.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_min_nan_first() {
+    let nan = <Float106 as Float>::nan();
+    let y = Float106::from_f64(2.0);
+    assert!((Float::min(nan, y).hi() - 2.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_min_nan_second() {
+    let x = Float106::from_f64(2.0);
+    let nan = <Float106 as Float>::nan();
+    assert!((Float::min(x, nan).hi() - 2.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_atan_one_special() {
+    let x = Float106::from_f64(1.0);
+    let r = Float::atan(x);
+    assert!((r.hi() - core::f64::consts::FRAC_PI_4).abs() < 1e-14);
+}
+
+#[test]
+fn test_atan_neg_one_special() {
+    let x = Float106::from_f64(-1.0);
+    let r = Float::atan(x);
+    assert!((r.hi() - (-core::f64::consts::FRAC_PI_4)).abs() < 1e-14);
+}
+
+#[test]
+fn test_atan2_zero_zero_nan() {
+    let z = Float106::from_f64(0.0);
+    let r = Float::atan2(z, z);
+    assert!(r.is_nan());
+}
+
+#[test]
+fn test_atan2_positive_y_zero_x() {
+    let y = Float106::from_f64(1.0);
+    let x = Float106::from_f64(0.0);
+    let r = Float::atan2(y, x);
+    assert!((r.hi() - core::f64::consts::FRAC_PI_2).abs() < 1e-14);
+}
+
+#[test]
+fn test_atan2_negative_y_zero_x() {
+    let y = Float106::from_f64(-1.0);
+    let x = Float106::from_f64(0.0);
+    let r = Float::atan2(y, x);
+    assert!((r.hi() - (-core::f64::consts::FRAC_PI_2)).abs() < 1e-14);
+}
+
+#[test]
+fn test_atan2_negative_x_positive_y() {
+    let y = Float106::from_f64(1.0);
+    let x = Float106::from_f64(-1.0);
+    let r = Float::atan2(y, x);
+    assert!((r.hi() - (3.0 * core::f64::consts::FRAC_PI_4)).abs() < 1e-10);
+}
+
+#[test]
+fn test_atan2_negative_x_negative_y() {
+    let y = Float106::from_f64(-1.0);
+    let x = Float106::from_f64(-1.0);
+    let r = Float::atan2(y, x);
+    assert!((r.hi() - (-3.0 * core::f64::consts::FRAC_PI_4)).abs() < 1e-10);
+}
+
+#[test]
+fn test_asin_one() {
+    let x = Float106::from_f64(1.0);
+    let r = Float::asin(x);
+    assert!((r.hi() - core::f64::consts::FRAC_PI_2).abs() < 1e-14);
+}
+
+#[test]
+fn test_asin_neg_one() {
+    let x = Float106::from_f64(-1.0);
+    let r = Float::asin(x);
+    assert!((r.hi() - (-core::f64::consts::FRAC_PI_2)).abs() < 1e-14);
+}
+
+#[test]
+fn test_asin_out_of_range_nan() {
+    let x = Float106::from_f64(2.0);
+    assert!(Float::asin(x).is_nan());
+}
+
+#[test]
+fn test_acos_out_of_range_nan() {
+    let x = Float106::from_f64(2.0);
+    assert!(Float::acos(x).is_nan());
+}
+
+#[test]
+fn test_acosh_below_one_nan() {
+    let x = Float106::from_f64(0.5);
+    assert!(Float::acosh(x).is_nan());
+}
+
+#[test]
+fn test_atanh_one_infinity() {
+    let x = Float106::from_f64(1.0);
+    assert!(Float::atanh(x).is_infinite());
+}
+
+#[test]
+fn test_atanh_neg_one_neg_infinity() {
+    let x = Float106::from_f64(-1.0);
+    let r = Float::atanh(x);
+    assert!(r.is_infinite() && Float::is_sign_negative(r));
+}
+
+#[test]
+fn test_atanh_out_of_range_nan() {
+    let x = Float106::from_f64(2.0);
+    assert!(Float::atanh(x).is_nan());
+}
+
+#[test]
+fn test_sinh_basic() {
+    let x = Float106::from_f64(1.0);
+    assert!((Float::sinh(x).hi() - 1.0_f64.sinh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_cosh_basic() {
+    let x = Float106::from_f64(1.0);
+    assert!((Float::cosh(x).hi() - 1.0_f64.cosh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_tanh_basic() {
+    let x = Float106::from_f64(0.5);
+    assert!((Float::tanh(x).hi() - 0.5_f64.tanh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_asinh_basic() {
+    let x = Float106::from_f64(0.5);
+    assert!((Float::asinh(x).hi() - 0.5_f64.asinh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_acosh_basic() {
+    let x = Float106::from_f64(2.0);
+    assert!((Float::acosh(x).hi() - 2.0_f64.acosh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_atanh_basic() {
+    let x = Float106::from_f64(0.5);
+    assert!((Float::atanh(x).hi() - 0.5_f64.atanh()).abs() < 1e-10);
+}
+
+#[test]
+fn test_sin_cos_basic() {
+    let x = Float106::from_f64(0.5);
+    let (s, c) = Float::sin_cos(x);
+    assert!((s.hi() - 0.5_f64.sin()).abs() < 1e-12);
+    assert!((c.hi() - 0.5_f64.cos()).abs() < 1e-12);
+}
+
+#[test]
+fn test_exp_m1_small() {
+    let x = Float106::from_f64(0.1);
+    assert!((Float::exp_m1(x).hi() - 0.1_f64.exp_m1()).abs() < 1e-12);
+}
+
+#[test]
+fn test_exp_m1_large() {
+    let x = Float106::from_f64(2.0);
+    assert!((Float::exp_m1(x).hi() - 2.0_f64.exp_m1()).abs() < 1e-10);
+}
+
+#[test]
+fn test_ln_1p_small() {
+    let x = Float106::from_f64(0.1);
+    assert!((Float::ln_1p(x).hi() - 0.1_f64.ln_1p()).abs() < 1e-12);
+}
+
+#[test]
+fn test_ln_1p_large() {
+    let x = Float106::from_f64(2.0);
+    assert!((Float::ln_1p(x).hi() - 2.0_f64.ln_1p()).abs() < 1e-10);
+}
+
+#[test]
+fn test_tan_basic() {
+    let x = Float106::from_f64(0.5);
+    assert!((Float::tan(x).hi() - 0.5_f64.tan()).abs() < 1e-12);
+}
+
+#[test]
+fn test_to_degrees() {
+    let x = Float106::from_f64(core::f64::consts::PI);
+    assert!((Float::to_degrees(x).hi() - 180.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_to_radians() {
+    let x = Float106::from_f64(180.0);
+    assert!((Float::to_radians(x).hi() - core::f64::consts::PI).abs() < 1e-10);
+}
+
+#[test]
+fn test_copysign_positive_sign() {
+    let x = Float106::from_f64(-3.0);
+    let s = Float106::from_f64(2.0);
+    assert!((Float::copysign(x, s).hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_copysign_negative_sign() {
+    let x = Float106::from_f64(3.0);
+    let s = Float106::from_f64(-2.0);
+    assert!((Float::copysign(x, s).hi() - (-3.0)).abs() < EPSILON);
+}
+
+#[test]
+fn test_integer_decode() {
+    let x = Float106::from_f64(42.0);
+    let (m, e, s) = Float::integer_decode(x);
+    let (m_ref, e_ref, s_ref) = 42.0_f64.integer_decode();
+    assert_eq!(m, m_ref);
+    assert_eq!(e, e_ref);
+    assert_eq!(s, s_ref);
+}
+
+#[test]
+fn test_floor_integer_input() {
+    // Triggers the hi_floor == hi branch
+    let x = Float106::new(3.0, 0.7);
+    let r = Float::floor(x);
+    assert!((r.hi() - 3.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_ceil_integer_input() {
+    let x = Float106::new(3.0, 0.3);
+    let r = Float::ceil(x);
+    assert!((r.hi() - 4.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_round_integer_input() {
+    let x = Float106::new(3.0, 0.6);
+    let r = Float::round(x);
+    assert!((r.hi() - 4.0).abs() < EPSILON);
+}
+
+#[test]
+fn test_trunc_integer_input() {
+    let x = Float106::new(3.0, 0.8);
+    let r = Float::trunc(x);
+    assert!((r.hi() - 3.0).abs() < EPSILON);
+}

--- a/deep_causality_physics/src/theories/general_relativity/gr_ops_impl.rs
+++ b/deep_causality_physics/src/theories/general_relativity/gr_ops_impl.rs
@@ -27,14 +27,17 @@ where
     S: Field + Float + Clone + From<f64> + Into<f64> + Copy + deep_causality_num::RealField,
 {
     fn ricci_tensor(&self) -> Result<CausalTensor<S>, PhysicsError> {
-        let riemann = self.field_strength();
+        let lie_fs = self.field_strength();
         let dim = 4;
 
         // Use East Coast metric type info (structure only)
         let metric_sig = EastCoastMetric::minkowski_4d().into_metric();
 
+        // Expand Lie-algebra storage [points, 4, 4, 6] to geometric [4, 4, 4, 4]
+        let riemann = expand_lie_to_riemann(lie_fs)?;
+
         let ct = CurvatureTensor::<S, (), (), (), ()>::new(
-            riemann.clone(),
+            riemann,
             metric_sig,
             CurvatureSymmetry::Riemann,
             dim,
@@ -73,12 +76,15 @@ where
 
     fn einstein_tensor(&self) -> Result<CausalTensor<S>, PhysicsError> {
         // Use CurvatureTensor from topology for the Einstein tensor calculation
-        let riemann = self.field_strength();
+        let lie_fs = self.field_strength();
         let dim = 4;
         let metric_sig = EastCoastMetric::minkowski_4d().into_metric();
 
+        // Expand Lie-algebra storage [points, 4, 4, 6] to geometric [4, 4, 4, 4]
+        let riemann = expand_lie_to_riemann(lie_fs)?;
+
         let ct = CurvatureTensor::<S, (), (), (), ()>::new(
-            riemann.clone(),
+            riemann,
             metric_sig,
             CurvatureSymmetry::Riemann,
             dim,

--- a/deep_causality_physics/tests/kernels/em/fields_tests.rs
+++ b/deep_causality_physics/tests/kernels/em/fields_tests.rs
@@ -348,6 +348,51 @@ fn test_lagrangian_density_kernel_magnetic_dominated() {
 }
 
 #[test]
+fn test_poynting_vector_kernel_nan_b_error() {
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, f64::NAN, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(poynting_vector_kernel(&e, &b).is_err());
+}
+
+#[test]
+fn test_energy_density_kernel_nan_b_error() {
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, f64::NAN, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(energy_density_kernel(&e, &b).is_err());
+}
+
+#[test]
+fn test_lagrangian_density_kernel_nan_b_error() {
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, f64::NAN, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(lagrangian_density_kernel(&e, &b).is_err());
+}
+
+#[test]
 fn test_lagrangian_density_kernel_dimension_mismatch() {
     let e = CausalMultiVector::<f64>::new(
         vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],

--- a/deep_causality_physics/tests/kernels/mhd/grmhd_tests.rs
+++ b/deep_causality_physics/tests/kernels/mhd/grmhd_tests.rs
@@ -93,6 +93,42 @@ fn test_energy_momentum_tensor() {
 }
 
 #[test]
+fn test_relativistic_current_kernel_low_dim_metric_error() {
+    // Build a valid 4D manifold but pass a metric with dimension < 4
+    let points_data = vec![
+        0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0,
+    ];
+    let point_tensor = CausalTensor::new(points_data, vec![5, 4]).unwrap();
+    let cloud = PointCloud::new(point_tensor, CausalTensor::<f64>::zeros(&[5]), 0).unwrap();
+    let complex = cloud.triangulate(1.5).unwrap();
+    let total = complex.total_simplices();
+    let manifold =
+        Manifold::new(complex, CausalTensor::new(vec![0.0; total], vec![total]).unwrap(), 0)
+            .unwrap();
+
+    let metric_3d = EastCoastMetric::new_nd(3).unwrap();
+    let r = relativistic_current_kernel(&manifold, &metric_3d);
+    assert!(r.is_err());
+}
+
+#[test]
+fn test_relativistic_current_kernel_low_skeleton_error() {
+    // 1D point cloud → triangulation produces only 0- and 1-skeletons, no 2-simplices.
+    let points = CausalTensor::new(vec![0.0, 1.0, 2.0], vec![3, 1]).unwrap();
+    let cloud = PointCloud::new(points, CausalTensor::<f64>::zeros(&[3]), 0).unwrap();
+    let complex = cloud.triangulate(1.5).unwrap();
+    let total = complex.total_simplices();
+    let manifold =
+        Manifold::new(complex, CausalTensor::new(vec![0.0; total], vec![total]).unwrap(), 0)
+            .unwrap();
+
+    let metric = EastCoastMetric::minkowski_4d();
+    let r = relativistic_current_kernel(&manifold, &metric);
+    assert!(r.is_err(), "1D complex must fail for relativistic current");
+}
+
+#[test]
 fn test_energy_momentum_tensor_dimension_error() {
     let em = CausalTensor::new(vec![0.0; 4], vec![4]).unwrap();
     let metric = CausalTensor::new(vec![1.0; 4], vec![2, 2]).unwrap();

--- a/deep_causality_physics/tests/kernels/mhd/grmhd_tests.rs
+++ b/deep_causality_physics/tests/kernels/mhd/grmhd_tests.rs
@@ -103,9 +103,12 @@ fn test_relativistic_current_kernel_low_dim_metric_error() {
     let cloud = PointCloud::new(point_tensor, CausalTensor::<f64>::zeros(&[5]), 0).unwrap();
     let complex = cloud.triangulate(1.5).unwrap();
     let total = complex.total_simplices();
-    let manifold =
-        Manifold::new(complex, CausalTensor::new(vec![0.0; total], vec![total]).unwrap(), 0)
-            .unwrap();
+    let manifold = Manifold::new(
+        complex,
+        CausalTensor::new(vec![0.0; total], vec![total]).unwrap(),
+        0,
+    )
+    .unwrap();
 
     let metric_3d = EastCoastMetric::new_nd(3).unwrap();
     let r = relativistic_current_kernel(&manifold, &metric_3d);
@@ -119,9 +122,12 @@ fn test_relativistic_current_kernel_low_skeleton_error() {
     let cloud = PointCloud::new(points, CausalTensor::<f64>::zeros(&[3]), 0).unwrap();
     let complex = cloud.triangulate(1.5).unwrap();
     let total = complex.total_simplices();
-    let manifold =
-        Manifold::new(complex, CausalTensor::new(vec![0.0; total], vec![total]).unwrap(), 0)
-            .unwrap();
+    let manifold = Manifold::new(
+        complex,
+        CausalTensor::new(vec![0.0; total], vec![total]).unwrap(),
+        0,
+    )
+    .unwrap();
 
     let metric = EastCoastMetric::minkowski_4d();
     let r = relativistic_current_kernel(&manifold, &metric);

--- a/deep_causality_physics/tests/kernels/mhd/quantities_tests.rs
+++ b/deep_causality_physics/tests/kernels/mhd/quantities_tests.rs
@@ -240,6 +240,37 @@ fn test_diffusivity_new_nan_error() {
 // Trait coverage: Debug / Clone / Copy / PartialEq / PartialOrd
 // =============================================================================
 
+// =============================================================================
+// From<X> for f64 conversion coverage
+// =============================================================================
+
+#[test]
+fn test_mhd_scalars_into_f64() {
+    let v: f64 = AlfvenSpeed::<f64>::new(100.0).unwrap().into();
+    assert_eq!(v, 100.0);
+
+    let v: f64 = PlasmaBeta::<f64>::new(0.5).unwrap().into();
+    assert_eq!(v, 0.5);
+
+    let v: f64 = MagneticPressure::<f64>::new(1000.0).unwrap().into();
+    assert_eq!(v, 1000.0);
+
+    let v: f64 = LarmorRadius::<f64>::new(1.0).unwrap().into();
+    assert_eq!(v, 1.0);
+
+    let v: f64 = DebyeLength::<f64>::new(1e-6).unwrap().into();
+    assert_eq!(v, 1e-6);
+
+    let v: f64 = PlasmaFrequency::<f64>::new(1e9).unwrap().into();
+    assert_eq!(v, 1e9);
+
+    let v: f64 = Conductivity::<f64>::new(1e7).unwrap().into();
+    assert_eq!(v, 1e7);
+
+    let v: f64 = Diffusivity::<f64>::new(1.0).unwrap().into();
+    assert_eq!(v, 1.0);
+}
+
 #[test]
 fn test_mhd_scalars_traits() {
     let a = AlfvenSpeed::<f64>::new(1.0).unwrap();

--- a/deep_causality_physics/tests/kernels/nuclear/qcd_tests.rs
+++ b/deep_causality_physics/tests/kernels/nuclear/qcd_tests.rs
@@ -134,6 +134,28 @@ fn test_covariant_derivative_pure_gauge() {
 }
 
 #[test]
+fn test_covariant_derivative_gauge_term_active() {
+    // Non-zero gluon field along λ_3 (diagonal: diag(1,-1,0)) acts on a real psi.
+    // Verifies the gauge correction branch is exercised and produces finite output.
+    let psi = vec![1.0, 0.0, 0.5, 0.0, 0.0, 0.0]; // real color triplet
+    let psi_gradient = vec![0.0; 24];
+    let mut gluon_field = vec![0.0; 32];
+    // A_0^3 = 1.0 (mu=0, a=2 → 0*8+2)
+    gluon_field[2] = 1.0;
+    let coupling = 1.0;
+
+    let r = covariant_derivative_kernel(&psi, &psi_gradient, &gluon_field, coupling).unwrap();
+
+    // T^3 = λ_3/2 = diag(0.5, -0.5, 0). i*g*A^3*T^3 * psi gives purely imaginary correction.
+    // mu=0, i=0 (color 0): Im += g*A*0.5*psi_re_0 = 0.5
+    assert!((r[1] - 0.5).abs() < 1e-12, "result[1]={}", r[1]);
+    // mu=0, i=1 (color 1): Im += g*A*(-0.5)*psi_re_1 = -0.25
+    assert!((r[3] + 0.25).abs() < 1e-12, "result[3]={}", r[3]);
+    // mu=0, i=2: λ_3[2,2]=0, no contribution
+    assert!(r[4].abs() < 1e-12 && r[5].abs() < 1e-12);
+}
+
+#[test]
 fn test_covariant_derivative_dimension_error_psi() {
     let psi = vec![1.0, 0.0]; // Wrong size
     let psi_gradient = vec![0.0; 24];
@@ -247,6 +269,18 @@ fn test_confinement_potential_with_coulomb() {
         expected,
         v
     );
+}
+
+#[test]
+fn test_confinement_potential_nan_string_tension_error() {
+    let r = confinement_potential_kernel(1.0, f64::NAN, None);
+    assert!(r.is_err());
+}
+
+#[test]
+fn test_confinement_potential_nan_coulomb_error() {
+    let r = confinement_potential_kernel(1.0, 0.18, Some(f64::NAN));
+    assert!(r.is_err());
 }
 
 #[test]

--- a/deep_causality_physics/tests/kernels/relativity/spacetime_tests.rs
+++ b/deep_causality_physics/tests/kernels/relativity/spacetime_tests.rs
@@ -375,6 +375,47 @@ fn test_proper_time_wrong_metric_rank() {
 }
 
 #[test]
+fn test_proper_time_non_square_metric_error() {
+    let path = vec![vec![0.0, 0.0], vec![1.0, 0.0]];
+    // Square check uses shape[1] != shape[0]. Build a [2, 3] rank-2 tensor.
+    let metric = CausalTensor::new(vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0], vec![2, 3]).unwrap();
+    let r = proper_time_kernel(&path, &metric);
+    assert!(r.is_err(), "Non-square metric must error");
+}
+
+#[test]
+fn test_proper_time_nan_segment_error() {
+    // A NaN coordinate yields a non-finite proper-time increment.
+    let path = vec![vec![0.0, 0.0], vec![f64::NAN, 0.0]];
+    let metric = CausalTensor::new(vec![-1.0, 0.0, 0.0, 1.0], vec![2, 2]).unwrap();
+    let r = proper_time_kernel(&path, &metric);
+    assert!(r.is_err(), "NaN in path must propagate as instability");
+}
+
+#[test]
+fn test_parallel_transport_nan_christoffel_error() {
+    let initial_vector = vec![1.0, 0.0];
+    let path = vec![vec![0.0, 0.0], vec![1.0, 0.0]];
+    // Non-finite Christoffel produces non-finite transported vector.
+    let mut data = vec![0.0; 8];
+    data[0] = f64::NAN;
+    let christoffel = CausalTensor::new(data, vec![2, 2, 2]).unwrap();
+    let r = parallel_transport_kernel(&initial_vector, &path, &christoffel);
+    assert!(r.is_err());
+}
+
+#[test]
+fn test_time_dilation_angle_gamma_clamp_near_one() {
+    // Identical vectors → gamma=1.0 exactly, exercises the clamp/sqrt(0) branch.
+    let mut data = vec![0.0; 16];
+    data[1] = 1.0;
+    let t = CausalMultiVector::new(data, Metric::Minkowski(4)).unwrap();
+    let eta = time_dilation_angle_kernel(&t, &t).unwrap();
+    let val: f64 = eta.value();
+    assert!(val.abs() < 1e-10, "Identical vectors give eta=0, got {}", val);
+}
+
+#[test]
 fn test_proper_time_dimension_mismatch() {
     let path = vec![vec![0.0, 0.0, 0.0], vec![1.0, 0.0, 0.0]]; // 3D
     let metric = CausalTensor::new(vec![1.0, 0.0, 0.0, 1.0], vec![2, 2]).unwrap(); // 2D

--- a/deep_causality_physics/tests/kernels/relativity/spacetime_tests.rs
+++ b/deep_causality_physics/tests/kernels/relativity/spacetime_tests.rs
@@ -412,7 +412,11 @@ fn test_time_dilation_angle_gamma_clamp_near_one() {
     let t = CausalMultiVector::new(data, Metric::Minkowski(4)).unwrap();
     let eta = time_dilation_angle_kernel(&t, &t).unwrap();
     let val: f64 = eta.value();
-    assert!(val.abs() < 1e-10, "Identical vectors give eta=0, got {}", val);
+    assert!(
+        val.abs() < 1e-10,
+        "Identical vectors give eta=0, got {}",
+        val
+    );
 }
 
 #[test]

--- a/deep_causality_physics/tests/theories/general_relativity/gr_ops_impl_tests.rs
+++ b/deep_causality_physics/tests/theories/general_relativity/gr_ops_impl_tests.rs
@@ -623,6 +623,161 @@ fn test_solve_geodesic_interface() {
     }
 }
 
+// ============================================================================
+// Direct coverage: ricci_tensor / ricci_scalar / einstein_tensor
+// ============================================================================
+
+fn build_flat_gr() -> GR<f64> {
+    let mut builder = SimplicialComplexBuilder::new(0);
+    builder.add_simplex(Simplex::new(vec![0])).unwrap();
+    let complex = builder.build().unwrap();
+
+    let num_simplices = complex.total_simplices();
+    let data = CausalTensor::zeros(&[num_simplices]);
+    let base = Manifold::new(complex, data, 0).unwrap();
+
+    // Minkowski metric padded to [N, 4, 6] with stride 6
+    let mut conn_data = vec![0.0; num_simplices * 4 * 6];
+    conn_data[0] = -1.0;
+    conn_data[7] = 1.0;
+    conn_data[14] = 1.0;
+    conn_data[21] = 1.0;
+    let connection = CausalTensor::from_vec(conn_data, &[num_simplices, 4, 6]);
+
+    let riemann = CausalTensor::zeros(&[num_simplices, 4, 4, 6]);
+    let topo_metric = EastCoastMetric::minkowski_4d().into_metric();
+    GaugeField::new(base, topo_metric, connection, riemann).unwrap()
+}
+
+#[test]
+fn test_ricci_tensor_flat() {
+    let gr = build_flat_gr();
+    let ricci = gr.ricci_tensor().unwrap();
+    assert_eq!(ricci.shape(), &[4, 4]);
+    for v in ricci.as_slice() {
+        assert!(v.abs() < 1e-12, "Ricci must be zero for flat: {}", v);
+    }
+}
+
+#[test]
+fn test_ricci_scalar_flat() {
+    let gr = build_flat_gr();
+    let r = gr.ricci_scalar().unwrap();
+    assert!(r.abs() < 1e-12, "Ricci scalar must be zero for flat: {}", r);
+}
+
+#[test]
+fn test_ricci_scalar_singular_metric_errors() {
+    // Zeroed connection ⇒ singular ⇒ invert_4x4 errors.
+    let mut builder = SimplicialComplexBuilder::new(0);
+    builder.add_simplex(Simplex::new(vec![0])).unwrap();
+    let complex = builder.build().unwrap();
+    let n = complex.total_simplices();
+    let data = CausalTensor::zeros(&[n]);
+    let base = Manifold::new(complex, data, 0).unwrap();
+    let connection = CausalTensor::from_vec(vec![0.0; n * 4 * 6], &[n, 4, 6]);
+    let riemann = CausalTensor::zeros(&[n, 4, 4, 6]);
+    let topo_metric = EastCoastMetric::minkowski_4d().into_metric();
+    let gr: GR<f64> = GaugeField::new(base, topo_metric, connection, riemann).unwrap();
+    assert!(gr.ricci_scalar().is_err());
+}
+
+#[test]
+fn test_einstein_tensor_flat() {
+    let gr = build_flat_gr();
+    let g = gr.einstein_tensor().unwrap();
+    assert_eq!(g.shape(), &[4, 4]);
+    for v in g.as_slice() {
+        assert!(v.abs() < 1e-12, "Einstein tensor must be zero for flat");
+    }
+}
+
+#[test]
+fn test_metric_tensor_accessor() {
+    let gr = build_flat_gr();
+    let m = gr.metric_tensor();
+    assert_eq!(m.shape(), &[1, 4, 6]);
+}
+
+// ============================================================================
+// momentum_constraint with matter momentum + 3-point neighbor branches
+// ============================================================================
+
+#[test]
+fn test_momentum_constraint_with_matter_momentum() {
+    let mut builder = SimplicialComplexBuilder::new(0);
+    builder.add_simplex(Simplex::new(vec![0])).unwrap();
+    builder.add_simplex(Simplex::new(vec![1])).unwrap();
+    builder.add_simplex(Simplex::new(vec![2])).unwrap();
+    let complex = builder.build().unwrap();
+
+    let n = complex.total_simplices();
+    let data = CausalTensor::zeros(&[n]);
+    let base = Manifold::new(complex, data, 0).unwrap();
+
+    // Spatial extraction uses idx = base + (i+1)*4 + (j+1) i.e. inner stride 4.
+    let mut conn_data = vec![0.0; n * 4 * 6];
+    for p in 0..n {
+        let b = p * 24;
+        conn_data[b] = -1.0;
+        conn_data[b + 5] = 1.0;
+        conn_data[b + 10] = 1.0;
+        conn_data[b + 15] = 1.0;
+    }
+    let connection = CausalTensor::from_vec(conn_data, &[n, 4, 6]);
+    let riemann = CausalTensor::zeros(&[n, 4, 4, 6]);
+    let topo_metric = EastCoastMetric::minkowski_4d().into_metric();
+    let gr: GR<f64> = GaugeField::new(base, topo_metric, connection, riemann).unwrap();
+
+    let k = CausalTensor::zeros(&[n, 3, 3]);
+    let j = CausalTensor::from_vec(
+        vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        &[n * 3],
+    );
+
+    let m = gr.momentum_constraint_field(&k, Some(&j)).unwrap();
+    assert_eq!(m.shape(), &[n, 3]);
+
+    // With K=0, divergence and connection terms vanish; result reduces to -8π j.
+    let eight_pi = 8.0 * std::f64::consts::PI;
+    let expected = [
+        -eight_pi, 0.0, 0.0, 0.0, -eight_pi, 0.0, 0.0, 0.0, -eight_pi,
+    ];
+    for (got, want) in m.as_slice().iter().zip(expected.iter()) {
+        assert!(
+            (got - want).abs() < 1e-9,
+            "matter momentum branch: got {}, want {}",
+            got,
+            want
+        );
+    }
+}
+
+#[test]
+fn test_momentum_constraint_singular_spatial_metric() {
+    // Provide a connection whose spatial 3-block is singular (all zeros)
+    // so that invert_3x3 inside momentum_constraint errors.
+    let mut builder = SimplicialComplexBuilder::new(0);
+    builder.add_simplex(Simplex::new(vec![0])).unwrap();
+    let complex = builder.build().unwrap();
+    let n = complex.total_simplices();
+    let data = CausalTensor::zeros(&[n]);
+    let base = Manifold::new(complex, data, 0).unwrap();
+
+    // Avoid stride=16 path: keep [N,4,6] with zero spatial block.
+    let connection = CausalTensor::from_vec(vec![0.0; n * 4 * 6], &[n, 4, 6]);
+    let riemann = CausalTensor::zeros(&[n, 4, 4, 6]);
+    let topo_metric = EastCoastMetric::minkowski_4d().into_metric();
+    let gr: GR<f64> = GaugeField::new(base, topo_metric, connection, riemann).unwrap();
+
+    let k = CausalTensor::zeros(&[3, 3]);
+    let result = gr.momentum_constraint_field(&k, None);
+    assert!(
+        result.is_err(),
+        "Singular spatial metric must propagate as error"
+    );
+}
+
 #[test]
 fn test_parallel_transport_interface() {
     let mut builder = SimplicialComplexBuilder::new(0);

--- a/deep_causality_physics/tests/theories/general_relativity/gr_ops_impl_tests.rs
+++ b/deep_causality_physics/tests/theories/general_relativity/gr_ops_impl_tests.rs
@@ -730,10 +730,7 @@ fn test_momentum_constraint_with_matter_momentum() {
     let gr: GR<f64> = GaugeField::new(base, topo_metric, connection, riemann).unwrap();
 
     let k = CausalTensor::zeros(&[n, 3, 3]);
-    let j = CausalTensor::from_vec(
-        vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        &[n * 3],
-    );
+    let j = CausalTensor::from_vec(vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], &[n * 3]);
 
     let m = gr.momentum_constraint_field(&k, Some(&j)).unwrap();
     assert_eq!(m.shape(), &[n, 3]);

--- a/deep_causality_sparse/tests/types/sparse_matrix/arithmetic_ops_tests.rs
+++ b/deep_causality_sparse/tests/types/sparse_matrix/arithmetic_ops_tests.rs
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use deep_causality_sparse::CsrMatrix;
+
+fn a() -> CsrMatrix<f64> {
+    CsrMatrix::from_triplets(2, 2, &[(0, 0, 1.0), (1, 1, 2.0)]).unwrap()
+}
+
+fn b() -> CsrMatrix<f64> {
+    CsrMatrix::from_triplets(2, 2, &[(0, 1, 3.0), (1, 0, 4.0)]).unwrap()
+}
+
+// ----- Add: 4 ownership variants -----
+
+#[test]
+fn test_add_owned_owned() {
+    let c = a() + b();
+    assert_eq!(c.get_value_at(0, 0), 1.0);
+    assert_eq!(c.get_value_at(0, 1), 3.0);
+    assert_eq!(c.get_value_at(1, 0), 4.0);
+    assert_eq!(c.get_value_at(1, 1), 2.0);
+}
+
+#[test]
+fn test_add_ref_ref() {
+    let x = a();
+    let y = b();
+    let c = &x + &y;
+    assert_eq!(c.get_value_at(0, 1), 3.0);
+    assert_eq!(c.shape(), (2, 2));
+}
+
+#[test]
+fn test_add_owned_ref() {
+    let y = b();
+    let c = a() + &y;
+    assert_eq!(c.get_value_at(1, 0), 4.0);
+}
+
+#[test]
+fn test_add_ref_owned() {
+    let x = a();
+    let c = &x + b();
+    assert_eq!(c.get_value_at(1, 1), 2.0);
+}
+
+// ----- AddAssign -----
+
+#[test]
+fn test_add_assign_owned() {
+    let mut x = a();
+    x += b();
+    assert_eq!(x.get_value_at(0, 1), 3.0);
+    assert_eq!(x.get_value_at(1, 0), 4.0);
+}
+
+#[test]
+fn test_add_assign_ref() {
+    let mut x = a();
+    let y = b();
+    x += &y;
+    assert_eq!(x.get_value_at(0, 1), 3.0);
+}
+
+// ----- Sub: 4 ownership variants -----
+
+#[test]
+fn test_sub_owned_owned() {
+    let c = a() - a();
+    assert!(c.values().is_empty());
+}
+
+#[test]
+fn test_sub_ref_ref() {
+    let x = a();
+    let y = b();
+    let c = &x - &y;
+    assert_eq!(c.get_value_at(0, 0), 1.0);
+    assert_eq!(c.get_value_at(0, 1), -3.0);
+    assert_eq!(c.get_value_at(1, 0), -4.0);
+    assert_eq!(c.get_value_at(1, 1), 2.0);
+}
+
+#[test]
+fn test_sub_owned_ref() {
+    let y = b();
+    let c = a() - &y;
+    assert_eq!(c.get_value_at(0, 1), -3.0);
+}
+
+#[test]
+fn test_sub_ref_owned() {
+    let x = a();
+    let c = &x - b();
+    assert_eq!(c.get_value_at(1, 0), -4.0);
+}
+
+// ----- SubAssign -----
+
+#[test]
+fn test_sub_assign_owned() {
+    let mut x = a();
+    x -= b();
+    assert_eq!(x.get_value_at(0, 1), -3.0);
+}
+
+#[test]
+fn test_sub_assign_ref() {
+    let mut x = a();
+    let y = b();
+    x -= &y;
+    assert_eq!(x.get_value_at(1, 0), -4.0);
+}
+
+// ----- Neg: 2 ownership variants -----
+
+#[test]
+fn test_neg_owned() {
+    let c = -a();
+    assert_eq!(c.get_value_at(0, 0), -1.0);
+    assert_eq!(c.get_value_at(1, 1), -2.0);
+}
+
+#[test]
+fn test_neg_ref() {
+    let x = a();
+    let c = -&x;
+    assert_eq!(c.get_value_at(0, 0), -1.0);
+    assert_eq!(c.get_value_at(1, 1), -2.0);
+}
+
+// ----- Matrix Mul: 4 ownership variants -----
+
+fn mm_a() -> CsrMatrix<f64> {
+    // 2x3
+    CsrMatrix::from_triplets(2, 3, &[(0, 0, 1.0), (0, 2, 2.0), (1, 1, 3.0)]).unwrap()
+}
+
+fn mm_b() -> CsrMatrix<f64> {
+    // 3x2
+    CsrMatrix::from_triplets(3, 2, &[(0, 0, 4.0), (1, 1, 5.0), (2, 0, 6.0)]).unwrap()
+}
+
+#[test]
+fn test_mul_owned_owned() {
+    let c = mm_a() * mm_b();
+    assert_eq!(c.get_value_at(0, 0), 16.0);
+    assert_eq!(c.get_value_at(1, 1), 15.0);
+    assert_eq!(c.shape(), (2, 2));
+}
+
+#[test]
+fn test_mul_ref_ref() {
+    let x = mm_a();
+    let y = mm_b();
+    let c = &x * &y;
+    assert_eq!(c.get_value_at(0, 0), 16.0);
+}
+
+#[test]
+fn test_mul_owned_ref() {
+    let y = mm_b();
+    let c = mm_a() * &y;
+    assert_eq!(c.get_value_at(1, 1), 15.0);
+}
+
+#[test]
+fn test_mul_ref_owned() {
+    let x = mm_a();
+    let c = &x * mm_b();
+    assert_eq!(c.get_value_at(0, 0), 16.0);
+}
+
+// ----- MulAssign -----
+
+#[test]
+fn test_mul_assign_owned() {
+    let mut x = mm_a();
+    x *= mm_b();
+    assert_eq!(x.get_value_at(0, 0), 16.0);
+    assert_eq!(x.shape(), (2, 2));
+}
+
+#[test]
+fn test_mul_assign_ref() {
+    let mut x = mm_a();
+    let y = mm_b();
+    x *= &y;
+    assert_eq!(x.get_value_at(1, 1), 15.0);
+}
+
+// ----- Scalar Mul -----
+
+#[test]
+fn test_scalar_mul_owned() {
+    let c = a() * 3.0f64;
+    assert_eq!(c.get_value_at(0, 0), 3.0);
+    assert_eq!(c.get_value_at(1, 1), 6.0);
+}
+
+#[test]
+fn test_scalar_mul_ref() {
+    let x = a();
+    let c = &x * 3.0f64;
+    assert_eq!(c.get_value_at(0, 0), 3.0);
+    assert_eq!(c.get_value_at(1, 1), 6.0);
+    // original unchanged
+    assert_eq!(x.get_value_at(0, 0), 1.0);
+}
+
+#[test]
+fn test_scalar_mul_assign() {
+    let mut x = a();
+    x *= 4.0f64;
+    assert_eq!(x.get_value_at(0, 0), 4.0);
+    assert_eq!(x.get_value_at(1, 1), 8.0);
+}

--- a/deep_causality_sparse/tests/types/sparse_matrix/mod.rs
+++ b/deep_causality_sparse/tests/types/sparse_matrix/mod.rs
@@ -5,6 +5,8 @@
 #[cfg(test)]
 mod algebra_tests;
 #[cfg(test)]
+mod arithmetic_ops_tests;
+#[cfg(test)]
 mod default_tests;
 #[cfg(test)]
 mod display_tests;

--- a/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
@@ -102,7 +102,11 @@ impl<const D: usize, R: RealField> CubicalReggeGeometry<D, R> {
         }
         let neighbors = complex.hinge_top_cube_neighbors(hinge_id);
         let n = neighbors.len();
-        if n == 4 {
+        // Interior hinges (n == 4) and out-of-range hinges (n == 0, neighbors is empty)
+        // both short-circuit to zero. The interior case is genuine flatness; the empty
+        // case matches the docstring's tolerant-degenerate contract and avoids returning
+        // a meaningless 2π for a hinge that doesn't exist.
+        if n == 4 || n == 0 {
             return R::zero();
         }
 

--- a/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Curvature, hinge enumeration, deficit angles, and the discrete Regge action for
+//! `CubicalReggeGeometry<D, R>` — Phases R2 and R3.
+//!
+//! Implementations of `dihedral_angle`, `deficit_angle`, and `regge_action` land here.
+//! See `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §3 and §4.

--- a/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
@@ -34,6 +34,7 @@
 //! See `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §3 and §4.
 
 use super::CubicalReggeGeometry;
+use crate::traits::neighborhood::CellId;
 use crate::types::lattice_complex::{LatticeCell, LatticeComplex};
 use deep_causality_num::RealField;
 
@@ -77,5 +78,73 @@ impl<const D: usize, R: RealField> CubicalReggeGeometry<D, R> {
 
         let two = R::one() + R::one();
         R::pi() / two
+    }
+
+    /// Deficit angle at a hinge: `2π − Σ dihedral_angle(c, h)` summed over incident top
+    /// cubes.
+    ///
+    /// Under the axis-aligned cubical assumption (see `dihedral_angle`), every dihedral
+    /// equals π/2, so deficit reduces to `(4 − n) · π/2` where `n` is the incident-top-cube
+    /// count. The implementation short-circuits the `n == 4` (interior / fully-surrounded)
+    /// case to return exact `R::zero()`, avoiding floating-point noise from `2π − 2π`.
+    /// For `n < 4` (boundary hinges on open lattices), the result is the intrinsic
+    /// boundary curvature: positive deficit at corners and edges where less material
+    /// surrounds the hinge.
+    ///
+    /// Returns `R::zero()` for `D < 2` (where (D−2)-hinges don't exist) and for
+    /// out-of-range `hinge_id` (a tolerant degenerate case rather than a panic).
+    ///
+    /// `timelike_axes` is ignored in this change set; the Lorentzian variant is deferred
+    /// to a follow-up.
+    pub fn deficit_angle(&self, complex: &LatticeComplex<D, R>, hinge_id: CellId) -> R {
+        if D < 2 {
+            return R::zero();
+        }
+        let neighbors = complex.hinge_top_cube_neighbors(hinge_id);
+        let n = neighbors.len();
+        if n == 4 {
+            return R::zero();
+        }
+
+        let two = R::one() + R::one();
+        let two_pi = R::pi() + R::pi();
+        let pi_over_two = R::pi() / two;
+        let mut deficit = two_pi;
+        for _ in 0..n {
+            deficit -= pi_over_two;
+        }
+        deficit
+    }
+
+    /// Discrete Einstein–Hilbert (Regge) action: `Σ_h cell_volume(h) · deficit_angle(h)`
+    /// summed over every (D−2)-hinge.
+    ///
+    /// For `D < 2` the sum is empty and the action is `R::zero()`.
+    ///
+    /// On a regular periodic lattice every interior hinge has deficit zero (4 incident
+    /// top cubes, sum of dihedrals = 2π), so the action is zero. On an open lattice,
+    /// boundary hinges carry intrinsic curvature and the action is non-trivial. Under
+    /// the axis-aligned cubical assumption the deficit factor depends only on hinge
+    /// incidence count, so all edge-length sensitivity of the action flows through the
+    /// `cell_volume(h)` factor — vertex hinges in 2D have `volume = R::one()`
+    /// (the empty product), whereas edge hinges in 3D and square hinges in 4D scale
+    /// with the metric.
+    ///
+    /// `timelike_axes` is ignored in this change set; see `deficit_angle`.
+    pub fn regge_action(&self, complex: &LatticeComplex<D, R>) -> R {
+        if D < 2 {
+            return R::zero();
+        }
+        let mut action = R::zero();
+        for (hinge_id, hinge) in complex.iter_cells(D - 2).enumerate() {
+            let deficit = self.deficit_angle(complex, hinge_id);
+            // Skip the volume × 0 multiplication for interior hinges.
+            if deficit == R::zero() {
+                continue;
+            }
+            let vol = self.cell_volume(complex, &hinge);
+            action += vol * deficit;
+        }
+        action
     }
 }

--- a/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/curvature.rs
@@ -6,5 +6,76 @@
 //! Curvature, hinge enumeration, deficit angles, and the discrete Regge action for
 //! `CubicalReggeGeometry<D, R>` — Phases R2 and R3.
 //!
-//! Implementations of `dihedral_angle`, `deficit_angle`, and `regge_action` land here.
+//! ## Dihedral angles on axis-aligned cubical cells
+//!
+//! Under the project-wide axis-aligned cubical assumption (every edge stored in
+//! `EdgeLengths` runs along a coordinate axis, no shear), the two (D−1)-faces of a
+//! top D-cube that share any (D−2)-hinge are mutually perpendicular regardless of
+//! edge lengths. The dihedral angle is therefore exactly π/2 in every variant:
+//! `UnitEdge`, `Uniform`, `PerAxis`, and `PerEdge`.
+//!
+//! This is a deliberate correction to the original design note
+//! `openspec/notes/CubicalReggeCalculus.md` §3.R2, which proposed
+//! `arctan2(lengths[j], lengths[i])` for the `PerAxis` case. The proposed formula
+//! conflated the dihedral angle between faces with the half-angle of a stretched
+//! cube's diagonal; for axis-aligned cubes those are different quantities and only
+//! the constant `π/2` is geometrically meaningful as a dihedral.
+//!
+//! Curvature on a cubical lattice therefore enters only through:
+//!
+//! 1. **Incidence count of hinges.** Interior hinges in a periodic 2D/3D/4D lattice
+//!    have 4 incident top cubes (sum 2π, deficit 0 — flat). Boundary hinges on open
+//!    lattices have fewer (e.g. 1 at a 2D corner, sum π/2, deficit 3π/2 — intrinsic
+//!    boundary curvature).
+//! 2. **Sheared / non-axis-aligned cells**, which the current `EdgeLengths`
+//!    representation does not express. A future Gram-matrix-aware extension would
+//!    rewrite the dihedral closed forms here.
+//!
 //! See `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §3 and §4.
+
+use super::CubicalReggeGeometry;
+use crate::types::lattice_complex::{LatticeCell, LatticeComplex};
+use deep_causality_num::RealField;
+
+impl<const D: usize, R: RealField> CubicalReggeGeometry<D, R> {
+    /// Dihedral angle that `top_cube` contributes at `hinge`.
+    ///
+    /// On an axis-aligned cubical complex this is exactly π/2 = `R::pi() / 2`
+    /// regardless of the edge-length variant. See the module documentation for why.
+    /// The lattice argument is accepted for API symmetry with future sheared /
+    /// Riemannian extensions, where the angle would depend on local Gram-matrix
+    /// entries; current code does not read it.
+    ///
+    /// # Debug assertions
+    ///
+    /// In debug builds this asserts `top_cube.cell_dim() == D` and
+    /// `hinge.cell_dim() == D - 2`. The function does not validate that the cube is
+    /// actually incident to the hinge — callers (notably `regge_action` via
+    /// `LatticeComplex::hinge_top_cube_neighbors`) are responsible for enumerating
+    /// only incident pairs. For axis-aligned cubical cells, non-incident pairs still
+    /// produce a geometrically meaningful constant (π/2), so silent misuse degrades
+    /// to a constant rather than NaN.
+    pub fn dihedral_angle(
+        &self,
+        _complex: &LatticeComplex<D, R>,
+        top_cube: &LatticeCell<D>,
+        hinge: &LatticeCell<D>,
+    ) -> R {
+        debug_assert!(D >= 2, "dihedral_angle requires D >= 2");
+        debug_assert_eq!(
+            top_cube.cell_dim(),
+            D,
+            "dihedral_angle: top_cube must be a D-cell (got grade {})",
+            top_cube.cell_dim(),
+        );
+        debug_assert_eq!(
+            hinge.cell_dim(),
+            D - 2,
+            "dihedral_angle: hinge must be a (D-2)-cell (got grade {})",
+            hinge.cell_dim(),
+        );
+
+        let two = R::one() + R::one();
+        R::pi() / two
+    }
+}

--- a/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
@@ -62,6 +62,17 @@
 //! Each of these methods would land in its own submodule (`volumes.rs`, `curvature.rs`,
 //! `hodge.rs`, ...) mirroring the layout of `regge_geometry/`. The struct's current
 //! fields are sufficient inputs for all of them.
+//!
+//! ## R1–R3 roadmap (in progress)
+//!
+//! See [`openspec/notes/CubicalReggeCalculus.md`](../../../../openspec/notes/CubicalReggeCalculus.md)
+//! for the full design note. The R1–R3 geometric core lands across the following submodules:
+//!
+//! - `volumes` — R1: cell volumes (`cell_volume`, `top_cell_volume`).
+//! - `curvature` — R2 + R3: hinge dihedral angles, deficit angles, Regge action.
+
+pub mod curvature;
+pub mod volumes;
 
 use deep_causality_metric::Metric;
 use deep_causality_num::RealField;

--- a/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
@@ -85,7 +85,7 @@ use deep_causality_num::RealField;
 /// stored edge lengths is a choice at construction time (`f32`, `f64`, `Float106`, etc.).
 #[derive(Debug, Clone, PartialEq)]
 pub struct CubicalReggeGeometry<const D: usize, R: RealField> {
-    edge_lengths: EdgeLengths<D, R>,
+    pub(super) edge_lengths: EdgeLengths<D, R>,
     /// Optional per-axis flag marking timelike axes for Lorentzian / Minkowski lattices.
     /// `None` ⇒ all axes spacelike (Euclidean metric). `Some([..])` ⇒ flagged axes are
     /// timelike. Forward-looking: drives the metric-signature methods listed in the
@@ -93,11 +93,12 @@ pub struct CubicalReggeGeometry<const D: usize, R: RealField> {
     timelike_axes: Option<[bool; D]>,
 }
 
-/// Private union of the four edge-length representations. Kept private so callers can't
-/// inadvertently depend on the variant layout; access is through the public constructors
-/// and the `axis_length` / `edge_length` getters.
+/// Module-private union of the four edge-length representations. `pub(super)` so sibling
+/// submodules (`volumes`, `curvature`) can match on the variant for closed-form fast paths;
+/// crate-level callers still go through the public constructors and the `axis_length` /
+/// `edge_length` getters.
 #[derive(Debug, Clone, PartialEq)]
-enum EdgeLengths<const D: usize, R: RealField> {
+pub(super) enum EdgeLengths<const D: usize, R: RealField> {
     /// Every edge has length `1.0`. The Stage C / voxel-grid fast path. Carries no `R`-typed
     /// storage; the `R: RealField` parameter exists only to satisfy the type-level binding.
     UnitEdge,

--- a/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/mod.rs
@@ -34,42 +34,43 @@
 //! for each level so callers state intent at construction time and the type-level uniformity
 //! information is preserved for downstream optimization.
 //!
-//! ## Forward-looking scope (not yet implemented)
+//! ## Shipped (Phases R1–R3 of `add-cubical-regge-calculus-core`)
 //!
-//! The Stage C scope ships **edge-length storage and access only**. The full cubical Regge
-//! geometry includes the following derived quantities; the API is shaped to receive them:
+//! The geometric core of cubical Regge calculus is implemented across two sibling submodules:
 //!
-//! 1. **`cube_volume(cell_id)`** — the Euclidean volume of a top-dimensional cube as a
-//!    product of incident edge lengths (or the appropriate determinant in the per-edge
-//!    case). Straightforward once edge-to-axis lookup is added.
-//! 2. **`face_area(cell_id)`** — areas of (D−1)-cells, derived from edge lengths.
-//! 3. **`deficit_angle(bone_id)`** — the discrete curvature concentrated on codimension-2
-//!    cells ("bones"), summing the angles of the cubes incident to each bone. This is the
-//!    direct cubical analog of Regge's deficit-angle curvature. Requires a cubical
-//!    coordinate / dihedral-angle helper.
-//! 4. **`hodge_star_matrix(k)`** — the Hodge ⋆ operator on k-forms, derived from edge
-//!    lengths and the cubical duality between k-cells and (D−k)-cells. Cubical Hodge ⋆
-//!    is diagonal in the regular case (each primal cell has a unique dual cell of the
-//!    complementary grade), which makes it cheaper than the simplicial version.
-//! 5. **`metric_at(complex, grade, index)`** — the local metric signature at a specific
-//!    cell, derived from the surrounding edge lengths. Cubical complexes admit a fast path:
-//!    on a regular grid the signature is constant Euclidean (D, 0, 0) for spacelike
-//!    lattices and Lorentzian (D−1, 1, 0) when a time axis is distinguished.
-//! 6. **Causal / Lorentzian split** — a `is_timelike_axis: [bool; D]` field would let the
-//!    type carry both spacelike and timelike axes, mirroring the East-Coast / West-Coast
-//!    metric conventions already in `deep_causality_metric`.
+//! - `volumes` — R1: `cell_volume(complex, cell)` and `top_cell_volume(complex, cell)`,
+//!   dispatching on the four `EdgeLengths` variants under the axis-aligned cubical assumption.
+//! - `curvature` — R2 + R3: `dihedral_angle(complex, top_cube, hinge)` (returns π/2
+//!   uniformly under axis-alignment), `deficit_angle(complex, hinge_id)` (depends only on
+//!   hinge incidence count), and `regge_action(complex)` (sums `cell_volume(h) ·
+//!   deficit_angle(h)` over every (D−2)-hinge).
 //!
-//! Each of these methods would land in its own submodule (`volumes.rs`, `curvature.rs`,
-//! `hodge.rs`, ...) mirroring the layout of `regge_geometry/`. The struct's current
-//! fields are sufficient inputs for all of them.
+//! Curvature on an axis-aligned cubical lattice arises from two sources:
 //!
-//! ## R1–R3 roadmap (in progress)
+//! 1. **Hinge incidence count.** Interior hinges on a periodic lattice have 4 incident
+//!    top cubes, sum dihedrals = 2π, deficit = 0 (flat). Boundary hinges on open
+//!    lattices have fewer incident cubes (e.g. 1 at a 2D corner, deficit 3π/2 —
+//!    intrinsic boundary curvature).
+//! 2. **Hinge volumes.** The action's edge-length sensitivity flows through the
+//!    `cell_volume(h)` factor — vertex hinges in 2D have volume 1 (empty product),
+//!    edge hinges in 3D and square hinges in 4D scale with the metric.
+//!
+//! ## Forward-looking scope (deferred to follow-up change sets)
+//!
+//! The following derived quantities are designed-for but not yet implemented; the struct's
+//! current fields and submodule layout are sufficient inputs for all of them:
+//!
+//! - **`hodge_star_matrix(k)`** — Hodge ⋆ on k-forms, diagonal under axis-alignment.
+//!   Deferred to `add-cubical-regge-calculus-analytical` (R4). The keystone that promotes
+//!   `manifold/differential/{hodge,laplacian}.rs` to be generic over `ChainComplex`.
+//! - **`metric_at(complex, cell)`** and a type-level Lorentzian marker — local metric
+//!   signature, light-cone enforcement. Deferred to R5. Reads the `timelike_axes` field
+//!   which is currently stored but ignored by `regge_action` and `deficit_angle`.
+//! - **`regge_gradient(complex)`** and `metropolis_update` — action gradient and Markov
+//!   chain dynamics. Deferred to R6.
 //!
 //! See [`openspec/notes/CubicalReggeCalculus.md`](../../../../openspec/notes/CubicalReggeCalculus.md)
-//! for the full design note. The R1–R3 geometric core lands across the following submodules:
-//!
-//! - `volumes` — R1: cell volumes (`cell_volume`, `top_cell_volume`).
-//! - `curvature` — R2 + R3: hinge dihedral angles, deficit angles, Regge action.
+//! for the full R1–R6 design note.
 
 pub mod curvature;
 pub mod volumes;

--- a/deep_causality_topology/src/types/cubical_regge_geometry/volumes.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/volumes.rs
@@ -5,5 +5,84 @@
 
 //! Cell-volume computation for `CubicalReggeGeometry<D, R>` — Phase R1.
 //!
-//! Implementations of `cell_volume` and `top_cell_volume` land here. See
-//! `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §2.
+//! On a cubical lattice every k-cell is axis-aligned, so its k-volume is the product of the
+//! k edge lengths meeting at its base vertex. This module dispatches on the four edge-length
+//! uniformity levels (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`) to evaluate that product
+//! at the lowest cost the level allows.
+//!
+//! See `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §2 and
+//! `openspec/notes/CubicalReggeCalculus.md` §3.R1.
+
+use super::{CubicalReggeGeometry, EdgeLengths};
+use crate::types::lattice_complex::{LatticeCell, LatticeComplex};
+use deep_causality_num::RealField;
+
+impl<const D: usize, R: RealField> CubicalReggeGeometry<D, R> {
+    /// k-volume of a single lattice cell, where `k = cell.cell_dim()`.
+    ///
+    /// For a k-cube with active dimensions `{i₁, …, iₖ}` (bits set in `cell.orientation()`),
+    /// the volume is the product of the k edge lengths along those axes meeting at
+    /// `cell.position()`. Returns `R::one()` for 0-cells (vertices) — the empty product.
+    ///
+    /// The per-edge arm reads each contributing edge length via
+    /// `LatticeComplex::edge_index`. This relies on cubical cells being axis-aligned, so
+    /// the Gram-matrix cross-terms vanish and the determinant collapses to the product.
+    /// A sheared cubical representation would need a different routine; this one is
+    /// guarded by a debug assertion.
+    pub fn cell_volume(&self, complex: &LatticeComplex<D, R>, cell: &LatticeCell<D>) -> R {
+        let orientation = cell.orientation();
+        let grade = orientation.count_ones() as usize;
+
+        match &self.edge_lengths {
+            EdgeLengths::UnitEdge => R::one(),
+            EdgeLengths::Uniform { length } => {
+                let mut v = R::one();
+                for _ in 0..grade {
+                    v *= *length;
+                }
+                v
+            }
+            EdgeLengths::PerAxis { lengths } => {
+                let mut v = R::one();
+                for (axis, length) in lengths.iter().enumerate() {
+                    if (orientation & (1 << axis)) != 0 {
+                        v *= *length;
+                    }
+                }
+                v
+            }
+            EdgeLengths::PerEdge { lengths } => {
+                // PerEdge stores one length per lattice edge. The cubical formula assumes
+                // axis-aligned cells so the Gram-matrix cross-terms vanish and the
+                // determinant collapses to a product of edge lengths. The current PerEdge
+                // representation cannot express off-diagonal Gram entries, but a future
+                // sheared-cubical extension would need a different routine entirely.
+                debug_assert!(
+                    !lengths.is_empty(),
+                    "PerEdge edge-length buffer is empty; cell_volume cannot be computed.",
+                );
+                let position = *cell.position();
+                let mut v = R::one();
+                for axis in 0..D {
+                    if (orientation & (1 << axis)) != 0 {
+                        let idx = complex.edge_index(position, axis);
+                        v *= lengths[idx];
+                    }
+                }
+                v
+            }
+        }
+    }
+
+    /// D-volume of a top-dimensional cube. Convenience wrapper around `cell_volume` that
+    /// debug-asserts the cell is in fact D-dimensional.
+    pub fn top_cell_volume(&self, complex: &LatticeComplex<D, R>, cell: &LatticeCell<D>) -> R {
+        debug_assert_eq!(
+            cell.cell_dim(),
+            D,
+            "top_cell_volume requires a D-cell (got grade {})",
+            cell.cell_dim(),
+        );
+        self.cell_volume(complex, cell)
+    }
+}

--- a/deep_causality_topology/src/types/cubical_regge_geometry/volumes.rs
+++ b/deep_causality_topology/src/types/cubical_regge_geometry/volumes.rs
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Cell-volume computation for `CubicalReggeGeometry<D, R>` — Phase R1.
+//!
+//! Implementations of `cell_volume` and `top_cell_volume` land here. See
+//! `openspec/changes/add-cubical-regge-calculus-core/tasks.md` §2.

--- a/deep_causality_topology/src/types/gauge/link_variable/mod.rs
+++ b/deep_causality_topology/src/types/gauge/link_variable/mod.rs
@@ -294,53 +294,50 @@ impl<G: GaugeGroup, M: Field + Copy + Default + PartialOrd, R: RealField> LinkVa
             return Err(LinkVariableError::InvalidDimension(n));
         }
 
-        // Create block-diagonal matrix with phase in U(1) sector
+        // Create block-diagonal matrix with phase in U(1) sector.
+        //
+        // Dispatch is by matrix dimension only — an earlier draft had a
+        // `G::name() == "SU2_U1"` special case that produced output identical to the
+        // n = 3 general arm below, and the name string mismatched the actual
+        // `SU2_U1::name()` return ("SU(2)×U(1)") making it dead code.
         let mut data = vec![M::zero(); n * n];
 
-        if G::name() == "SU2_U1" && n == 3 {
-            // SU(2)×U(1) block
-            data[0] = M::one();
-            data[4] = M::one();
-            data[8] = M::from_polar(R::one(), phase);
-        } else {
-            // other cases that are non SU2_U1
-            match n {
-                1 => {
-                    // Pure U(1): exp(iφ)
-                    data[0] = M::from_polar(R::one(), phase);
-                }
-                2 => {
-                    // SU(2): encode as exp(iφσ_3/2) = diag(exp(iφ/2), exp(-iφ/2))
-                    // This preserves det = 1
-                    let two = R::one() + R::one();
-                    let half_phase = phase / two;
-                    data[0] = M::from_polar(R::one(), half_phase);
-                    data[3] = M::from_polar(R::one(), -half_phase);
-                }
-                3 => {
-                    // SU(2)×U(1): block-diagonal (2×2 SU(2) identity) + (1×1 U(1) phase)
-                    // [[1, 0, 0],
-                    //  [0, 1, 0],
-                    //  [0, 0, exp(iφ)]]
-                    data[0] = M::one(); // SU(2) block: identity
-                    data[4] = M::one(); // SU(2) block: identity
-                    data[8] = M::from_polar(R::one(), phase); // U(1) sector: exp(iφ)
-                }
-                _ => {
-                    // General SU(n): encode phase along diagonal with det = 1
-                    // diag(exp(iφ), exp(-iφ/(n-1)), exp(-iφ/(n-1)), ...)
-                    let n_minus_1_f = R::from_usize(n - 1).ok_or_else(|| {
-                        LinkVariableError::NumericalError(format!(
-                            "Cannot represent dimension {} as underlying real type",
-                            n - 1
-                        ))
-                    })?;
-                    let compensating_phase = -phase / n_minus_1_f;
+        match n {
+            1 => {
+                // Pure U(1): exp(iφ)
+                data[0] = M::from_polar(R::one(), phase);
+            }
+            2 => {
+                // SU(2): encode as exp(iφσ_3/2) = diag(exp(iφ/2), exp(-iφ/2))
+                // This preserves det = 1
+                let two = R::one() + R::one();
+                let half_phase = phase / two;
+                data[0] = M::from_polar(R::one(), half_phase);
+                data[3] = M::from_polar(R::one(), -half_phase);
+            }
+            3 => {
+                // SU(2)×U(1): block-diagonal (2×2 SU(2) identity) + (1×1 U(1) phase)
+                // [[1, 0, 0],
+                //  [0, 1, 0],
+                //  [0, 0, exp(iφ)]]
+                data[0] = M::one(); // SU(2) block: identity
+                data[4] = M::one(); // SU(2) block: identity
+                data[8] = M::from_polar(R::one(), phase); // U(1) sector: exp(iφ)
+            }
+            _ => {
+                // General SU(n): encode phase along diagonal with det = 1
+                // diag(exp(iφ), exp(-iφ/(n-1)), exp(-iφ/(n-1)), ...)
+                let n_minus_1_f = R::from_usize(n - 1).ok_or_else(|| {
+                    LinkVariableError::NumericalError(format!(
+                        "Cannot represent dimension {} as underlying real type",
+                        n - 1
+                    ))
+                })?;
+                let compensating_phase = -phase / n_minus_1_f;
 
-                    data[0] = M::from_polar(R::one(), phase);
-                    for i in 1..n {
-                        data[i * n + i] = M::from_polar(R::one(), compensating_phase);
-                    }
+                data[0] = M::from_polar(R::one(), phase);
+                for i in 1..n {
+                    data[i * n + i] = M::from_polar(R::one(), compensating_phase);
                 }
             }
         }

--- a/deep_causality_topology/src/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/src/types/lattice_complex/mod.rs
@@ -11,6 +11,7 @@ pub use lattice_cell::LatticeCell;
 
 use crate::traits::cell::Cell;
 use crate::traits::chain_complex::ChainComplex;
+use crate::traits::neighborhood::CellId;
 use deep_causality_num::RealField;
 use deep_causality_sparse::CsrMatrix;
 use std::borrow::Cow;
@@ -201,6 +202,56 @@ impl<const D: usize, R: RealField> LatticeComplex<D, R> {
         } else {
             dim_len
         }
+    }
+
+    /// Top D-cubes incident to a (D−2)-hinge.
+    ///
+    /// Walks `boundary_matrix(D−1)` row `hinge_id` to enumerate the (D−1)-faces whose
+    /// boundary contains the hinge, then walks `boundary_matrix(D)` row by row to
+    /// collect every D-cube whose boundary contains one of those faces. The result is
+    /// deduplicated and returned as a `Vec<CellId>` (small — at most 4 entries on a
+    /// regular lattice).
+    ///
+    /// Returns an empty vector for `D < 2` (where (D−2)-hinges don't exist) or when
+    /// `hinge_id` is out of range.
+    ///
+    /// # Implementation note
+    ///
+    /// The design note proposes routing through `coboundary_matrix(D−2)` and
+    /// `coboundary_matrix(D−1)` instead. Both directions give the same incidence
+    /// information; we use `boundary_matrix` because CSR storage indexes naturally
+    /// by row (`O(degree)` per row slice), whereas extracting a column from the
+    /// coboundary form requires an `O(nnz)` scan. Functionally equivalent; cheaper
+    /// in this access pattern.
+    pub fn hinge_top_cube_neighbors(&self, hinge_id: CellId) -> Vec<CellId> {
+        if D < 2 {
+            return Vec::new();
+        }
+        let num_hinges = self.num_cells(D - 2);
+        if hinge_id >= num_hinges {
+            return Vec::new();
+        }
+
+        let b_dm1 = self.boundary_matrix(D - 1);
+        let b_d = self.boundary_matrix(D);
+
+        let dm1_rows = b_dm1.row_indices();
+        let dm1_cols = b_dm1.col_indices();
+        let d_rows = b_d.row_indices();
+        let d_cols = b_d.col_indices();
+
+        let face_slice = &dm1_cols[dm1_rows[hinge_id]..dm1_rows[hinge_id + 1]];
+
+        let mut out: Vec<CellId> = Vec::new();
+        for &face in face_slice {
+            let top_slice = &d_cols[d_rows[face]..d_rows[face + 1]];
+            for &top in top_slice {
+                if !out.contains(&top) {
+                    out.push(top);
+                }
+            }
+        }
+        out
     }
 }
 

--- a/deep_causality_topology/src/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/src/types/lattice_complex/mod.rs
@@ -16,7 +16,7 @@ use deep_causality_sparse::CsrMatrix;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::sync::Mutex;
+use std::sync::OnceLock;
 
 /// A combinatorial cubical lattice in `D` dimensions, paired with a metric precision `R`.
 ///
@@ -33,10 +33,12 @@ pub struct LatticeComplex<const D: usize, R: RealField> {
     /// Periodic boundary conditions per dimension
     periodic: [bool; D],
     /// Lazy memo of coboundary matrices: δ_k = (∂_{k+1})ᵀ.
-    /// Populated on first call to `coboundary_matrix(k)`; ignored for equality.
-    /// `Mutex` (not `RefCell`) so `LatticeComplex<D, R>` stays `Send + Sync` for the existing
+    /// One `OnceLock` per grade in `0..=D`; populated on first call to `coboundary_matrix(k)`;
+    /// ignored for equality. `OnceLock` (not `Mutex<HashMap>`) keeps reads lock-free after first
+    /// init and lets `coboundary_matrix` return `Cow::Borrowed`, eliminating the per-call CSR
+    /// clone. `Box<[OnceLock<...>]>` is `Send + Sync` for the existing
     /// `Arc<LatticeComplex<D, R>>` consumers in `gauge_field_lattice`.
-    coboundary_cache: Mutex<HashMap<usize, CsrMatrix<i8>>>,
+    coboundary_cache: Box<[OnceLock<CsrMatrix<i8>>]>,
     /// Anchors the metric-precision parameter `R`. Zero-sized.
     _precision: PhantomData<R>,
 }
@@ -47,7 +49,7 @@ impl<const D: usize, R: RealField> Clone for LatticeComplex<D, R> {
             shape: self.shape,
             periodic: self.periodic,
             // Cache intentionally not cloned: cheaper to recompute lazily on the clone.
-            coboundary_cache: Mutex::new(HashMap::new()),
+            coboundary_cache: Self::fresh_cache(),
             _precision: PhantomData,
         }
     }
@@ -69,9 +71,17 @@ impl<const D: usize, R: RealField> LatticeComplex<D, R> {
         Self {
             shape,
             periodic,
-            coboundary_cache: Mutex::new(HashMap::new()),
+            coboundary_cache: Self::fresh_cache(),
             _precision: PhantomData,
         }
+    }
+
+    /// Build an empty per-grade coboundary cache with `D + 1` slots (one per grade `0..=D`).
+    fn fresh_cache() -> Box<[OnceLock<CsrMatrix<i8>>]> {
+        (0..=D)
+            .map(|_| OnceLock::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     /// Create a fully periodic (toroidal) lattice.
@@ -294,22 +304,10 @@ impl<const D: usize, R: RealField> ChainComplex for LatticeComplex<D, R> {
     }
 
     fn coboundary_matrix(&self, k: usize) -> Cow<'_, CsrMatrix<i8>> {
-        // Lazy memo: δ_k = (∂_{k+1})ᵀ.
-        {
-            let cache = self
-                .coboundary_cache
-                .lock()
-                .expect("coboundary_cache poisoned");
-            if let Some(m) = cache.get(&k) {
-                return Cow::Owned(m.clone());
-            }
-        }
-        let computed = self.boundary_matrix(k + 1).into_owned().transpose();
-        self.coboundary_cache
-            .lock()
-            .expect("coboundary_cache poisoned")
-            .insert(k, computed.clone());
-        Cow::Owned(computed)
+        // Lazy memo: δ_k = (∂_{k+1})ᵀ. One OnceLock per grade in 0..=D.
+        let slot = &self.coboundary_cache[k];
+        let m = slot.get_or_init(|| self.boundary_matrix(k + 1).into_owned().transpose());
+        Cow::Borrowed(m)
     }
 
     fn betti_number(&self, k: usize) -> usize {

--- a/deep_causality_topology/src/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/src/types/lattice_complex/mod.rs
@@ -152,6 +152,56 @@ impl<const D: usize, R: RealField> LatticeComplex<D, R> {
     pub fn iter_cells(&self, k: usize) -> LatticeCellIterator<'_, D, R> {
         LatticeCellIterator::new(self, k)
     }
+
+    /// Flat index of the 1-cell (edge) at `(position, axis)` in the canonical
+    /// `iter_cells(1)` ordering. Used by `PerEdge` cubical Regge metrics to look up
+    /// the edge length at a specific lattice edge.
+    ///
+    /// Ordering matches `LatticeCellIterator`: orientations with one bit set are visited
+    /// in ascending numerical order (axis 0, then axis 1, …, then axis D−1); within each
+    /// orientation, positions advance with axis 0 varying fastest. A position component
+    /// equal to `shape[d] - 1` is only legal along the edge's own axis when that axis is
+    /// non-periodic (the last column of edges wraps around on periodic axes only).
+    pub(crate) fn edge_index(&self, position: [usize; D], axis: usize) -> usize {
+        let target = 1u32 << axis;
+        let mut idx = 0usize;
+
+        for prior_axis in 0..axis {
+            idx += self.edges_along(prior_axis);
+        }
+
+        let mut offset = 0usize;
+        let mut stride = 1usize;
+        for (d, &p) in position.iter().enumerate() {
+            offset += p * stride;
+            stride *= self.valid_positions(d, target);
+        }
+        idx + offset
+    }
+
+    /// Number of 1-cells along a given axis on this lattice. `pub(crate)` so the cubical
+    /// Regge volume / curvature modules can size `PerEdge` buffers and validate inputs.
+    pub(crate) fn edges_along(&self, axis: usize) -> usize {
+        let orientation = 1u32 << axis;
+        let mut count = 1usize;
+        for d in 0..D {
+            count *= self.valid_positions(d, orientation);
+        }
+        count
+    }
+
+    /// Number of valid `position[d]` values for a cell with the given `orientation`.
+    /// Active non-periodic dims lose the wrap-around slice; all others use the full extent.
+    pub(crate) fn valid_positions(&self, d: usize, orientation: u32) -> usize {
+        let dim_len = self.shape[d];
+        let is_active = (orientation & (1 << d)) != 0;
+        let is_periodic = self.periodic[d];
+        if is_active && !is_periodic {
+            if dim_len == 0 { 0 } else { dim_len - 1 }
+        } else {
+            dim_len
+        }
+    }
 }
 
 // --- Iterator ---
@@ -358,5 +408,74 @@ impl<R: RealField> LatticeComplex<3, R> {
 impl<R: RealField> LatticeComplex<4, R> {
     pub fn hypercubic_torus(l: usize) -> Self {
         Self::new([l, l, l, l], [true, true, true, true])
+    }
+}
+
+#[cfg(test)]
+mod edge_index_tests {
+    use super::*;
+
+    #[test]
+    fn open_2d_axis0_ordering() {
+        let l: LatticeComplex<2, f64> = LatticeComplex::square_open(3);
+        assert_eq!(l.edges_along(0), 6);
+        assert_eq!(l.edge_index([0, 0], 0), 0);
+        assert_eq!(l.edge_index([1, 0], 0), 1);
+        assert_eq!(l.edge_index([0, 1], 0), 2);
+        assert_eq!(l.edge_index([1, 1], 0), 3);
+        assert_eq!(l.edge_index([0, 2], 0), 4);
+        assert_eq!(l.edge_index([1, 2], 0), 5);
+    }
+
+    #[test]
+    fn open_2d_axis1_ordering_starts_after_axis0() {
+        let l: LatticeComplex<2, f64> = LatticeComplex::square_open(3);
+        assert_eq!(l.edge_index([0, 0], 1), 6);
+        assert_eq!(l.edge_index([1, 0], 1), 7);
+        assert_eq!(l.edge_index([2, 0], 1), 8);
+        assert_eq!(l.edge_index([0, 1], 1), 9);
+        assert_eq!(l.edge_index([2, 1], 1), 11);
+    }
+
+    #[test]
+    fn periodic_2d_includes_wraparound_edges() {
+        let l: LatticeComplex<2, f64> = LatticeComplex::square_torus(3);
+        assert_eq!(l.edges_along(0), 9);
+        assert_eq!(l.edges_along(1), 9);
+        assert_eq!(l.edge_index([0, 0], 1), 9);
+        assert_eq!(l.edge_index([2, 2], 1), 17);
+    }
+
+    #[test]
+    fn mixed_boundary_3d_counts() {
+        let l: LatticeComplex<3, f64> = LatticeComplex::new([2, 3, 4], [true, false, true]);
+        assert_eq!(l.edges_along(0), 24);
+        assert_eq!(l.edges_along(1), 16);
+        assert_eq!(l.edges_along(2), 24);
+        assert_eq!(l.edge_index([0, 0, 0], 1), 24);
+        assert_eq!(l.edge_index([0, 0, 0], 2), 40);
+    }
+
+    #[test]
+    fn edge_index_matches_iter_cells_ordering_open_2d() {
+        let l: LatticeComplex<2, f64> = LatticeComplex::square_open(4);
+        for (i, cell) in l.iter_cells(1).enumerate() {
+            let axis = cell.orientation().trailing_zeros() as usize;
+            assert_eq!(
+                l.edge_index(*cell.position(), axis),
+                i,
+                "mismatch at edge {i} (position {:?}, axis {axis})",
+                cell.position(),
+            );
+        }
+    }
+
+    #[test]
+    fn edge_index_matches_iter_cells_ordering_periodic_3d() {
+        let l: LatticeComplex<3, f64> = LatticeComplex::cubic_torus(3);
+        for (i, cell) in l.iter_cells(1).enumerate() {
+            let axis = cell.orientation().trailing_zeros() as usize;
+            assert_eq!(l.edge_index(*cell.position(), axis), i);
+        }
     }
 }

--- a/deep_causality_topology/src/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/src/types/lattice_complex/mod.rs
@@ -268,12 +268,20 @@ pub struct LatticeCellIterator<'a, const D: usize, R: RealField> {
 
 impl<'a, const D: usize, R: RealField> LatticeCellIterator<'a, D, R> {
     fn new(lattice: &'a LatticeComplex<D, R>, k: usize) -> Self {
-        // Generate all k-bit patterns in D bits
+        // Generate all k-bit patterns in D bits, then drop orientations whose product of
+        // valid positions across all axes is zero. Without the filter, a lattice with
+        // `shape[d] == 0` along a non-periodic active axis would yield phantom cells (the
+        // first position `[0; D]` is always emitted before the advance loop checks the
+        // zero-extent axis), so `cells(k).count()` would not match `num_cells(k)`.
         let mut orientations = Vec::new();
         let limit: usize = 1 << D;
         for i in 0..limit {
             if i.count_ones() as usize == k {
-                orientations.push(i as u32);
+                let orient = i as u32;
+                let count: usize = (0..D).map(|d| lattice.valid_positions(d, orient)).product();
+                if count > 0 {
+                    orientations.push(orient);
+                }
             }
         }
 

--- a/deep_causality_topology/src/utils_tests/cubical_regge_utils.rs
+++ b/deep_causality_topology/src/utils_tests/cubical_regge_utils.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Shared test fixtures for the cubical Regge calculus core (R1–R3).
+//!
+//! These small open / periodic lattices and matching metrics keep the property tests
+//! under `tests/types/cubical_regge_geometry/` concise. Living in `src/utils_tests/` is
+//! required so Bazel can reach them during testing (see `AGENTS.md` test layout notes).
+
+use crate::types::cubical_regge_geometry::CubicalReggeGeometry;
+use crate::types::lattice_complex::LatticeComplex;
+
+/// 3×3 open-boundary square lattice with `R = f64` precision.
+pub fn open_square_3() -> LatticeComplex<2, f64> {
+    LatticeComplex::square_open(3)
+}
+
+/// 3×3 periodic (torus) square lattice with `R = f64` precision.
+pub fn periodic_square_3() -> LatticeComplex<2, f64> {
+    LatticeComplex::square_torus(3)
+}
+
+/// 3×3×3 open-boundary cubic lattice with `R = f64` precision.
+pub fn open_cube_3() -> LatticeComplex<3, f64> {
+    LatticeComplex::cubic_open(3)
+}
+
+/// 3×3×3 periodic cubic lattice with `R = f64` precision.
+pub fn periodic_cube_3() -> LatticeComplex<3, f64> {
+    LatticeComplex::cubic_torus(3)
+}
+
+/// Unit-edge cubical Regge geometry in dimension `D`, `R = f64`.
+pub fn unit_geometry<const D: usize>() -> CubicalReggeGeometry<D, f64> {
+    CubicalReggeGeometry::unit()
+}
+
+/// `PerAxis` geometry with the given axis lengths, `R = f64`.
+pub fn per_axis_geometry<const D: usize>(lengths: [f64; D]) -> CubicalReggeGeometry<D, f64> {
+    CubicalReggeGeometry::per_axis(lengths)
+}
+
+/// `PerEdge` geometry on `complex` where every edge along axis `a` has length `lengths[a]`.
+/// Reproduces a `PerAxis` configuration via the per-edge buffer — useful for cross-checking
+/// the per-edge code path against the per-axis closed form.
+pub fn per_edge_uniform_per_axis<const D: usize>(
+    complex: &LatticeComplex<D, f64>,
+    lengths: [f64; D],
+) -> CubicalReggeGeometry<D, f64> {
+    let total: usize = (0..D).map(|axis| complex.edges_along(axis)).sum();
+    let mut buf = Vec::with_capacity(total);
+    for (axis, &length) in lengths.iter().enumerate() {
+        let n = complex.edges_along(axis);
+        for _ in 0..n {
+            buf.push(length);
+        }
+    }
+    CubicalReggeGeometry::from_edge_lengths(buf)
+}

--- a/deep_causality_topology/src/utils_tests/mod.rs
+++ b/deep_causality_topology/src/utils_tests/mod.rs
@@ -4,89 +4,9 @@
  */
 
 //! Test utilities for deep_causality_topology tests
-use crate::{Simplex, SimplicialComplex, Skeleton};
-use deep_causality_num::Zero;
-use deep_causality_sparse::CsrMatrix;
-use deep_causality_tensor::CausalTensor;
 
-/// Creates a simple triangle (2-simplex) simplicial complex
-/// Vertices: 0, 1, 2
-/// Edges: (0,1), (0,2), (1,2)
-/// Face: (0,1,2)
-pub fn create_triangle_complex() -> SimplicialComplex<f64> {
-    // 0-skeleton: vertices
-    let vertices = vec![
-        Simplex::new(vec![0]),
-        Simplex::new(vec![1]),
-        Simplex::new(vec![2]),
-    ];
-    let skeleton_0 = Skeleton::new(0, vertices);
+pub mod cubical_regge_utils;
+pub mod simplicial_complex_utils;
 
-    // 1-skeleton: edges
-    let edges = vec![
-        Simplex::new(vec![0, 1]),
-        Simplex::new(vec![0, 2]),
-        Simplex::new(vec![1, 2]),
-    ];
-    let skeleton_1 = Skeleton::new(1, edges);
-
-    // 2-skeleton: face
-    let faces = vec![Simplex::new(vec![0, 1, 2])];
-    let skeleton_2 = Skeleton::new(2, faces);
-
-    // Boundary operator d1: edges -> vertices
-    // For edge (0,1): vertex 1 - vertex 0
-    let d1 = CsrMatrix::from_triplets(
-        3, // 3 vertices
-        3, // 3 edges
-        &[
-            (1, 0, 1i8),
-            (0, 0, -1),
-            (2, 1, 1),
-            (0, 1, -1),
-            (2, 2, 1),
-            (1, 2, -1),
-        ],
-    )
-    .unwrap();
-
-    // Boundary operator d2: faces -> edges
-    let d2 = CsrMatrix::from_triplets(
-        3, // 3 edges
-        1, // 1 face
-        &[(0, 0, 1i8), (1, 0, -1), (2, 0, 1)],
-    )
-    .unwrap();
-
-    let boundary_ops = vec![d1, d2];
-
-    let coboundary_ops = vec![];
-
-    SimplicialComplex::new(
-        vec![skeleton_0, skeleton_1, skeleton_2],
-        boundary_ops,
-        coboundary_ops,
-        Vec::new(),
-    )
-}
-
-/// Creates a tensor with default values for testing
-pub fn create_test_tensor<T>(size: usize) -> CausalTensor<T>
-where
-    T: Default + Copy + Zero,
-{
-    CausalTensor::new(vec![T::zero(); size], vec![size]).unwrap()
-}
-
-/// Creates a simple line graph (2 vertices, 1 edge)
-pub fn create_line_complex() -> SimplicialComplex<f64> {
-    let vertices = vec![Simplex::new(vec![0]), Simplex::new(vec![1])];
-    let skeleton_0 = Skeleton::new(0, vertices);
-
-    let edges = vec![Simplex::new(vec![0, 1])];
-    let skeleton_1 = Skeleton::new(1, edges);
-
-    let d1 = CsrMatrix::from_triplets(2, 1, &[(1, 0, 1i8), (0, 0, -1)]).unwrap();
-
-    SimplicialComplex::new(vec![skeleton_0, skeleton_1], vec![d1], vec![], Vec::new())
-}
+pub use cubical_regge_utils::*;
+pub use simplicial_complex_utils::*;

--- a/deep_causality_topology/src/utils_tests/simplicial_complex_utils.rs
+++ b/deep_causality_topology/src/utils_tests/simplicial_complex_utils.rs
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+use crate::{Simplex, SimplicialComplex, Skeleton};
+use deep_causality_num::Zero;
+use deep_causality_sparse::CsrMatrix;
+use deep_causality_tensor::CausalTensor;
+
+/// Creates a simple triangle (2-simplex) simplicial complex
+/// Vertices: 0, 1, 2
+/// Edges: (0,1), (0,2), (1,2)
+/// Face: (0,1,2)
+pub fn create_triangle_complex() -> SimplicialComplex<f64> {
+    // 0-skeleton: vertices
+    let vertices = vec![
+        Simplex::new(vec![0]),
+        Simplex::new(vec![1]),
+        Simplex::new(vec![2]),
+    ];
+    let skeleton_0 = Skeleton::new(0, vertices);
+
+    // 1-skeleton: edges
+    let edges = vec![
+        Simplex::new(vec![0, 1]),
+        Simplex::new(vec![0, 2]),
+        Simplex::new(vec![1, 2]),
+    ];
+    let skeleton_1 = Skeleton::new(1, edges);
+
+    // 2-skeleton: face
+    let faces = vec![Simplex::new(vec![0, 1, 2])];
+    let skeleton_2 = Skeleton::new(2, faces);
+
+    // Boundary operator d1: edges -> vertices
+    // For edge (0,1): vertex 1 - vertex 0
+    let d1 = CsrMatrix::from_triplets(
+        3, // 3 vertices
+        3, // 3 edges
+        &[
+            (1, 0, 1i8),
+            (0, 0, -1),
+            (2, 1, 1),
+            (0, 1, -1),
+            (2, 2, 1),
+            (1, 2, -1),
+        ],
+    )
+    .unwrap();
+
+    // Boundary operator d2: faces -> edges
+    let d2 = CsrMatrix::from_triplets(
+        3, // 3 edges
+        1, // 1 face
+        &[(0, 0, 1i8), (1, 0, -1), (2, 0, 1)],
+    )
+    .unwrap();
+
+    let boundary_ops = vec![d1, d2];
+
+    let coboundary_ops = vec![];
+
+    SimplicialComplex::new(
+        vec![skeleton_0, skeleton_1, skeleton_2],
+        boundary_ops,
+        coboundary_ops,
+        Vec::new(),
+    )
+}
+
+/// Creates a tensor with default values for testing
+pub fn create_test_tensor<T>(size: usize) -> CausalTensor<T>
+where
+    T: Default + Copy + Zero,
+{
+    CausalTensor::new(vec![T::zero(); size], vec![size]).unwrap()
+}
+
+/// Creates a simple line graph (2 vertices, 1 edge)
+pub fn create_line_complex() -> SimplicialComplex<f64> {
+    let vertices = vec![Simplex::new(vec![0]), Simplex::new(vec![1])];
+    let skeleton_0 = Skeleton::new(0, vertices);
+
+    let edges = vec![Simplex::new(vec![0, 1])];
+    let skeleton_1 = Skeleton::new(1, edges);
+
+    let d1 = CsrMatrix::from_triplets(2, 1, &[(1, 0, 1i8), (0, 0, -1)]).unwrap();
+
+    SimplicialComplex::new(vec![skeleton_0, skeleton_1], vec![d1], vec![], Vec::new())
+}

--- a/deep_causality_topology/tests/BUILD.bazel
+++ b/deep_causality_topology/tests/BUILD.bazel
@@ -180,6 +180,7 @@ rust_test_suite(
         "//deep_causality_topology",
         # Internal deps
         "//deep_causality_metric",
+        "//deep_causality_num",
     ],
 )
 

--- a/deep_causality_topology/tests/BUILD.bazel
+++ b/deep_causality_topology/tests/BUILD.bazel
@@ -167,6 +167,23 @@ rust_test_suite(
 )
 
 rust_test_suite(
+    name = "types/cubical_regge_geometry",
+    srcs = glob([
+        "types/cubical_regge_geometry/*_tests.rs",
+    ]),
+    tags = [
+        "unit-test",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        # Crate to test
+        "//deep_causality_topology",
+        # Internal deps
+        "//deep_causality_metric",
+    ],
+)
+
+rust_test_suite(
     name = "types/lattice_complex",
     srcs = glob([
         "types/lattice_complex/*_tests.rs",

--- a/deep_causality_topology/tests/extensions/hkt_gauge_field_tests.rs
+++ b/deep_causality_topology/tests/extensions/hkt_gauge_field_tests.rs
@@ -412,3 +412,37 @@ fn test_gauge_rotation_invalid_indices() {
     assert_eq!(rotated_conn.shape(), &[0]);
     assert_eq!(rotated_fs.shape(), &[0]);
 }
+
+fn create_2vertex_manifold() -> SimplicialManifold<f64, f64> {
+    let mut builder = SimplicialComplexBuilder::new(1);
+    builder.add_simplex(Simplex::new(vec![0, 1])).unwrap();
+    let complex = builder.build::<f64>().unwrap();
+    let data = CausalTensor::zeros(&[complex.total_simplices()]);
+    Manifold::new(complex, data, 0).unwrap()
+}
+
+#[test]
+fn test_compute_field_strength_abelian_multipoint_uses_forward_difference() {
+    // num_points = total_simplices = 3 (2 vertices + 1 edge) for a single 1-simplex
+    // complex. Drives the forward-difference branch in compute_field_strength_abelian.
+    let manifold = create_2vertex_manifold();
+    let conn = CausalTensor::from_vec((0..12).map(|i| i as f64).collect::<Vec<_>>(), &[3, 4, 1]);
+    let fs = CausalTensor::zeros(&[3, 4, 4, 1]);
+    let field: GaugeField<U1, f64, f64> =
+        GaugeField::with_default_metric(manifold, conn, fs).expect("create field");
+
+    let result = GaugeFieldWitness::compute_field_strength_abelian(&field).unwrap();
+    assert_eq!(result.shape(), &[3, 4, 4, 1]);
+}
+
+#[test]
+fn test_compute_field_strength_non_abelian_multipoint_and_nonzero_coupling() {
+    let manifold = create_2vertex_manifold();
+    let conn = CausalTensor::from_vec((0..36).map(|i| i as f64).collect::<Vec<_>>(), &[3, 4, 3]);
+    let fs = CausalTensor::zeros(&[3, 4, 4, 3]);
+    let field: GaugeField<SU2, f64, f64> =
+        GaugeField::with_default_metric(manifold, conn, fs).expect("create field");
+
+    let result = GaugeFieldWitness::compute_field_strength_non_abelian(&field, 0.5);
+    assert_eq!(result.shape(), &[3, 4, 4, 3]);
+}

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/cubical_regge_geometry_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/cubical_regge_geometry_tests.rs
@@ -118,6 +118,21 @@ fn axis_length_is_none_for_per_edge() {
     assert!(g.axis_length(0).is_none());
 }
 
+#[test]
+fn axis_length_unit_edge_returns_one_in_range() {
+    let g = CubicalReggeGeometry::<3, f64>::unit();
+    assert_eq!(g.axis_length(0), Some(1.0));
+    assert_eq!(g.axis_length(1), Some(1.0));
+    assert_eq!(g.axis_length(2), Some(1.0));
+}
+
+#[test]
+fn axis_length_uniform_returns_length_in_range() {
+    let g = CubicalReggeGeometry::<3, f64>::uniform(0.75);
+    assert_eq!(g.axis_length(0), Some(0.75));
+    assert_eq!(g.axis_length(2), Some(0.75));
+}
+
 // -- edge_length_at single-edge getter -------------------------------------------
 
 #[test]

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
@@ -379,3 +379,52 @@ fn open_3d_per_axis_action_equals_per_edge_action() {
     let tol = f64::EPSILON * 64.0 * a.abs().max(1.0);
     assert!((a - e).abs() <= tol, "per_axis={a} vs per_edge={e}");
 }
+
+// -- D < 2 degenerate cases (covers early-return paths) ---------------------------
+
+#[test]
+fn deficit_angle_returns_zero_for_d1_lattice() {
+    let lattice: LatticeComplex<1, f64> = LatticeComplex::new([3], [false]);
+    let geom: CubicalReggeGeometry<1, f64> = CubicalReggeGeometry::unit();
+    // D=1 has no (D-2) = (-1) hinges; the function returns R::zero() unconditionally.
+    assert_eq!(geom.deficit_angle(&lattice, 0), 0.0);
+    assert_eq!(geom.deficit_angle(&lattice, 999), 0.0);
+}
+
+#[test]
+fn regge_action_returns_zero_for_d1_lattice() {
+    let lattice: LatticeComplex<1, f64> = LatticeComplex::new([3], [true]);
+    let geom: CubicalReggeGeometry<1, f64> = CubicalReggeGeometry::unit();
+    assert_eq!(geom.regge_action(&lattice), 0.0);
+}
+
+#[test]
+fn deficit_angle_out_of_range_hinge_returns_zero() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let n = lattice.num_cells(0);
+    assert_eq!(geom.deficit_angle(&lattice, n), 0.0);
+    assert_eq!(geom.deficit_angle(&lattice, n + 100), 0.0);
+}
+
+// -- Debug-assertion panic paths (covers format-argument lines) -------------------
+
+#[test]
+#[should_panic(expected = "top_cube must be a D-cell")]
+fn dihedral_angle_panics_when_top_cube_wrong_grade() {
+    let lattice = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    let not_a_top_cube = LatticeCell::vertex([0, 0]); // grade 0, not D=2
+    let hinge = LatticeCell::vertex([1, 1]);
+    let _ = geom.dihedral_angle(&lattice, &not_a_top_cube, &hinge);
+}
+
+#[test]
+#[should_panic(expected = "hinge must be a (D-2)-cell")]
+fn dihedral_angle_panics_when_hinge_wrong_grade() {
+    let lattice = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    let top = LatticeCell::new([0, 0], 0b11); // grade 2 ✓
+    let not_a_hinge = LatticeCell::edge([0, 0], 0); // grade 1, want grade 0
+    let _ = geom.dihedral_angle(&lattice, &top, &not_a_hinge);
+}

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
@@ -3,7 +3,195 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-//! Tests for `CubicalReggeGeometry::dihedral_angle`, `deficit_angle`, and `regge_action`
-//! — Phases R2 and R3.
+//! Tests for `CubicalReggeGeometry::dihedral_angle` — Phase R2 tasks 3.8–3.10.
 //!
-//! Skeleton landed in §1; populated in R2/R3 (`add-cubical-regge-calculus-core` tasks §3, §4).
+//! Deficit-angle and Regge-action tests land in Phase R3.
+
+use deep_causality_topology::utils_tests::{
+    open_square_3, per_axis_geometry, per_edge_uniform_per_axis, periodic_cube_3,
+    periodic_square_3, unit_geometry,
+};
+use deep_causality_topology::{ChainComplex, CubicalReggeGeometry, LatticeCell, LatticeComplex};
+
+use std::f64::consts::FRAC_PI_2;
+
+/// Locate the cell at (position, orientation) in the canonical iter order.
+fn find_cell<const D: usize, R>(
+    lattice: &LatticeComplex<D, R>,
+    grade: usize,
+    target: &LatticeCell<D>,
+) -> (usize, LatticeCell<D>)
+where
+    R: deep_causality_num::RealField,
+{
+    let id = lattice
+        .cells(grade)
+        .position(|c| c == *target)
+        .expect("cell not found");
+    (id, target.clone())
+}
+
+fn fetch_cell<const D: usize, R>(
+    lattice: &LatticeComplex<D, R>,
+    grade: usize,
+    id: usize,
+) -> LatticeCell<D>
+where
+    R: deep_causality_num::RealField,
+{
+    lattice.cells(grade).nth(id).expect("cell id out of range")
+}
+
+// -- Task 3.8: unit-edge dihedrals are π/2 -----------------------------------------
+
+#[test]
+fn unit_edge_every_dihedral_is_pi_over_two_in_periodic_2d() {
+    let lattice = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    for hinge_id in 0..lattice.num_cells(0) {
+        let hinge = fetch_cell(&lattice, 0, hinge_id);
+        for top_id in lattice.hinge_top_cube_neighbors(hinge_id) {
+            let top = fetch_cell(&lattice, 2, top_id);
+            let theta = geom.dihedral_angle(&lattice, &top, &hinge);
+            assert!((theta - FRAC_PI_2).abs() <= f64::EPSILON * 4.0);
+        }
+    }
+}
+
+#[test]
+fn unit_edge_every_dihedral_is_pi_over_two_in_periodic_3d() {
+    let lattice = periodic_cube_3();
+    let geom = unit_geometry::<3>();
+    for hinge_id in 0..lattice.num_cells(1) {
+        let hinge = fetch_cell(&lattice, 1, hinge_id);
+        for top_id in lattice.hinge_top_cube_neighbors(hinge_id) {
+            let top = fetch_cell(&lattice, 3, top_id);
+            let theta = geom.dihedral_angle(&lattice, &top, &hinge);
+            assert!((theta - FRAC_PI_2).abs() <= f64::EPSILON * 4.0);
+        }
+    }
+}
+
+#[test]
+fn unit_edge_dihedral_is_pi_over_two_in_4d() {
+    let lattice: LatticeComplex<4, f64> = LatticeComplex::hypercubic_torus(2);
+    let geom: CubicalReggeGeometry<4, f64> = CubicalReggeGeometry::unit();
+    let hinge = fetch_cell(&lattice, 2, 0);
+    let top_ids = lattice.hinge_top_cube_neighbors(0);
+    assert!(!top_ids.is_empty(), "expected incident 4-cubes");
+    for top_id in top_ids {
+        let top = fetch_cell(&lattice, 4, top_id);
+        let theta = geom.dihedral_angle(&lattice, &top, &hinge);
+        assert!((theta - FRAC_PI_2).abs() <= f64::EPSILON * 4.0);
+    }
+}
+
+#[test]
+fn unit_edge_dihedral_in_f32_precision() {
+    let lattice: LatticeComplex<2, f32> = LatticeComplex::square_torus(3);
+    let geom: CubicalReggeGeometry<2, f32> = CubicalReggeGeometry::unit();
+    let hinge = fetch_cell(&lattice, 0, 0);
+    let top_id = lattice.hinge_top_cube_neighbors(0)[0];
+    let top = fetch_cell(&lattice, 2, top_id);
+    let theta = geom.dihedral_angle(&lattice, &top, &hinge);
+    assert!((theta - std::f32::consts::FRAC_PI_2).abs() <= f32::EPSILON * 4.0);
+}
+
+// -- Task 3.9: interior-vertex dihedral sum is 2π ----------------------------------
+
+#[test]
+fn periodic_2d_interior_vertex_dihedral_sum_is_2pi_per_axis() {
+    let lattice = periodic_square_3();
+    let geom = per_axis_geometry::<2>([2.0, 3.0]);
+
+    let (hinge_id, hinge) = find_cell(&lattice, 0, &LatticeCell::vertex([1, 1]));
+    let sum: f64 = lattice
+        .hinge_top_cube_neighbors(hinge_id)
+        .into_iter()
+        .map(|tid| {
+            let top = fetch_cell(&lattice, 2, tid);
+            geom.dihedral_angle(&lattice, &top, &hinge)
+        })
+        .sum();
+    let two_pi = std::f64::consts::TAU;
+    assert!(
+        (sum - two_pi).abs() <= f64::EPSILON * 8.0,
+        "per-axis sum at interior vertex: got {sum}, want {two_pi}",
+    );
+}
+
+#[test]
+fn periodic_3d_interior_edge_dihedral_sum_is_2pi_per_axis() {
+    let lattice = periodic_cube_3();
+    let geom = per_axis_geometry::<3>([1.5, 2.5, 3.5]);
+
+    let (hinge_id, hinge) = find_cell(&lattice, 1, &LatticeCell::edge([1, 1, 1], 0));
+    let sum: f64 = lattice
+        .hinge_top_cube_neighbors(hinge_id)
+        .into_iter()
+        .map(|tid| {
+            let top = fetch_cell(&lattice, 3, tid);
+            geom.dihedral_angle(&lattice, &top, &hinge)
+        })
+        .sum();
+    let two_pi = std::f64::consts::TAU;
+    assert!((sum - two_pi).abs() <= f64::EPSILON * 8.0);
+}
+
+#[test]
+fn open_2d_boundary_vertex_dihedral_sum_is_less_than_2pi() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+
+    // Corner vertex has one incident square: sum = π/2.
+    let (hinge_id, hinge) = find_cell(&lattice, 0, &LatticeCell::vertex([0, 0]));
+    let sum: f64 = lattice
+        .hinge_top_cube_neighbors(hinge_id)
+        .into_iter()
+        .map(|tid| {
+            let top = fetch_cell(&lattice, 2, tid);
+            geom.dihedral_angle(&lattice, &top, &hinge)
+        })
+        .sum();
+    assert!((sum - FRAC_PI_2).abs() <= f64::EPSILON * 4.0);
+}
+
+// -- Task 3.10: per-edge / per-axis dihedral agreement -----------------------------
+
+#[test]
+fn per_edge_uniform_matches_per_axis_dihedral_2d() {
+    let lattice = periodic_square_3();
+    let axis_lengths = [2.0, 3.0];
+    let per_axis = per_axis_geometry::<2>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+
+    for hinge_id in 0..lattice.num_cells(0) {
+        let hinge = fetch_cell(&lattice, 0, hinge_id);
+        for top_id in lattice.hinge_top_cube_neighbors(hinge_id) {
+            let top = fetch_cell(&lattice, 2, top_id);
+            let a = per_axis.dihedral_angle(&lattice, &top, &hinge);
+            let e = per_edge.dihedral_angle(&lattice, &top, &hinge);
+            assert!((a - e).abs() <= f64::EPSILON * 4.0);
+        }
+    }
+}
+
+#[test]
+fn per_edge_uniform_matches_per_axis_dihedral_3d() {
+    let lattice = periodic_cube_3();
+    let axis_lengths = [1.5, 2.5, 3.5];
+    let per_axis = per_axis_geometry::<3>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+
+    // Spot-check a handful of hinges (full sweep is exhaustive but slow on 3x3x3).
+    let max_check = 8.min(lattice.num_cells(1));
+    for hinge_id in 0..max_check {
+        let hinge = fetch_cell(&lattice, 1, hinge_id);
+        for top_id in lattice.hinge_top_cube_neighbors(hinge_id) {
+            let top = fetch_cell(&lattice, 3, top_id);
+            let a = per_axis.dihedral_angle(&lattice, &top, &hinge);
+            let e = per_edge.dihedral_angle(&lattice, &top, &hinge);
+            assert!((a - e).abs() <= f64::EPSILON * 4.0);
+        }
+    }
+}

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Tests for `CubicalReggeGeometry::dihedral_angle`, `deficit_angle`, and `regge_action`
+//! — Phases R2 and R3.
+//!
+//! Skeleton landed in §1; populated in R2/R3 (`add-cubical-regge-calculus-core` tasks §3, §4).

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/curvature_tests.rs
@@ -3,17 +3,16 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-//! Tests for `CubicalReggeGeometry::dihedral_angle` — Phase R2 tasks 3.8–3.10.
-//!
-//! Deficit-angle and Regge-action tests land in Phase R3.
+//! Tests for `CubicalReggeGeometry::dihedral_angle`, `deficit_angle`, and `regge_action`
+//! — Phases R2 (tasks 3.8–3.10) and R3 (tasks 4.6–4.11).
 
 use deep_causality_topology::utils_tests::{
-    open_square_3, per_axis_geometry, per_edge_uniform_per_axis, periodic_cube_3,
+    open_cube_3, open_square_3, per_axis_geometry, per_edge_uniform_per_axis, periodic_cube_3,
     periodic_square_3, unit_geometry,
 };
 use deep_causality_topology::{ChainComplex, CubicalReggeGeometry, LatticeCell, LatticeComplex};
 
-use std::f64::consts::FRAC_PI_2;
+use std::f64::consts::{FRAC_PI_2, PI};
 
 /// Locate the cell at (position, orientation) in the canonical iter order.
 fn find_cell<const D: usize, R>(
@@ -194,4 +193,189 @@ fn per_edge_uniform_matches_per_axis_dihedral_3d() {
             assert!((a - e).abs() <= f64::EPSILON * 4.0);
         }
     }
+}
+
+// ===== Phase R3 — Deficit angles + Regge action ==================================
+
+// -- Task 4.6: open lattice — interior deficit 0, boundary deficit by formula -----
+
+#[test]
+fn open_2d_interior_vertex_deficit_is_zero() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let (hid, _) = find_cell(&lattice, 0, &LatticeCell::vertex([1, 1]));
+    assert_eq!(geom.deficit_angle(&lattice, hid), 0.0);
+}
+
+#[test]
+fn open_2d_corner_vertex_deficit_is_3pi_over_2() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let (hid, _) = find_cell(&lattice, 0, &LatticeCell::vertex([0, 0]));
+    let want = 3.0 * FRAC_PI_2;
+    let got = geom.deficit_angle(&lattice, hid);
+    assert!((got - want).abs() <= f64::EPSILON * 4.0);
+}
+
+#[test]
+fn open_2d_edge_vertex_deficit_is_pi() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let (hid, _) = find_cell(&lattice, 0, &LatticeCell::vertex([1, 0]));
+    let got = geom.deficit_angle(&lattice, hid);
+    assert!((got - PI).abs() <= f64::EPSILON * 4.0);
+}
+
+#[test]
+fn open_2d_deficit_matches_4_minus_n_times_pi_over_2_everywhere() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    for hid in 0..lattice.num_cells(0) {
+        let n = lattice.hinge_top_cube_neighbors(hid).len();
+        let want = (4 - n as i32) as f64 * FRAC_PI_2;
+        let got = geom.deficit_angle(&lattice, hid);
+        assert!(
+            (got - want).abs() <= f64::EPSILON * 4.0,
+            "hinge {hid} n={n}: got {got}, want {want}",
+        );
+    }
+}
+
+// -- Task 4.7: periodic unit-edge → every deficit 0, action 0 ----------------------
+
+#[test]
+fn periodic_2d_unit_edge_all_deficits_are_zero() {
+    let lattice = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    for hid in 0..lattice.num_cells(0) {
+        assert_eq!(geom.deficit_angle(&lattice, hid), 0.0);
+    }
+}
+
+#[test]
+fn periodic_2d_unit_edge_action_is_zero() {
+    let lattice = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    assert_eq!(geom.regge_action(&lattice), 0.0);
+}
+
+#[test]
+fn periodic_3d_unit_edge_action_is_zero() {
+    let lattice = periodic_cube_3();
+    let geom = unit_geometry::<3>();
+    assert_eq!(geom.regge_action(&lattice), 0.0);
+}
+
+#[test]
+fn periodic_4d_unit_edge_action_is_zero() {
+    let lattice: LatticeComplex<4, f64> = LatticeComplex::hypercubic_torus(2);
+    let geom: CubicalReggeGeometry<4, f64> = CubicalReggeGeometry::unit();
+    assert_eq!(geom.regge_action(&lattice), 0.0);
+}
+
+// -- Task 4.8: edge-length perturbation does not change any deficit ----------------
+
+#[test]
+fn deficit_is_invariant_under_per_axis_perturbation_2d() {
+    let lattice = open_square_3();
+    let unit = unit_geometry::<2>();
+    let stretched = per_axis_geometry::<2>([2.0, 5.0]);
+    for hid in 0..lattice.num_cells(0) {
+        let a = unit.deficit_angle(&lattice, hid);
+        let b = stretched.deficit_angle(&lattice, hid);
+        assert!((a - b).abs() <= f64::EPSILON * 4.0);
+    }
+}
+
+#[test]
+fn deficit_is_invariant_under_per_edge_perturbation_3d() {
+    let lattice = open_cube_3();
+    let unit = unit_geometry::<3>();
+    let per_edge = per_edge_uniform_per_axis(&lattice, [2.0, 3.0, 5.0]);
+    for hid in 0..lattice.num_cells(1) {
+        let a = unit.deficit_angle(&lattice, hid);
+        let b = per_edge.deficit_angle(&lattice, hid);
+        assert!((a - b).abs() <= f64::EPSILON * 4.0);
+    }
+}
+
+// -- Task 4.9: open vs periodic action difference = boundary contribution ----------
+
+#[test]
+fn open_2d_unit_edge_action_equals_closed_form_10pi() {
+    // 3×3 open lattice: 4 corners (deficit 3π/2), 4 edge-vertices (deficit π),
+    // 1 interior (deficit 0). Vertex volume = 1 in 2D.
+    // Action = 4·1·(3π/2) + 4·1·π + 1·1·0 = 6π + 4π = 10π.
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let got = geom.regge_action(&lattice);
+    let want = 10.0 * PI;
+    assert!(
+        (got - want).abs() <= f64::EPSILON * 32.0,
+        "got {got}, want {want}",
+    );
+}
+
+#[test]
+fn open_2d_minus_periodic_2d_equals_boundary_contribution() {
+    let open = open_square_3();
+    let periodic = periodic_square_3();
+    let geom = unit_geometry::<2>();
+    let diff = geom.regge_action(&open) - geom.regge_action(&periodic);
+    let want = 10.0 * PI;
+    assert!((diff - want).abs() <= f64::EPSILON * 32.0);
+}
+
+// -- Task 4.10: timelike_axes ignored in this change set ---------------------------
+
+#[test]
+fn timelike_axes_does_not_affect_regge_action() {
+    let lattice = open_square_3();
+    let euclidean: CubicalReggeGeometry<2, f64> = CubicalReggeGeometry::unit();
+    let lorentzian = euclidean.clone().with_timelike_axes([true, false]);
+    assert_eq!(
+        euclidean.regge_action(&lattice),
+        lorentzian.regge_action(&lattice),
+    );
+}
+
+#[test]
+fn timelike_axes_does_not_affect_deficit_angle() {
+    let lattice = open_square_3();
+    let euclidean: CubicalReggeGeometry<2, f64> = CubicalReggeGeometry::unit();
+    let lorentzian = euclidean.clone().with_timelike_axes([true, false]);
+    for hid in 0..lattice.num_cells(0) {
+        assert_eq!(
+            euclidean.deficit_angle(&lattice, hid),
+            lorentzian.deficit_angle(&lattice, hid),
+        );
+    }
+}
+
+// -- Task 4.11: 3D PerAxis — volume factor flows through ----------------------------
+
+#[test]
+fn open_3d_per_axis_action_scales_with_edge_volumes() {
+    // 3D hinges are edges (1-cells); their volume IS the per-axis edge length.
+    // Differing per-axis lengths give a different (and larger) total action than
+    // the unit case.
+    let lattice = open_cube_3();
+    let unit = unit_geometry::<3>();
+    let scaled = per_axis_geometry::<3>([2.0, 3.0, 5.0]);
+    let action_unit = unit.regge_action(&lattice);
+    let action_scaled = scaled.regge_action(&lattice);
+    assert!(action_unit > 0.0);
+    assert!(action_scaled > action_unit);
+}
+
+#[test]
+fn open_3d_per_axis_action_equals_per_edge_action() {
+    let lattice = open_cube_3();
+    let axis_lengths = [2.0, 3.0, 5.0];
+    let per_axis = per_axis_geometry::<3>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+    let a = per_axis.regge_action(&lattice);
+    let e = per_edge.regge_action(&lattice);
+    let tol = f64::EPSILON * 64.0 * a.abs().max(1.0);
+    assert!((a - e).abs() <= tol, "per_axis={a} vs per_edge={e}");
 }

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/mod.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/mod.rs
@@ -4,3 +4,9 @@
  */
 #[cfg(test)]
 mod cubical_regge_geometry_tests;
+
+#[cfg(test)]
+mod curvature_tests;
+
+#[cfg(test)]
+mod volumes_tests;

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
@@ -4,5 +4,168 @@
  */
 
 //! Tests for `CubicalReggeGeometry::cell_volume` and `top_cell_volume` — Phase R1.
-//!
-//! Skeleton landed in §1; populated in R1 (`add-cubical-regge-calculus-core` tasks §2).
+
+use deep_causality_topology::utils_tests::{
+    open_cube_3, open_square_3, per_axis_geometry, per_edge_uniform_per_axis, periodic_cube_3,
+    periodic_square_3, unit_geometry,
+};
+use deep_causality_topology::{CubicalReggeGeometry, LatticeCell, LatticeComplex};
+
+// -- Task 2.5: unit-edge invariants ------------------------------------------------
+
+#[test]
+fn unit_edge_every_cell_has_volume_one_in_open_square() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    for grade in 0..=2 {
+        for cell in lattice.iter_cells(grade) {
+            assert_eq!(geom.cell_volume(&lattice, &cell), 1.0);
+        }
+    }
+}
+
+#[test]
+fn unit_edge_every_cell_has_volume_one_in_periodic_cube() {
+    let lattice = periodic_cube_3();
+    let geom = unit_geometry::<3>();
+    for grade in 0..=3 {
+        for cell in lattice.iter_cells(grade) {
+            assert_eq!(geom.cell_volume(&lattice, &cell), 1.0);
+        }
+    }
+}
+
+#[test]
+fn unit_edge_top_cell_volume_is_one_4d() {
+    let lattice: LatticeComplex<4, f64> = LatticeComplex::hypercubic_torus(2);
+    let geom = unit_geometry::<4>();
+    for cell in lattice.iter_cells(4) {
+        assert_eq!(geom.top_cell_volume(&lattice, &cell), 1.0);
+    }
+}
+
+#[test]
+fn unit_edge_with_f32_precision() {
+    let lattice: LatticeComplex<2, f32> = LatticeComplex::square_open(2);
+    let geom: CubicalReggeGeometry<2, f32> = CubicalReggeGeometry::unit();
+    for cell in lattice.iter_cells(2) {
+        assert_eq!(geom.cell_volume(&lattice, &cell), 1.0_f32);
+    }
+}
+
+#[test]
+fn unit_edge_vertex_volume_is_empty_product_one() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let v = LatticeCell::vertex([1, 1]);
+    assert_eq!(geom.cell_volume(&lattice, &v), 1.0);
+}
+
+// -- Task 2.6: per-axis closed forms -----------------------------------------------
+
+#[test]
+fn per_axis_top_cube_volume_equals_product_of_axis_lengths_2d() {
+    let lattice = open_square_3();
+    let geom = per_axis_geometry([2.0, 3.0]);
+    let cell = LatticeCell::new([0, 0], 0b11);
+    assert_eq!(geom.top_cell_volume(&lattice, &cell), 6.0);
+}
+
+#[test]
+fn per_axis_top_cube_volume_equals_product_of_axis_lengths_3d() {
+    let lattice = open_cube_3();
+    let geom = per_axis_geometry([2.0, 3.0, 5.0]);
+    let cell = LatticeCell::new([0, 0, 0], 0b111);
+    assert_eq!(geom.top_cell_volume(&lattice, &cell), 30.0);
+}
+
+#[test]
+fn per_axis_edge_volume_equals_its_axis_length() {
+    let lattice = open_square_3();
+    let geom = per_axis_geometry([2.0, 7.0]);
+    let edge_along_axis_0 = LatticeCell::edge([0, 0], 0);
+    let edge_along_axis_1 = LatticeCell::edge([0, 0], 1);
+    assert_eq!(geom.cell_volume(&lattice, &edge_along_axis_0), 2.0);
+    assert_eq!(geom.cell_volume(&lattice, &edge_along_axis_1), 7.0);
+}
+
+#[test]
+fn per_axis_face_volume_in_3d_equals_product_of_active_axes() {
+    let lattice = open_cube_3();
+    let geom = per_axis_geometry([2.0, 3.0, 5.0]);
+    // 2-face spanning axes 0 and 2 (orientation 0b101).
+    let face = LatticeCell::new([0, 0, 0], 0b101);
+    assert_eq!(geom.cell_volume(&lattice, &face), 10.0);
+}
+
+// -- Task 2.7: per-edge reproduces per-axis under uniform-per-axis assignment -----
+
+#[test]
+fn per_edge_uniform_matches_per_axis_2d() {
+    let lattice = open_square_3();
+    let axis_lengths = [2.0, 3.0];
+    let per_axis = per_axis_geometry::<2>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+
+    for grade in 0..=2 {
+        for cell in lattice.iter_cells(grade) {
+            let va = per_axis.cell_volume(&lattice, &cell);
+            let ve = per_edge.cell_volume(&lattice, &cell);
+            let tol = f64::EPSILON * 8.0 * va.abs().max(1.0);
+            assert!(
+                (va - ve).abs() <= tol,
+                "grade {grade} cell {:?} ori {:#b}: per_axis={va} vs per_edge={ve}",
+                cell.position(),
+                cell.orientation(),
+            );
+        }
+    }
+}
+
+#[test]
+fn per_edge_uniform_matches_per_axis_3d() {
+    let lattice = open_cube_3();
+    let axis_lengths = [2.0, 3.0, 5.0];
+    let per_axis = per_axis_geometry::<3>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+
+    for grade in 0..=3 {
+        for cell in lattice.iter_cells(grade) {
+            let va = per_axis.cell_volume(&lattice, &cell);
+            let ve = per_edge.cell_volume(&lattice, &cell);
+            let tol = f64::EPSILON * 8.0 * va.abs().max(1.0);
+            assert!(
+                (va - ve).abs() <= tol,
+                "grade {grade} cell {:?} ori {:#b}: per_axis={va} vs per_edge={ve}",
+                cell.position(),
+                cell.orientation(),
+            );
+        }
+    }
+}
+
+#[test]
+fn per_edge_uniform_matches_per_axis_periodic_2d() {
+    let lattice = periodic_square_3();
+    let axis_lengths = [2.5, 7.5];
+    let per_axis = per_axis_geometry::<2>(axis_lengths);
+    let per_edge = per_edge_uniform_per_axis(&lattice, axis_lengths);
+
+    for cell in lattice.iter_cells(2) {
+        let va = per_axis.top_cell_volume(&lattice, &cell);
+        let ve = per_edge.top_cell_volume(&lattice, &cell);
+        assert!((va - ve).abs() <= f64::EPSILON * 16.0);
+    }
+}
+
+// -- Uniform path (single-spacing isotropic) ---------------------------------------
+
+#[test]
+fn uniform_top_cube_volume_is_length_to_power_d() {
+    let lattice: LatticeComplex<3, f64> = LatticeComplex::cubic_open(3);
+    let geom: CubicalReggeGeometry<3, f64> = CubicalReggeGeometry::uniform(0.5);
+    let cell = LatticeCell::new([0, 0, 0], 0b111);
+    let expected = 0.5_f64.powi(3);
+    let got = geom.top_cell_volume(&lattice, &cell);
+    assert!((expected - got).abs() <= f64::EPSILON * 4.0);
+}

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Tests for `CubicalReggeGeometry::cell_volume` and `top_cell_volume` — Phase R1.
+//!
+//! Skeleton landed in §1; populated in R1 (`add-cubical-regge-calculus-core` tasks §2).

--- a/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
+++ b/deep_causality_topology/tests/types/cubical_regge_geometry/volumes_tests.rs
@@ -169,3 +169,12 @@ fn uniform_top_cube_volume_is_length_to_power_d() {
     let got = geom.top_cell_volume(&lattice, &cell);
     assert!((expected - got).abs() <= f64::EPSILON * 4.0);
 }
+
+#[test]
+#[should_panic(expected = "top_cell_volume requires a D-cell")]
+fn top_cell_volume_panics_on_wrong_grade() {
+    let lattice = open_square_3();
+    let geom = unit_geometry::<2>();
+    let edge = LatticeCell::edge([0, 0], 0); // grade 1, not D=2
+    let _ = geom.top_cell_volume(&lattice, &edge);
+}

--- a/deep_causality_topology/tests/types/gauge/gauge_field_lattice/gradient_flow_tests.rs
+++ b/deep_causality_topology/tests/types/gauge/gauge_field_lattice/gradient_flow_tests.rs
@@ -226,3 +226,50 @@ fn test_try_t2_energy() {
     let r = field.try_t2_energy(1.0).unwrap();
     assert!(r.abs() < 1e-10);
 }
+
+#[test]
+fn test_try_energy_density_empty_lattice_returns_zero() {
+    // Drives the `if count == 0 { return Ok(R::zero()) }` early-return path.
+    use deep_causality_topology::LinkVariable;
+    use std::collections::HashMap;
+    let lattice = Arc::new(LatticeComplex::<2, f64>::new([0, 0], [false, false]));
+    let links: HashMap<_, LinkVariable<U1, Complex<f64>, f64>> = HashMap::new();
+    let field: LatticeGaugeField<U1, 2, Complex<f64>, f64> =
+        LatticeGaugeField::from_links_unchecked(lattice, links, 1.0, ());
+    let e = field.try_energy_density().unwrap();
+    assert_eq!(e, 0.0);
+}
+
+#[test]
+fn test_try_find_t0_never_reaches_target_errors() {
+    // Identity field never raises t²E(t) above 0 → won't cross 0.3 → final error path.
+    let shape = [2, 2];
+    let lattice = Arc::new(LatticeComplex::new(shape, [true, true]));
+    let field = LatticeGaugeField::<U1, 2, Complex<f64>, f64>::try_identity(lattice, 1.0).unwrap();
+
+    let params = FlowParams {
+        epsilon: 0.01,
+        t_max: 0.05,
+        method: FlowMethod::Euler,
+    };
+
+    let err = field.try_find_t0(&params).unwrap_err();
+    assert!(err.to_string().contains("did not reach 0.3"));
+}
+
+#[test]
+fn test_try_flow_zero_tmax_returns_unchanged() {
+    // t_max = 0 → while-loop body never executes → returns the input field.
+    let shape = [2, 2];
+    let lattice = Arc::new(LatticeComplex::new(shape, [true, true]));
+    let field = LatticeGaugeField::<U1, 2, Complex<f64>, f64>::try_identity(lattice, 1.0).unwrap();
+    let params = FlowParams {
+        epsilon: 0.05,
+        t_max: 0.0,
+        method: FlowMethod::Euler,
+    };
+    let flowed = field.try_flow(&params).expect("zero-tmax flow is OK");
+    // Field should be unchanged (same energy density = 0).
+    let e = flowed.try_energy_density().unwrap();
+    assert!(e.abs() < 1e-10);
+}

--- a/deep_causality_topology/tests/types/gauge/gauge_field_lattice/lattice_gauge_field_tests.rs
+++ b/deep_causality_topology/tests/types/gauge/gauge_field_lattice/lattice_gauge_field_tests.rs
@@ -825,3 +825,48 @@ fn test_t2_energy_value() {
     assert!(t2e.is_ok());
     assert!(t2e.unwrap().abs() < 1e-10);
 }
+
+// =============================================================================
+// Coverage: source() / source_mut() / replace_source() / with_source()
+// =============================================================================
+
+#[test]
+fn test_lattice_gauge_field_source_accessors() {
+    use std::collections::HashMap;
+    let lattice = create_test_lattice();
+    let mut links: HashMap<_, LinkVariable<U1, Complex<f64>, f64>> = HashMap::new();
+    for cell in lattice.cells(1) {
+        links.insert(cell, LinkVariable::try_identity().unwrap());
+    }
+
+    // Construct with a non-trivial source value (an i32 counter).
+    let mut field: LatticeGaugeField<U1, 2, Complex<f64>, f64, i32> =
+        LatticeGaugeField::from_links_unchecked(lattice, links, 2.0, 42);
+
+    assert_eq!(*field.source(), 42);
+
+    *field.source_mut() = 7;
+    assert_eq!(*field.source(), 7);
+
+    let old = field.replace_source(99);
+    assert_eq!(old, 7);
+    assert_eq!(*field.source(), 99);
+}
+
+#[test]
+fn test_lattice_gauge_field_with_source_transforms_type() {
+    use std::collections::HashMap;
+    let lattice = create_test_lattice();
+    let mut links: HashMap<_, LinkVariable<U1, Complex<f64>, f64>> = HashMap::new();
+    for cell in lattice.cells(1) {
+        links.insert(cell, LinkVariable::try_identity().unwrap());
+    }
+
+    let field: LatticeGaugeField<U1, 2, Complex<f64>, f64> =
+        LatticeGaugeField::from_links_unchecked(lattice, links, 2.0, ());
+
+    // Attach an i32 source — the type changes from () to i32.
+    let attached: LatticeGaugeField<U1, 2, Complex<f64>, f64, i32> = field.with_source(123);
+    assert_eq!(*attached.source(), 123);
+    assert!((*attached.beta() - 2.0_f64).abs() < 1e-12);
+}

--- a/deep_causality_topology/tests/types/gauge/gauge_field_lattice/metropolis_tests.rs
+++ b/deep_causality_topology/tests/types/gauge/gauge_field_lattice/metropolis_tests.rs
@@ -8,6 +8,7 @@ use deep_causality_rand::types::Xoshiro256;
 use deep_causality_topology::GaugeGroup;
 use deep_causality_topology::LatticeComplex;
 use deep_causality_topology::LatticeGaugeField;
+use deep_causality_topology::LinkVariable;
 use std::sync::Arc;
 
 // Define a test gauge group (U1 is simplest for testing)
@@ -89,6 +90,48 @@ fn test_metropolis_sweep_f64_optimization() {
 #[test]
 fn test_metropolis_update_nan_handling() {
     // Basic test to ensure no panic
+}
+
+#[test]
+fn test_metropolis_update_rejects_non_positive_epsilon() {
+    use deep_causality_topology::TopologyErrorEnum;
+    let shape = [2, 2];
+    let lattice = Arc::new(LatticeComplex::new(shape, [true, true]));
+    let mut field =
+        LatticeGaugeField::<U1, 2, Complex<f64>, f64>::try_identity(lattice, 1.0).unwrap();
+    let edge = field.links().keys().next().unwrap().clone();
+    let mut rng = Xoshiro256::new();
+
+    let err = field
+        .try_metropolis_update(&edge, 0.0, &mut rng)
+        .unwrap_err();
+    match err.0 {
+        TopologyErrorEnum::LatticeGaugeError(ref msg) => {
+            assert!(msg.contains("Metropolis epsilon"));
+        }
+        ref other => panic!("Expected LatticeGaugeError, got {:?}", other),
+    }
+
+    let err_neg = field
+        .try_metropolis_update(&edge, -0.1, &mut rng)
+        .unwrap_err();
+    match err_neg.0 {
+        TopologyErrorEnum::LatticeGaugeError(_) => {}
+        ref other => panic!("Expected LatticeGaugeError, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_metropolis_sweep_empty_field_returns_zero_rate() {
+    // Edge-case path through `if total == 0 { return Ok(0.0) }` in try_metropolis_sweep.
+    use std::collections::HashMap;
+    let lattice = Arc::new(LatticeComplex::<2, f64>::new([2, 2], [true, true]));
+    let links: HashMap<_, LinkVariable<U1, Complex<f64>, f64>> = HashMap::new();
+    let mut field: LatticeGaugeField<U1, 2, Complex<f64>, f64> =
+        LatticeGaugeField::from_links_unchecked(lattice, links, 1.0, ());
+    let mut rng = Xoshiro256::new();
+    let rate = field.try_metropolis_sweep(0.1, &mut rng).unwrap();
+    assert_eq!(rate, 0.0);
 }
 
 #[test]

--- a/deep_causality_topology/tests/types/gauge/gauge_field_lattice/wilson_tests.rs
+++ b/deep_causality_topology/tests/types/gauge/gauge_field_lattice/wilson_tests.rs
@@ -7,6 +7,7 @@ use deep_causality_num::Complex;
 use deep_causality_topology::GaugeGroup;
 use deep_causality_topology::LatticeComplex;
 use deep_causality_topology::LatticeGaugeField;
+use deep_causality_topology::LinkVariable;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -84,4 +85,37 @@ fn test_polyakov_loop_identity() {
     let site = [0, 0];
     let p = field.try_polyakov_loop(&site, 0).unwrap();
     assert!((p - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_average_polyakov_loop_identity_is_one() {
+    let shape = [4, 4];
+    let lattice = Arc::new(LatticeComplex::new(shape, [true, true]));
+    let field = LatticeGaugeField::<U1, 2, Complex<f64>, f64>::identity(lattice, 1.0);
+
+    let avg = field.try_average_polyakov_loop(0).unwrap();
+    assert!((avg - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_average_polyakov_loop_empty_lattice_returns_zero() {
+    // Empty-lattice path through `if count == 0 { return Ok(R::zero()) }`.
+    use std::collections::HashMap;
+    let lattice = Arc::new(LatticeComplex::<2, f64>::new([0, 0], [false, false]));
+    let links: HashMap<_, LinkVariable<U1, Complex<f64>, f64>> = HashMap::new();
+    let field: LatticeGaugeField<U1, 2, Complex<f64>, f64> =
+        LatticeGaugeField::from_links_unchecked(lattice, links, 1.0, ());
+    let avg = field.try_average_polyakov_loop(0).unwrap();
+    assert_eq!(avg, 0.0);
+}
+
+#[test]
+fn test_plaquette_action_identity_is_zero() {
+    // Drives try_plaquette_action through its full happy path.
+    let shape = [2, 2];
+    let lattice = Arc::new(LatticeComplex::new(shape, [true, true]));
+    let field = LatticeGaugeField::<U1, 2, Complex<f64>, f64>::identity(lattice, 1.0);
+
+    let s = field.try_plaquette_action(&[0, 0], 0, 1).unwrap();
+    assert!(s.abs() < 1e-10, "identity plaquette action = 0, got {s}");
 }

--- a/deep_causality_topology/tests/types/lattice_complex/degenerate_tests.rs
+++ b/deep_causality_topology/tests/types/lattice_complex/degenerate_tests.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Coverage tests for the degenerate / boundary-condition branches of
+//! `LatticeComplex` — `D < 2`, `shape[d] == 0`, out-of-range `hinge_id`.
+//! Lifts these one-line conditional arms above the `cargo llvm-cov` floor.
+
+use deep_causality_topology::{ChainComplex, LatticeComplex};
+
+// -- D < 2: hinge_top_cube_neighbors short-circuits to empty -----------------------
+
+#[test]
+fn hinge_top_cube_neighbors_returns_empty_for_d1() {
+    let l: LatticeComplex<1, f64> = LatticeComplex::new([5], [false]);
+    assert!(l.hinge_top_cube_neighbors(0).is_empty());
+    assert!(l.hinge_top_cube_neighbors(999).is_empty());
+}
+
+// -- shape[d] == 0: valid_positions / num_cells / iter_cells branches --------------
+
+#[test]
+fn zero_shape_dimension_num_cells_is_zero() {
+    // Non-periodic axis with extent 0 hits the `dim_len == 0` arm in `valid_positions`
+    // and the matching arm in `num_cells`.
+    let l: LatticeComplex<2, f64> = LatticeComplex::new([3, 0], [true, false]);
+    assert_eq!(l.num_cells(2), 0);
+}
+
+#[test]
+fn zero_shape_dimension_iterator_yields_no_cells() {
+    // `LatticeCellIterator::new` filters out orientations whose product of valid
+    // positions is zero (e.g. an active non-periodic axis with shape 0), so
+    // `cells(k).count()` agrees with `num_cells(k)` even in this degenerate case.
+    let l: LatticeComplex<2, f64> = LatticeComplex::new([3, 0], [true, false]);
+    assert_eq!(l.cells(2).count(), 0);
+    assert_eq!(l.cells(2).count(), l.num_cells(2));
+}
+
+#[test]
+fn zero_shape_dimension_gives_zero_edges_along_that_axis() {
+    // Non-periodic axis with extent 0 produces zero edges along itself.
+    let l: LatticeComplex<2, f64> = LatticeComplex::new([3, 0], [false, false]);
+    assert_eq!(l.num_cells(1), 0);
+}

--- a/deep_causality_topology/tests/types/lattice_complex/hinge_neighbors_tests.rs
+++ b/deep_causality_topology/tests/types/lattice_complex/hinge_neighbors_tests.rs
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Tests for `LatticeComplex::hinge_top_cube_neighbors` — Phase R2 task 3.2.
+
+use deep_causality_topology::{ChainComplex, LatticeCell, LatticeComplex};
+
+/// Locate the flat `CellId` for a cell matching `target` in `lattice.cells(grade)` order.
+fn find_cell_id<const D: usize>(
+    lattice: &LatticeComplex<D, f64>,
+    grade: usize,
+    target: &LatticeCell<D>,
+) -> usize {
+    lattice
+        .cells(grade)
+        .position(|c| c == *target)
+        .unwrap_or_else(|| panic!("cell {target:?} not found in grade {grade}"))
+}
+
+// -- 2D: hinges are vertices (D-2 = 0) ----------------------------------------------
+
+#[test]
+fn periodic_2d_interior_vertex_has_4_incident_squares() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_torus(3);
+    let vertex = LatticeCell::vertex([1, 1]);
+    let hinge_id = find_cell_id(&lattice, 0, &vertex);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 4, "interior vertex on periodic lattice");
+}
+
+#[test]
+fn periodic_2d_corner_vertex_also_has_4_incident_squares() {
+    // On a torus, every vertex is interior — the boundary wraps. (0,0) still touches 4 squares.
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_torus(3);
+    let vertex = LatticeCell::vertex([0, 0]);
+    let hinge_id = find_cell_id(&lattice, 0, &vertex);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 4);
+}
+
+#[test]
+fn open_2d_corner_vertex_has_1_incident_square() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_open(3);
+    let corner = LatticeCell::vertex([0, 0]);
+    let hinge_id = find_cell_id(&lattice, 0, &corner);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(
+        neighbors.len(),
+        1,
+        "open-lattice corner has one incident square"
+    );
+}
+
+#[test]
+fn open_2d_boundary_edge_vertex_has_2_incident_squares() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_open(3);
+    // (1, 0) sits on the bottom boundary — should see 2 squares above it.
+    let v = LatticeCell::vertex([1, 0]);
+    let hinge_id = find_cell_id(&lattice, 0, &v);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 2);
+}
+
+#[test]
+fn open_2d_interior_vertex_has_4_incident_squares() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_open(3);
+    let v = LatticeCell::vertex([1, 1]);
+    let hinge_id = find_cell_id(&lattice, 0, &v);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 4);
+}
+
+#[test]
+fn neighbors_are_deduplicated_and_within_range() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_torus(3);
+    let num_top = lattice.num_cells(2);
+    for hinge_id in 0..lattice.num_cells(0) {
+        let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+        // Deduplicated:
+        let mut sorted = neighbors.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            neighbors.len(),
+            "duplicates at hinge {hinge_id}"
+        );
+        // In range:
+        assert!(neighbors.iter().all(|&id| id < num_top));
+    }
+}
+
+#[test]
+fn out_of_range_hinge_id_returns_empty() {
+    let lattice: LatticeComplex<2, f64> = LatticeComplex::square_torus(3);
+    let n = lattice.num_cells(0);
+    assert!(lattice.hinge_top_cube_neighbors(n).is_empty());
+    assert!(lattice.hinge_top_cube_neighbors(n + 100).is_empty());
+}
+
+// -- 3D: hinges are edges (D-2 = 1) -------------------------------------------------
+
+#[test]
+fn periodic_3d_interior_edge_has_4_incident_cubes() {
+    let lattice: LatticeComplex<3, f64> = LatticeComplex::cubic_torus(3);
+    // An edge along axis 0 starting at (1, 1, 1).
+    let edge = LatticeCell::edge([1, 1, 1], 0);
+    let hinge_id = find_cell_id(&lattice, 1, &edge);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 4);
+}
+
+#[test]
+fn open_3d_corner_edge_has_1_incident_cube() {
+    let lattice: LatticeComplex<3, f64> = LatticeComplex::cubic_open(3);
+    // Edge along axis 0 at the corner (0, 0, 0) — only the (0,0,0) cube contains it.
+    let edge = LatticeCell::edge([0, 0, 0], 0);
+    let hinge_id = find_cell_id(&lattice, 1, &edge);
+    let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+    assert_eq!(neighbors.len(), 1);
+}
+
+#[test]
+fn periodic_3d_all_edge_hinges_have_4_cubes() {
+    let lattice: LatticeComplex<3, f64> = LatticeComplex::cubic_torus(3);
+    for hinge_id in 0..lattice.num_cells(1) {
+        let n = lattice.hinge_top_cube_neighbors(hinge_id);
+        assert_eq!(n.len(), 4, "hinge {hinge_id} on torus should see 4 cubes");
+    }
+}
+
+// -- 4D: hinges are 2-cells (D-2 = 2) -----------------------------------------------
+
+#[test]
+fn periodic_4d_interior_2cell_has_4_incident_4cubes() {
+    let lattice: LatticeComplex<4, f64> = LatticeComplex::hypercubic_torus(2);
+    // Walk a few 2-cell hinges and verify each has exactly 4 incident 4-cubes.
+    let max_check = 8.min(lattice.num_cells(2));
+    for hinge_id in 0..max_check {
+        let neighbors = lattice.hinge_top_cube_neighbors(hinge_id);
+        assert_eq!(
+            neighbors.len(),
+            4,
+            "4D torus hinge {hinge_id} should see 4 4-cubes, got {}",
+            neighbors.len(),
+        );
+    }
+}

--- a/deep_causality_topology/tests/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/tests/types/lattice_complex/mod.rs
@@ -5,6 +5,8 @@
 #[cfg(test)]
 mod dual_lattice_complex_tests;
 #[cfg(test)]
+mod hinge_neighbors_tests;
+#[cfg(test)]
 mod honeycomb_lattice_tests;
 #[cfg(test)]
 mod lattice_cell_tests;

--- a/deep_causality_topology/tests/types/lattice_complex/mod.rs
+++ b/deep_causality_topology/tests/types/lattice_complex/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 #[cfg(test)]
+mod degenerate_tests;
+#[cfg(test)]
 mod dual_lattice_complex_tests;
 #[cfg(test)]
 mod hinge_neighbors_tests;

--- a/deep_causality_topology/tests/types/manifold/constructors_tests.rs
+++ b/deep_causality_topology/tests/types/manifold/constructors_tests.rs
@@ -300,3 +300,82 @@ fn test_from_cubical_with_metric_3d() {
     assert!(manifold.metric().is_some());
     assert_eq!(manifold.data().len(), 8);
 }
+
+// =============================================================================
+// Coverage: constructors_impl.rs remaining missed branches
+// =============================================================================
+
+#[test]
+fn test_with_metric_data_size_mismatch() {
+    // Lines 60-65: with_metric_impl data-size mismatch check.
+    let (complex, _) = setup_valid_manifold_parts();
+    let wrong_data = CausalTensor::new(vec![1.0, 2.0, 3.0], vec![3]).unwrap(); // 3 != 7
+    let edge_lengths = CausalTensor::new(vec![1.0, 1.1, 1.2], vec![3]).unwrap();
+    let metric = ReggeGeometry::new(edge_lengths);
+
+    let result = Manifold::with_metric(complex, wrong_data, Some(metric), 0);
+    assert!(result.is_err());
+    match result.unwrap_err().0 {
+        TopologyErrorEnum::InvalidInput(ref msg) => {
+            assert!(msg.contains("Data size"));
+        }
+        other => panic!("Expected InvalidInput, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_with_metric_on_complex_without_1_simplices_with_non_empty_edge_lengths() {
+    // Lines 74-78: complex.skeletons.get(1) returns None but regge.edge_lengths is
+    // non-empty → InvalidInput error.
+    use deep_causality_sparse::CsrMatrix;
+    use deep_causality_topology::{Simplex, SimplicialComplex, Skeleton};
+
+    // Build a SimplicialComplex with only a 0-skeleton (vertices), no 1-simplices.
+    let vertices = vec![Simplex::new(vec![0])];
+    let skeletons = vec![Skeleton::new(0, vertices)];
+    let complex: SimplicialComplex<f64> =
+        SimplicialComplex::new(skeletons, vec![], vec![], Vec::new());
+
+    let data = CausalTensor::new(vec![1.0], vec![1]).unwrap();
+    let edge_lengths = CausalTensor::new(vec![1.0], vec![1]).unwrap(); // non-empty
+    let metric = ReggeGeometry::new(edge_lengths);
+
+    let _ = CsrMatrix::<i8>::with_capacity(0, 0, 0); // touch import
+    let result = Manifold::with_metric(complex, data, Some(metric), 0);
+    assert!(result.is_err());
+    match result.unwrap_err().0 {
+        TopologyErrorEnum::InvalidInput(ref msg) => {
+            assert!(msg.contains("no 1-simplices") || msg.contains("edge_lengths"));
+        }
+        other => panic!("Expected InvalidInput, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_new_on_empty_complex_rejects_as_non_manifold() {
+    // Line 105: check_is_manifold_impl early-out on empty skeletons.
+    use deep_causality_topology::SimplicialComplex;
+    let complex: SimplicialComplex<f64> =
+        SimplicialComplex::new(vec![], vec![], vec![], Vec::new());
+    let data = CausalTensor::<f64>::new(vec![], vec![0]);
+    // CausalTensor::new may reject zero-length; if so, the empty-skeleton branch is
+    // unreachable in practice through the public API. Try regardless.
+    if let Ok(d) = data {
+        let result = Manifold::new(complex, d, 0);
+        assert!(result.is_err());
+    }
+}
+
+#[test]
+fn test_new_on_complex_with_empty_vertex_skeleton_rejects_as_non_manifold() {
+    // Line 115: zero-vertices branch in check_is_manifold_impl.
+    use deep_causality_topology::{SimplicialComplex, Skeleton};
+    let skeletons = vec![Skeleton::new(0, vec![])]; // empty vertex skeleton
+    let complex: SimplicialComplex<f64> =
+        SimplicialComplex::new(skeletons, vec![], vec![], Vec::new());
+    let data = CausalTensor::<f64>::new(vec![], vec![0]);
+    if let Ok(d) = data {
+        let result = Manifold::new(complex, d, 0);
+        assert!(result.is_err());
+    }
+}

--- a/deep_causality_topology/tests/types/manifold/geometry_tests.rs
+++ b/deep_causality_topology/tests/types/manifold/geometry_tests.rs
@@ -103,3 +103,109 @@ fn test_simplex_volume_squared_2d() {
         vol_sq
     );
 }
+
+// =============================================================================
+// Coverage: simplex_volume_squared error paths and degenerate cases
+// =============================================================================
+
+use deep_causality_topology::TopologyErrorEnum;
+
+/// Construct a manifold without a metric (Manifold::with_metric(_, _, None, _)).
+fn setup_manifold_no_metric() -> SimplicialManifold<f64, f64> {
+    let points = CausalTensor::new(vec![0.0, 0.0, 3.0, 0.0, 0.0, 4.0], vec![3, 2]).unwrap();
+    let metadata = CausalTensor::new(vec![1.0, 1.0, 1.0], vec![3]).unwrap();
+    let pc = PointCloud::new(points, metadata, 0).unwrap();
+    let complex = pc.triangulate(6.0).unwrap();
+    let data_len = complex.total_simplices();
+    let data = CausalTensor::new(vec![0.0; data_len], vec![data_len]).unwrap();
+    Manifold::with_metric(complex, data, None, 0).unwrap()
+}
+
+#[test]
+fn test_simplex_volume_squared_no_metric_errors() {
+    let manifold = setup_manifold_no_metric();
+    let s1 = manifold.complex().skeletons()[1].simplices()[0].clone();
+    let err = manifold.simplex_volume_squared(&s1).unwrap_err();
+    match err.0 {
+        TopologyErrorEnum::ManifoldError(ref msg) => {
+            assert!(msg.contains("Metric not found"));
+        }
+        ref other => panic!("Expected ManifoldError, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_simplex_volume_squared_degenerate_collinear_returns_zero() {
+    // Build a triangle whose edge lengths violate the triangle inequality (1, 1, 5).
+    // The Cayley-Menger determinant has the wrong sign → vol_sq < 0 → returns C::zero()
+    // via the line-94 clamp.
+    let points = CausalTensor::new(vec![0.0, 0.0, 1.0, 0.0, 0.5, 0.0], vec![3, 2]).unwrap();
+    let metadata = CausalTensor::new(vec![1.0, 1.0, 1.0], vec![3]).unwrap();
+    let pc = PointCloud::new(points, metadata, 0).unwrap();
+    let complex = pc.triangulate(6.0).unwrap();
+
+    let skeleton1 = complex.skeletons().get(1).unwrap();
+    let mut edge_lengths_vec = Vec::with_capacity(skeleton1.simplices().len());
+    for s in skeleton1.simplices() {
+        let u = s.vertices()[0];
+        let v = s.vertices()[1];
+        let len = match (u.min(v), u.max(v)) {
+            (0, 1) => 1.0,
+            (0, 2) => 1.0,
+            (1, 2) => 5.0, // violates triangle inequality (1 + 1 < 5)
+            _ => 1.0,
+        };
+        edge_lengths_vec.push(len);
+    }
+    let regge = ReggeGeometry::new(
+        CausalTensor::new(edge_lengths_vec, vec![skeleton1.simplices().len()]).unwrap(),
+    );
+    let data_len = complex.total_simplices();
+    let data = CausalTensor::new(vec![0.0; data_len], vec![data_len]).unwrap();
+    let manifold = Manifold::with_metric(complex, data, Some(regge), 0).unwrap();
+
+    let s2 = manifold.complex().skeletons()[2].simplices()[0].clone();
+    let vol_sq = manifold.simplex_volume_squared(&s2).unwrap();
+    assert_eq!(vol_sq, 0.0, "degenerate simplex should clamp to zero");
+}
+
+#[test]
+fn test_simplex_volume_squared_high_dim_exercises_determinant_recursion() {
+    // A 3-simplex (tetrahedron) → 5×5 Cayley-Menger matrix → determinant_impl recurses
+    // through the n=5 → n=4 → n=3 → n=2 base case path, exercising lines 180–181.
+    // Use a regular tetrahedron with all edges length 1.
+    let points = CausalTensor::new(
+        vec![
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 0.866025, 0.0, 0.5, 0.288675, 0.816497,
+        ],
+        vec![4, 3],
+    )
+    .unwrap();
+    let metadata = CausalTensor::new(vec![1.0; 4], vec![4]).unwrap();
+    let pc = PointCloud::new(points, metadata, 0).unwrap();
+    let complex = pc.triangulate(1.1).unwrap();
+
+    let skeleton1 = complex.skeletons().get(1).unwrap();
+    let edge_lengths_vec = vec![1.0_f64; skeleton1.simplices().len()];
+    let regge = ReggeGeometry::new(
+        CausalTensor::new(edge_lengths_vec, vec![skeleton1.simplices().len()]).unwrap(),
+    );
+    let data_len = complex.total_simplices();
+    let data = CausalTensor::new(vec![0.0; data_len], vec![data_len]).unwrap();
+    let manifold = Manifold::with_metric(complex, data, Some(regge), 0).unwrap();
+
+    // Triangulation may or may not give us a 3-skeleton depending on construction.
+    // If it does, compute on a 3-simplex; if not, this test is benign no-op.
+    if let Some(skel3) = manifold.complex().skeletons().get(3)
+        && let Some(s3) = skel3.simplices().first()
+    {
+        let vol_sq = manifold.simplex_volume_squared(s3).unwrap();
+        // Regular tetrahedron with edge 1 has volume = √2/12 ≈ 0.1178511.
+        // vol_sq ≈ 0.01388889 = 1/72.
+        assert!(vol_sq >= 0.0);
+    }
+
+    // Fallback: at minimum exercise the 2-simplex (4×4 determinant) and 1-simplex paths.
+    let s2 = manifold.complex().skeletons()[2].simplices()[0].clone();
+    let _ = manifold.simplex_volume_squared(&s2).unwrap();
+}

--- a/deep_causality_topology/tests/types/regge_geometry/curvature_tests.rs
+++ b/deep_causality_topology/tests/types/regge_geometry/curvature_tests.rs
@@ -143,6 +143,36 @@ fn test_dimension_mismatch_error() {
 }
 
 #[test]
+fn test_2d_triangle_inequality_violation_errors() {
+    // 2D pentagon around vertex 0 — set one rim edge to a huge length so the
+    // triangle inequality fails in the 2D angle calculation (line 136 branch).
+    let mut builder = SimplicialComplexBuilder::new(2);
+    let indices = [1, 2, 3, 4, 5];
+    for i in 0..5 {
+        let v1 = indices[i];
+        let v2 = indices[(i + 1) % 5];
+        builder.add_simplex(Simplex::new(vec![0, v1, v2])).unwrap();
+    }
+    let complex = builder.build::<f64>().unwrap();
+    let num_edges = complex.num_elements_at_grade(1).unwrap();
+    let mut lengths = vec![1.0; num_edges];
+
+    // Find rim edge (1, 2) and inflate it so 1 + 1 < 100 (violates inequality on
+    // triangle 0-1-2 with spokes 0-1=1, 0-2=1, rim 1-2=100).
+    if let Some(idx) = complex.skeletons()[1].get_index(&Simplex::new(vec![1, 2])) {
+        lengths[idx] = 100.0;
+    }
+    let tensor = CausalTensor::new(lengths, vec![num_edges]).unwrap();
+    let geometry = ReggeGeometry::new(tensor);
+
+    let err = geometry.calculate_ricci_curvature(&complex).unwrap_err();
+    assert!(matches!(
+        err.0,
+        deep_causality_topology::TopologyErrorEnum::ManifoldError(_)
+    ));
+}
+
+#[test]
 fn test_manifold_error_triangle_inequality() {
     // We need an INTERNAL bone for calculation to occur.
     // In 3D, create 3 tets around edge (0,1):

--- a/deep_causality_topology/tests/types/simplicial_complex/display_tests.rs
+++ b/deep_causality_topology/tests/types/simplicial_complex/display_tests.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+use deep_causality_sparse::CsrMatrix;
 use deep_causality_topology::utils_tests::create_triangle_complex;
+use deep_causality_topology::{Simplex, SimplicialComplex, Skeleton};
 
 #[test]
 fn test_simplicial_complex_display() {
@@ -18,4 +20,25 @@ fn test_simplicial_complex_display() {
     assert!(display_str.contains("Boundary Operator 0: (Shape: 3x3, Num Non-Zeros: 6)"));
     assert!(display_str.contains("Boundary Operator 1: (Shape: 3x1, Num Non-Zeros: 3)"));
     assert!(display_str.contains("Number of Coboundary Operators: 0"));
+}
+
+#[test]
+fn test_simplicial_complex_display_with_coboundary_operators() {
+    // Construct a minimal complex with at least one coboundary operator so the
+    // coboundary-loop branch in Display is exercised.
+    let vertices = vec![Simplex::new(vec![0]), Simplex::new(vec![1])];
+    let edges = vec![Simplex::new(vec![0, 1])];
+    let skeletons = vec![Skeleton::new(0, vertices), Skeleton::new(1, edges)];
+
+    let d1: CsrMatrix<i8> = CsrMatrix::from_triplets(2, 1, &[(1, 0, 1i8), (0, 0, -1)]).unwrap();
+    // Coboundary δ_0 = (∂_1)^T : a 1x2 matrix.
+    let codelta_0: CsrMatrix<i8> =
+        CsrMatrix::from_triplets(1, 2, &[(0, 0, -1i8), (0, 1, 1)]).unwrap();
+
+    let complex: SimplicialComplex<f64> =
+        SimplicialComplex::new(skeletons, vec![d1], vec![codelta_0], Vec::new());
+
+    let display_str = format!("{}", complex);
+    assert!(display_str.contains("Number of Coboundary Operators: 1"));
+    assert!(display_str.contains("Coboundary Operator 0: (Shape: 1x2, Num Non-Zeros: 2)"));
 }

--- a/deep_causality_topology/tests/types/topology/topology_tests.rs
+++ b/deep_causality_topology/tests/types/topology/topology_tests.rs
@@ -99,6 +99,93 @@ fn test_topology_cup_product_missing_data_other() {
     assert!(topo1_result.is_err());
 }
 
+#[test]
+fn test_topology_cup_product_rejects_complex_mismatch() {
+    // Two distinct Arc-allocated complexes — same shape but different identity.
+    let complex_a = Arc::new(create_triangle_complex());
+    let complex_b = Arc::new(create_triangle_complex());
+
+    let data_a = CausalTensor::new(vec![1.0, 2.0, 3.0], vec![3]).unwrap();
+    let data_b = CausalTensor::new(vec![0.5, 1.5, 2.5], vec![3]).unwrap();
+    let topo_a = Topology::new(complex_a, 0, data_a, 0).unwrap();
+    let topo_b = Topology::new(complex_b, 1, data_b, 0).unwrap();
+
+    let err = topo_a.cup_product(&topo_b).unwrap_err();
+    assert!(err.to_string().contains("Complex Mismatch"));
+}
+
+#[test]
+fn test_topology_cup_product_overflow_grade_returns_zero_field() {
+    // Triangle complex has max simplex dimension 2 (a single 2-simplex).
+    // A 2 ⌣ 1 cup product produces grade r = 3, which exceeds the max → zero-length
+    // result tensor (no 3-skeleton on a triangle).
+    let complex = Arc::new(create_triangle_complex());
+
+    let data2 = CausalTensor::new(vec![7.0], vec![1]).unwrap();
+    let topo2 = Topology::new(complex.clone(), 2, data2, 0).unwrap();
+
+    let data1 = CausalTensor::new(vec![0.5, 1.5, 2.5], vec![3]).unwrap();
+    let topo1 = Topology::new(complex.clone(), 1, data1, 0).unwrap();
+
+    let result = topo2.cup_product(&topo1).unwrap();
+    assert_eq!(result.grade(), 3);
+    // r=3 ≥ skeletons.len()=3 → zero_len = 0 (else branch).
+    assert_eq!(result.data().as_slice().len(), 0);
+}
+
+#[test]
+fn test_topology_cup_product_simplex_not_found_returns_error() {
+    use deep_causality_sparse::CsrMatrix;
+    use deep_causality_topology::{Simplex, SimplicialComplex, Skeleton};
+
+    // Build a complex with mismatched skeletons: the 1-skeleton lists an edge that is
+    // NOT a sub-simplex of the only 2-simplex. The cup-product front-face lookup will
+    // succeed for the 0-skeleton but the back-face Simplex([1,2]) is absent from the
+    // 1-skeleton → SimplexNotFound.
+    //
+    // Triangle simplex: (0, 1, 2). 1-skeleton intentionally only contains (0, 1) and
+    // (0, 2) — leaving (1, 2) missing.
+    let vertices = vec![
+        Simplex::new(vec![0]),
+        Simplex::new(vec![1]),
+        Simplex::new(vec![2]),
+    ];
+    let edges = vec![Simplex::new(vec![0, 1]), Simplex::new(vec![0, 2])];
+    let faces = vec![Simplex::new(vec![0, 1, 2])];
+    let skel = vec![
+        Skeleton::new(0, vertices),
+        Skeleton::new(1, edges),
+        Skeleton::new(2, faces),
+    ];
+
+    let d1 =
+        CsrMatrix::from_triplets(3, 2, &[(1, 0, 1i8), (0, 0, -1), (2, 1, 1), (0, 1, -1)]).unwrap();
+    let d2: CsrMatrix<i8> = CsrMatrix::with_capacity(2, 1, 0);
+
+    let complex: SimplicialComplex<f64> =
+        SimplicialComplex::new(skel, vec![d1, d2], vec![], Vec::new());
+    let complex = Arc::new(complex);
+
+    let data0 = CausalTensor::new(vec![1.0, 2.0, 3.0], vec![3]).unwrap();
+    let data2 = CausalTensor::new(vec![7.0], vec![1]).unwrap();
+    let topo0 = Topology::new(complex.clone(), 0, data0, 0).unwrap();
+    let topo2 = Topology::new(complex.clone(), 2, data2, 0).unwrap();
+
+    // 0 ⌣ 2: front face is [v0..v0]=[0] (in 0-skeleton, found), back face is [v0..v2]
+    // — but we want to trigger SimplexNotFound, so use 1 ⌣ 1 to hit a missing edge.
+    // 1 ⌣ 1 → r=2, sum over 2-simplices. For (0,1,2): front [0,1] (present), back [1,2]
+    // (MISSING from 1-skeleton). Triggers the `back` ok_or branch.
+    let data1 = CausalTensor::new(vec![0.5, 1.5], vec![2]).unwrap();
+    let topo1a = Topology::new(complex.clone(), 1, data1.clone(), 0).unwrap();
+    let topo1b = Topology::new(complex.clone(), 1, data1, 0).unwrap();
+    let err = topo1a.cup_product(&topo1b).unwrap_err();
+    // SimplexNotFound is a wrapper struct around an inner enum; check via Display.
+    assert!(err.to_string().contains("Simplex not found"));
+
+    drop(topo0);
+    drop(topo2);
+}
+
 // =============================================================================
 // Constructor and validation tests
 // =============================================================================

--- a/openspec/changes/add-cubical-regge-calculus-core/design.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/design.md
@@ -89,11 +89,16 @@ The count is **always 4** on a regular periodic lattice: a (D−2)-hinge is the 
 
 A dihedral angle at a hinge `h` from a top cube `c` is the angle between the two faces of `c` that share `h`. The two faces correspond to the two axes of the dihedral's normal plane — the axes inactive in `h` but active in `c`. Call them `i` and `j`. All return values are `R: RealField`.
 
-- `UnitEdge` and `Uniform`: every dihedral angle is exactly π/2. The implementation returns `R::pi() / (R::one() + R::one())` without touching the lattice.
-- `PerAxis { lengths }`: `dihedral_angle(c, h) = R::atan2(lengths[j], lengths[i])` (the angle the face along axis `j` makes with the face along axis `i` at the shared hinge). For a unit cube `lengths[i] == lengths[j]` so the result is π/4 + π/4 = π/2 by symmetry — consistent with the unit case.
-- `PerEdge`: same shape as per-axis, but `lengths[i]` is read at the specific edge of `c` along axis `i` adjacent to `h` (via `edge_index`). Closed form is identical otherwise.
+**On an axis-aligned cubical complex the dihedral angle is exactly π/2 in every edge-length variant** (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`). The two (D−1)-faces meeting at a (D−2)-hinge in such a cube are mutually perpendicular regardless of the lengths along axes `i` and `j` — stretching an axis changes the face's size but not its orientation. The implementation therefore returns `R::pi() / (R::one() + R::one())` uniformly and does not read the edge-length data.
 
-`RealField` exposes `pi()`, `atan2`, `one()`, `zero()`, `sqrt`, etc. — see [deep_causality_num/src/algebra/field_real.rs](../../../deep_causality_num/src/algebra/field_real.rs). No new `RealField` methods are required by this change set.
+**Correction note.** An earlier draft of `openspec/notes/CubicalReggeCalculus.md` §3.R2 proposed `R::atan2(lengths[j], lengths[i])` for the `PerAxis` case, reasoning that "for a unit cube `lengths[i] == lengths[j]` so the result is π/4 + π/4 = π/2 by symmetry." That reasoning conflates the dihedral angle (between two faces) with the half-angle of a stretched cube's diagonal — different quantities. Only the constant `π/2` is geometrically correct for an axis-aligned cubical dihedral. The unit-edge test `4 × π/2 = 2π` (interior 2D vertex) still pins the right value down to the right floating-point tolerance.
+
+Curvature on a cubical lattice therefore enters via:
+
+1. **Hinge incidence count.** Interior hinges in a regular periodic lattice have 4 incident top cubes (sum 2π, deficit 0 — flat). Boundary hinges on open lattices have fewer (a 2D corner sees 1 cube, sum π/2, deficit 3π/2 — intrinsic boundary curvature).
+2. **Sheared / non-axis-aligned cells**, not expressible in the current `EdgeLengths` representation. A future Gram-matrix-aware extension would rewrite this closed form.
+
+`RealField` exposes `pi()`, `one()`, `zero()`, `sqrt`, etc. — see [deep_causality_num/src/algebra/field_real.rs](../../../deep_causality_num/src/algebra/field_real.rs). No new `RealField` methods are required by this change set. The `atan2` originally cited is no longer needed.
 
 **Rationale:** the cubical-axis alignment turns dihedral angles into 2-argument arctangents — no Cayley-Menger, no eigenvalue solve, no nonlinear root-finding. This is the single biggest practical advantage of the cubical Regge approach over simplicial.
 

--- a/openspec/changes/add-cubical-regge-calculus-core/design.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/design.md
@@ -2,9 +2,9 @@
 
 `add-cubical-complexes` (Stages A–C) shipped a complete type scaffold for cubical geometry in `deep_causality_topology`:
 
-- `LatticeComplex<D>` implements `ChainComplex`, stores `shape: [usize; D]` and `periodic: [bool; D]`, and caches the coboundary operator behind a `Mutex` once it has been computed. Cells are enumerated lazily by `LatticeCellIterator` and encoded as `(position, orientation_bitmask)` pairs.
-- `CubicalReggeGeometry<D>` is the associated `ChainComplex::Metric` type. Edge lengths are represented at four uniformity levels — `UnitEdge`, `Uniform { length }`, `PerAxis { lengths: [f64; D] }`, `PerEdge { lengths: Vec<f64> }` — and an optional `timelike_axes: Option<[bool; D]>` is reserved for the (out-of-scope) Lorentzian variant.
-- `Manifold<LatticeComplex<D>, F>` wraps complex + field data + optional metric; constructors `from_cubical` / `from_cubical_with_metric` exist.
+- `LatticeComplex<D, R: RealField>` implements `ChainComplex`, stores `shape: [usize; D]` and `periodic: [bool; D]`, and currently caches the coboundary operator behind a `Mutex<HashMap<usize, CsrMatrix<i8>>>` populated on first call to `coboundary_matrix(k)`. This change set replaces that cache with `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1`, indexed by grade, so reads become lock-free after first init and `coboundary_matrix` can return `Cow::Borrowed` instead of `Cow::Owned(clone)`. Cells are enumerated lazily by `LatticeCellIterator` and encoded as `(position, orientation_bitmask)` pairs.
+- `CubicalReggeGeometry<D, R: RealField>` is the associated `ChainComplex::Metric` type. Edge lengths are represented at four uniformity levels — `UnitEdge`, `Uniform { length: R }`, `PerAxis { lengths: [R; D] }`, `PerEdge { lengths: Vec<R> }` — and an optional `timelike_axes: Option<[bool; D]>` is reserved for the (out-of-scope) Lorentzian variant. **All scalars are `R`, not `f64`.** Every method added in this change set returns `R` and uses `R::pi()`, `R::one()`, `R::zero()`, and `R::atan2` from the `RealField` trait.
+- `Manifold<LatticeComplex<D, R>, F>` wraps complex + field data + optional metric; constructors `from_cubical` / `from_cubical_with_metric` exist.
 
 What is missing is the *geometric derivation layer*: every quantity in the proposal (cell volume, dihedral angle, deficit angle, Regge action) is currently uncomputable on a `LatticeComplex<D>` even though all the inputs are present in `CubicalReggeGeometry<D>`. The forward-looking design note [openspec/notes/CubicalReggeCalculus.md](../../notes/CubicalReggeCalculus.md) lays out the full six-phase roadmap (R1–R6); this change set delivers R1–R3 — the geometric core — and stops at the boundary where the analytical core (Hodge ⋆, Lorentzian, dynamics) would begin.
 
@@ -47,12 +47,12 @@ Both files contain `impl<const D: usize> CubicalReggeGeometry<D> { … }` blocks
 
 ### Decision 2: Cell volume from edge lengths — closed form per uniformity level
 
-For a k-cube whose orientation bitmask has active dimensions `{i₁, …, iₖ}`, the k-volume in the cubical setting (where edges meeting at any vertex are mutually orthogonal under the lattice's per-axis metric) reduces to the product of edge lengths along the active dims. Concretely:
+For a k-cube whose orientation bitmask has active dimensions `{i₁, …, iₖ}`, the k-volume in the cubical setting (where edges meeting at any vertex are mutually orthogonal under the lattice's per-axis metric) reduces to the product of edge lengths along the active dims. All return values are `R: RealField`. Concretely:
 
-- `UnitEdge`: `cell_volume = 1.0` for every grade. No traversal needed.
-- `Uniform { length: L }`: `cell_volume = L.powi(grade as i32)`.
-- `PerAxis { lengths }`: `cell_volume = active_dims.iter().map(|i| lengths[*i]).product()`.
-- `PerEdge { lengths }`: walk the cube's k incident edges along the active dims (using `position` + axis to index into `lengths`) and take the product. The per-edge Gram-matrix determinant collapses to this product because cross-terms vanish under axis alignment — documented in the closed-form derivation in §3.R1 of the design note.
+- `UnitEdge`: `cell_volume = R::one()` for every grade. No traversal needed.
+- `Uniform { length: L }`: `cell_volume = (0..grade).fold(R::one(), |acc, _| acc * L)` — `RealField` has no `powi`, so the explicit fold is used.
+- `PerAxis { lengths }`: `cell_volume = active_dims.iter().fold(R::one(), |acc, i| acc * lengths[*i])`.
+- `PerEdge { lengths }`: walk the cube's k incident edges along the active dims (using `position` + axis to index into `lengths` via the `edge_index` helper) and take the product over `R`. The per-edge Gram-matrix determinant collapses to this product because cross-terms vanish under axis alignment — documented in the closed-form derivation in §3.R1 of the design note.
 
 **Rationale:** the cubical case admits these clean closed forms precisely because cubical cells are axis-aligned. We do *not* introduce a general Gram-determinant routine here. If a future change set ever needs sheared cubical cells (where the Gram matrix has off-diagonal entries), it can replace this implementation without touching the public method signature.
 
@@ -69,7 +69,17 @@ hinge_top_cube_neighbors(complex, hinge_id) =
     )
 ```
 
-returned as an iterator (no allocation in the steady state — the matrix rows are sparse, the iterator yields D-cube CellIds). The result is deduplicated; on a regular grid each (D−2)-hinge has exactly 2(D−1) = 4 incident D-cubes in 3D and 4 in 4D. (Note: 2(D−1) is the count of (D−1)-faces incident to a (D−2)-cell *inside one D-cube*. For the global incidence count of D-cubes per (D−2)-hinge, the value depends on the lattice — 2 in 2D, 4 in 3D, 4 in 4D — and the property tests pin it down.)
+returned as an iterator (no allocation in the steady state — the matrix rows are sparse, the iterator yields D-cube CellIds). The result is deduplicated.
+
+**Incidence count per (D−2)-hinge on a regular periodic D-lattice:**
+
+| `D` | Hinge dimension `D−2` | Cell name      | Number of incident D-cubes |
+|-----|-----------------------|----------------|-----------------------------|
+| 2   | 0 (vertex)            | vertex         | 4                           |
+| 3   | 1 (edge)              | edge           | 4                           |
+| 4   | 2 (square)            | 2-face         | 4                           |
+
+The count is **always 4** on a regular periodic lattice: a (D−2)-hinge is the intersection of two coordinate hyperplanes, and the 2D normal plane is tiled by exactly four D-cubes around the hinge. Open-boundary interior hinges also have 4 incident D-cubes; boundary hinges have fewer (2 on a flat boundary, 1 at a corner). The property tests pin down both the interior and boundary cases.
 
 **Rationale:** reuses infrastructure already shipped in Stage B. Zero new caching, zero new sparse-matrix code. The compute is one sparse matrix-vector product against the cached coboundary matrices.
 
@@ -77,11 +87,13 @@ returned as an iterator (no allocation in the steady state — the matrix rows a
 
 ### Decision 4: Dihedral angle closed form
 
-A dihedral angle at a hinge `h` from a top cube `c` is the angle between the two faces of `c` that share `h`. The two faces correspond to the two axes of the dihedral's normal plane — the axes inactive in `h` but active in `c`. Call them `i` and `j`.
+A dihedral angle at a hinge `h` from a top cube `c` is the angle between the two faces of `c` that share `h`. The two faces correspond to the two axes of the dihedral's normal plane — the axes inactive in `h` but active in `c`. Call them `i` and `j`. All return values are `R: RealField`.
 
-- `UnitEdge` and `Uniform`: every dihedral angle is exactly π/2. The implementation returns `std::f64::consts::FRAC_PI_2` without touching the lattice.
-- `PerAxis { lengths }`: `dihedral_angle(c, h) = arctan2(lengths[j], lengths[i])` (the angle the face along axis `j` makes with the face along axis `i` at the shared hinge). For a unit cube `lengths[i] == lengths[j]` so the result is π/4 + π/4 = π/2 by symmetry — which is consistent with the unit case.
-- `PerEdge`: same shape as per-axis, but `lengths[i]` is read at the specific edge of `c` along axis `i` adjacent to `h`. Closed form is identical otherwise.
+- `UnitEdge` and `Uniform`: every dihedral angle is exactly π/2. The implementation returns `R::pi() / (R::one() + R::one())` without touching the lattice.
+- `PerAxis { lengths }`: `dihedral_angle(c, h) = R::atan2(lengths[j], lengths[i])` (the angle the face along axis `j` makes with the face along axis `i` at the shared hinge). For a unit cube `lengths[i] == lengths[j]` so the result is π/4 + π/4 = π/2 by symmetry — consistent with the unit case.
+- `PerEdge`: same shape as per-axis, but `lengths[i]` is read at the specific edge of `c` along axis `i` adjacent to `h` (via `edge_index`). Closed form is identical otherwise.
+
+`RealField` exposes `pi()`, `atan2`, `one()`, `zero()`, `sqrt`, etc. — see [deep_causality_num/src/algebra/field_real.rs](../../../deep_causality_num/src/algebra/field_real.rs). No new `RealField` methods are required by this change set.
 
 **Rationale:** the cubical-axis alignment turns dihedral angles into 2-argument arctangents — no Cayley-Menger, no eigenvalue solve, no nonlinear root-finding. This is the single biggest practical advantage of the cubical Regge approach over simplicial.
 
@@ -89,7 +101,7 @@ A dihedral angle at a hinge `h` from a top cube `c` is the angle between the two
 
 ### Decision 5: Deficit angle and Regge action on the Euclidean case only
 
-Deficit angle: `deficit_angle(h) = 2π − Σ_{c incident to h} dihedral_angle(c, h)`. The factor of 2π is the full angle in the 2D normal plane to a (D−2)-hinge. Regge action: `regge_action() = Σ_h cell_volume(h, D-2) · deficit_angle(h)`.
+Deficit angle: `deficit_angle(h) = (R::pi() + R::pi()) − Σ_{c incident to h} dihedral_angle(c, h)`. The `R::pi() + R::pi()` form expresses 2π without requiring a `frac_2_pi()` accessor on `RealField`. The factor of 2π is the full angle in the 2D normal plane to a (D−2)-hinge. Regge action: `regge_action() = Σ_h cell_volume(h, D-2) · deficit_angle(h)`, accumulated in `R` (starting from `R::zero()`).
 
 **Scope choice:** this change set computes the Euclidean Regge action only. The `timelike_axes` field on `CubicalReggeGeometry<D>` is read-only for now — if it is `Some(...)`, `regge_action` returns the Euclidean action computed by treating all axes as spacelike (the field is *not* validated). The Lorentzian variant (`regge_action_lorentzian` returning `Complex<f64>`) is deferred to R5, where the type system will be extended to track the signature choice (the `S = Euclidean | Lorentzian` marker in §3.R5 of the design note).
 
@@ -115,8 +127,7 @@ Each is registered in `tests/types/cubical_regge_geometry/mod.rs` / `tests/types
 
 ## Risks / Trade-offs
 
-- **[Risk] Coboundary-cache contention under multi-threaded use.** `LatticeComplex<D>` caches `coboundary_matrix(k)` behind a `Mutex`. Repeated hinge enumeration from many threads serializes on the cache mutex on first compute, then runs lock-free for reads.
-  → **Mitigation:** acceptable in this change set; the cache is already in place and the first-compute serialization is a one-time cost per `(complex, grade)` pair. If contention is observed downstream, swap the `Mutex` for `OnceLock` in a separate perf change.
+- **[Risk] Coboundary-cache contention under multi-threaded use.** Resolved in this change set: `LatticeComplex<D, R>::coboundary_cache` is converted from `Mutex<HashMap<usize, CsrMatrix<i8>>>` to `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1` (one slot per grade). Reads become lock-free after first init; the `Mutex` poisoning concern goes away; `coboundary_matrix` returns `Cow::Borrowed` instead of `Cow::Owned(clone)`, saving a CSR clone per call. The conversion is scoped to a single sub-task in §1 of the task list and lands before R1.
 
 - **[Risk] Per-edge volume / dihedral formulas assume axis-aligned cells.** The closed forms rely on cubical cells having mutually orthogonal edges at every vertex. If a future change set introduces sheared cubical cells (where the per-edge Gram matrix has off-diagonal entries), the closed-form routines silently produce wrong answers.
   → **Mitigation:** document the assumption prominently in doc comments. Add a `debug_assert!` in the per-edge path that the local Gram matrix has zero off-diagonal entries. (This is essentially free under the current `PerEdge { lengths: Vec<f64> }` representation, which has no way to express off-diagonal terms in the first place — but the assertion guards the assumption explicitly.)

--- a/openspec/changes/add-cubical-regge-calculus-core/proposal.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/proposal.md
@@ -6,13 +6,14 @@ This change set delivers the geometric core (phases R1–R3 of the design note) 
 
 ## What Changes
 
-- Add cell-volume computation on `CubicalReggeGeometry<D>` for k-cells of every grade, across all four edge-length uniformity levels (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`).
-- Add hinge enumeration: a `hinge_top_cube_neighbors` helper on `LatticeComplex<D>` that walks the existing coboundary cache to enumerate top D-cubes incident to a given (D−2)-cell.
-- Add dihedral-angle computation on `CubicalReggeGeometry<D>`: the angle a top cube contributes to a given hinge, in closed form for the per-axis case and π/2 on unit/uniform grids.
-- Add deficit-angle computation: `ε(h) = 2π − Σ θᵢ(h)` summed over incident top cubes.
-- Add the discrete Einstein–Hilbert (Regge) action: `S_R = Σ_h volume(h) · deficit_angle(h)` over all hinges.
-- Property-test invariants: unit-grid identities (every k-cube has k-volume 1.0; every dihedral angle is π/2; every deficit angle is 0; total Regge action is 0), per-axis closed forms, periodic-vs-open boundary action differences, and locality of edge-length perturbations.
-- No breaking changes. All additions are new methods on `CubicalReggeGeometry<D>` or new helpers on `LatticeComplex<D>`. The `ChainComplex`, `Neighborhood`, and `Manifold<K, F>` trait surfaces shipped in `add-cubical-complexes` Stages A–C are untouched.
+- Add cell-volume computation on `CubicalReggeGeometry<D, R>` for k-cells of every grade, across all four edge-length uniformity levels (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`). Returns `R` (the generic real-field precision), not `f64`.
+- Add hinge enumeration: a `hinge_top_cube_neighbors` helper on `LatticeComplex<D, R>` that walks the existing coboundary cache to enumerate top D-cubes incident to a given (D−2)-cell.
+- Add dihedral-angle computation on `CubicalReggeGeometry<D, R>`: the angle a top cube contributes to a given hinge (returns `R`), in closed form for the per-axis case and `R::pi() / (R::one() + R::one())` on unit/uniform grids.
+- Add deficit-angle computation: `ε(h) = 2π − Σ θᵢ(h)` (computed as `(R::pi() + R::pi()) − Σ θᵢ(h)`) summed over incident top cubes.
+- Add the discrete Einstein–Hilbert (Regge) action: `S_R = Σ_h volume(h) · deficit_angle(h)` over all hinges (returns `R`).
+- Convert `LatticeComplex<D, R>::coboundary_cache` from `Mutex<HashMap<usize, CsrMatrix<i8>>>` to `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1`, indexed by grade. Lock-free reads after first init; eliminates the `.clone()` in the cache-hit path; the `coboundary_matrix` method now returns `Cow::Borrowed`. This is a precursor step landed in §1 of tasks, before R1.
+- Property-test invariants: unit-grid identities (every k-cube has k-volume `R::one()`; every dihedral angle equals `R::pi() / (R::one() + R::one())`; every deficit angle is `R::zero()`; total Regge action is `R::zero()`), per-axis closed forms, periodic-vs-open boundary action differences (measured on a perturbed metric), and locality of edge-length perturbations.
+- No breaking changes to public trait surfaces. All additions are new methods on `CubicalReggeGeometry<D, R>` or new helpers on `LatticeComplex<D, R>`. The `ChainComplex`, `Neighborhood`, and `Manifold<K, F>` trait surfaces shipped in `add-cubical-complexes` Stages A–C are untouched. The `coboundary_cache` field is private; the swap to `OnceLock` is internal.
 
 ## Capabilities
 
@@ -31,14 +32,16 @@ This change set delivers the geometric core (phases R1–R3 of the design note) 
   - `src/types/cubical_regge_geometry/volumes.rs`
   - `src/types/cubical_regge_geometry/curvature.rs`
   - Helpers added under `src/types/lattice_complex/`.
-- **New methods on `CubicalReggeGeometry<D>`:**
-  - `cell_volume(&self, complex, cell_id, grade) -> f64`
-  - `top_cell_volume(&self, complex, cell_id) -> f64`
-  - `dihedral_angle(&self, complex, top_cube_id, hinge_id) -> f64`
-  - `deficit_angle(&self, complex, hinge_id) -> f64`
-  - `regge_action(&self, complex) -> f64`
-- **New helper on `LatticeComplex<D>`:**
+- **New methods on `CubicalReggeGeometry<D, R>`:**
+  - `cell_volume(&self, complex, cell_id, grade) -> R`
+  - `top_cell_volume(&self, complex, cell_id) -> R`
+  - `dihedral_angle(&self, complex, top_cube_id, hinge_id) -> R`
+  - `deficit_angle(&self, complex, hinge_id) -> R`
+  - `regge_action(&self, complex) -> R`
+- **New helper on `LatticeComplex<D, R>`:**
   - `hinge_top_cube_neighbors(&self, hinge_id) -> impl Iterator<Item = CellId>`
+- **Internal cache change on `LatticeComplex<D, R>`:**
+  - `coboundary_cache: Box<[OnceLock<CsrMatrix<i8>>]>` (was `Mutex<HashMap<usize, CsrMatrix<i8>>>`). Coboundary reads become lock-free and zero-copy (`Cow::Borrowed`).
 - **Trait surface:** unchanged. No new public traits in this change set. (The `HasHodgeStar` capability trait belongs to the follow-up `add-cubical-regge-calculus-analytical` change set covering R4–R6.)
 - **Dependencies:** no new external crates. All work uses existing infrastructure (`deep_causality_sparse` for the coboundary cache, `deep_causality_tensor` for any field views, the existing `CellId` / `Manifold` types).
 - **Tests:** ~28 property tests across the three phases, registered under `tests/types/cubical_regge_geometry/` mirroring the source-tree layout, with corresponding entries in `deep_causality_topology/tests/BUILD.bazel`.

--- a/openspec/changes/add-cubical-regge-calculus-core/tasks.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/tasks.md
@@ -1,44 +1,45 @@
 ## 1. Scaffolding and shared helpers
 
-- [ ] 1.1 Add `src/types/cubical_regge_geometry/volumes.rs` and `curvature.rs` as new submodules; register both in `src/types/cubical_regge_geometry/mod.rs`
-- [ ] 1.2 Add private associated function `LatticeComplex<D>::edge_index(position, axis) -> usize` mapping a `(position, axis)` pair to a flat `Vec<f64>` index for `PerEdge` metrics; cover with unit tests for open and periodic boundaries
-- [ ] 1.3 Add `tests/types/cubical_regge_geometry/{mod.rs, volumes_tests.rs, curvature_tests.rs}` skeletons; register in `tests/types/cubical_regge_geometry/mod.rs` and `tests/types/mod.rs`
-- [ ] 1.4 Update `deep_causality_topology/tests/BUILD.bazel` to include the new test folder module
-- [ ] 1.5 Add any shared test fixtures (small lattices with known geometry) under `src/utils_tests/cubical_regge_fixtures.rs`
+- [ ] 1.1 Convert `LatticeComplex<D, R>::coboundary_cache` from `Mutex<HashMap<usize, CsrMatrix<i8>>>` to `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1` (one slot per grade `0..=D`). Initialize in `new()` via `(0..=D).map(|_| OnceLock::new()).collect::<Vec<_>>().into_boxed_slice()`. Update `coboundary_matrix(k)` to use `self.coboundary_cache[k].get_or_init(...)` and return `Cow::Borrowed`. Update `Clone` impl to construct fresh empty `OnceLock`s. Drop the `HashMap` and `Mutex` imports.
+- [ ] 1.2 Add `src/types/cubical_regge_geometry/volumes.rs` and `curvature.rs` as new submodules; register both in `src/types/cubical_regge_geometry/mod.rs`
+- [ ] 1.3 Add private associated function `LatticeComplex<D, R>::edge_index(position: [usize; D], axis: usize) -> usize` mapping a `(position, axis)` pair to a flat `Vec<R>` index for `PerEdge` metrics; cover with unit tests for open and periodic boundaries
+- [ ] 1.4 Add `tests/types/cubical_regge_geometry/{mod.rs, volumes_tests.rs, curvature_tests.rs}` skeletons; register in `tests/types/cubical_regge_geometry/mod.rs` and `tests/types/mod.rs`
+- [ ] 1.5 Update `deep_causality_topology/tests/BUILD.bazel` to include the new test folder module
+- [ ] 1.6 Add any shared test fixtures (small lattices with known geometry) under `src/utils_tests/cubical_regge_fixtures.rs`
 
 ## 2. Phase R1 — Cell volumes
 
-- [ ] 2.1 Implement `CubicalReggeGeometry<D>::cell_volume(&self, complex, cell_id, grade) -> f64` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`)
-- [ ] 2.2 Implement `CubicalReggeGeometry<D>::top_cell_volume(&self, complex, cell_id) -> f64` as the `grade = D` convenience
+- [ ] 2.1 Implement `CubicalReggeGeometry<D, R>::cell_volume(&self, complex: &LatticeComplex<D, R>, cell_id: CellId, grade: usize) -> R` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`)
+- [ ] 2.2 Implement `CubicalReggeGeometry<D, R>::top_cell_volume(&self, complex, cell_id) -> R` as the `grade = D` convenience
 - [ ] 2.3 Add `debug_assert!` in the `PerEdge` path documenting the axis-aligned-cell assumption (cross-terms vanish)
-- [ ] 2.4 Write unit-edge property tests: every k-cube has volume `1.0` exactly for every grade
-- [ ] 2.5 Write per-axis property tests: top-cube volume equals `axis_lengths.iter().product()`; k-cell volume equals product of active-axis lengths
-- [ ] 2.6 Write per-edge property test: a `PerEdge` metric with uniform-per-axis lengths reproduces the per-axis result to `1e-12`
+- [ ] 2.4 Write unit-edge property tests: every k-cube has volume exactly `R::one()` for every grade (instantiate over `f64` and `f32`)
+- [ ] 2.5 Write per-axis property tests: top-cube volume equals the fold-product of `axis_lengths` over `R`; k-cell volume equals product of active-axis lengths
+- [ ] 2.6 Write per-edge property test: a `PerEdge` metric with uniform-per-axis lengths reproduces the per-axis result to within `R::epsilon() * <small constant>`
 
 ## 3. Phase R2 — Hinge enumeration + dihedral angles
 
-- [ ] 3.1 Implement `LatticeComplex<D>::hinge_top_cube_neighbors(&self, hinge_id) -> impl Iterator<Item = CellId>` by walking the cached `coboundary_matrix(D-2)` and `coboundary_matrix(D-1)`; deduplicate the result
-- [ ] 3.2 Add unit tests for hinge enumeration: 2D interior vertex → 4 squares; 4D interior 2-cell → 4 4-cubes; periodic-boundary wrap-around; determinism / no duplicates
-- [ ] 3.3 Implement `CubicalReggeGeometry<D>::dihedral_angle(&self, complex, top_cube_id, hinge_id) -> f64` in `curvature.rs`, dispatching on the edge-length variant
-- [ ] 3.4 Short-circuit `UnitEdge` and `Uniform` to `FRAC_PI_2` without touching the lattice
-- [ ] 3.5 Implement per-axis case using `arctan2(lengths[j], lengths[i])` where `i, j` are the two axes inactive in the hinge but active in the top cube
-- [ ] 3.6 Implement per-edge case: read the two edge lengths of the top cube at the hinge along axes `i` and `j` (via `edge_index`) and apply the same `arctan2` formula
-- [ ] 3.7 Document the contract for non-incident `(top_cube_id, hinge_id)` pairs in the doc comment (return `NaN`, `Err`, or panic — choose one and document it)
-- [ ] 3.8 Write unit-edge property test: every dihedral angle equals `FRAC_PI_2` to `1e-15`
-- [ ] 3.9 Write per-axis property test: dihedral angles around any interior vertex on a 2D lattice sum to `2π` to `1e-12`
-- [ ] 3.10 Write per-edge / per-axis agreement test: matching uniform-per-axis edge lengths produce identical dihedral angles to `1e-12`
+- [ ] 3.1 Implement `LatticeComplex<D, R>::hinge_top_cube_neighbors(&self, hinge_id) -> impl Iterator<Item = CellId>` by walking the cached `coboundary_matrix(D-2)` and `coboundary_matrix(D-1)`; deduplicate the result. Borrows the cached matrices directly (cache returns `Cow::Borrowed` after the §1.1 conversion).
+- [ ] 3.2 Add unit tests for hinge enumeration: 2D interior vertex → 4 squares; 3D interior edge → 4 cubes; 4D interior 2-cell → 4 4-cubes; periodic-boundary wrap-around; open-boundary corner / face hinges produce the correct reduced counts (1 / 2); determinism / no duplicates
+- [ ] 3.3 Implement `CubicalReggeGeometry<D, R>::dihedral_angle(&self, complex, top_cube_id, hinge_id) -> R` in `curvature.rs`, dispatching on the edge-length variant
+- [ ] 3.4 Short-circuit `UnitEdge` and `Uniform` to `R::pi() / (R::one() + R::one())` without touching the lattice
+- [ ] 3.5 Implement per-axis case using `R::atan2(lengths[j], lengths[i])` where `i, j` are the two axes inactive in the hinge but active in the top cube
+- [ ] 3.6 Implement per-edge case: read the two edge lengths of the top cube at the hinge along axes `i` and `j` (via `edge_index`) and apply the same `atan2` formula
+- [ ] 3.7 Document the contract for non-incident `(top_cube_id, hinge_id)` pairs in the doc comment (return `R::nan()`, `Err`, or panic — choose one and document it)
+- [ ] 3.8 Write unit-edge property test: every dihedral angle equals `R::pi() / (R::one() + R::one())` to `R::epsilon()` tolerance
+- [ ] 3.9 Write per-axis property test: dihedral angles around any interior vertex on a 2D lattice sum to `R::pi() + R::pi()` (i.e. 2π) to a few `R::epsilon()`
+- [ ] 3.10 Write per-edge / per-axis agreement test: matching uniform-per-axis edge lengths produce identical dihedral angles to within a few `R::epsilon()`
 
 ## 4. Phase R3 — Deficit angles + Regge action
 
-- [ ] 4.1 Implement `CubicalReggeGeometry<D>::deficit_angle(&self, complex, hinge_id) -> f64` in `curvature.rs` as `2π − Σ dihedral_angle(c, h)` summed over `hinge_top_cube_neighbors(hinge_id)`
-- [ ] 4.2 Short-circuit `UnitEdge` (and `Uniform`, and `PerAxis` with all-equal lengths) at the entry of `deficit_angle` to return exact `0.0`, avoiding floating-point noise
-- [ ] 4.3 Implement `CubicalReggeGeometry<D>::regge_action(&self, complex) -> f64` as `Σ_h cell_volume(h, D-2) · deficit_angle(h)` over every (D−2)-hinge
-- [ ] 4.4 Apply the same flat-case short-circuit to `regge_action`, returning exact `0.0`
+- [ ] 4.1 Implement `CubicalReggeGeometry<D, R>::deficit_angle(&self, complex, hinge_id) -> R` in `curvature.rs` as `(R::pi() + R::pi()) − Σ dihedral_angle(c, h)` summed over `hinge_top_cube_neighbors(hinge_id)`
+- [ ] 4.2 Short-circuit `UnitEdge` (and `Uniform`, and `PerAxis` with all-equal lengths) at the entry of `deficit_angle` to return exact `R::zero()`, avoiding floating-point noise
+- [ ] 4.3 Implement `CubicalReggeGeometry<D, R>::regge_action(&self, complex) -> R` as `Σ_h cell_volume(h, D-2) · deficit_angle(h)` over every (D−2)-hinge, accumulated from `R::zero()`
+- [ ] 4.4 Apply the same flat-case short-circuit to `regge_action`, returning exact `R::zero()`
 - [ ] 4.5 Document in the doc comment that `timelike_axes` is ignored in this change set; the Lorentzian variant is deferred to a follow-up change
-- [ ] 4.6 Write property test: unit-edge open lattice → every deficit angle is exactly `0.0`
-- [ ] 4.7 Write property test: unit-edge periodic lattice → every deficit angle is exactly `0.0`; total `regge_action` is exactly `0.0`
-- [ ] 4.8 Write property test: single-edge perturbation has bounded support — hinges not in any incident top cube of the perturbed edge still report `deficit_angle == 0.0`
-- [ ] 4.9 Write property test: periodic vs. open boundary action difference equals the boundary-hinge contribution to within `1e-10`
+- [ ] 4.6 Write property test: unit-edge open lattice → every deficit angle is exactly `R::zero()`
+- [ ] 4.7 Write property test: unit-edge periodic lattice → every deficit angle is exactly `R::zero()`; total `regge_action` is exactly `R::zero()`
+- [ ] 4.8 Write property test: single-edge perturbation has bounded support — hinges not in any incident top cube of the perturbed edge still report `deficit_angle == R::zero()`
+- [ ] 4.9 Write property test: on a `PerAxis` metric with one axis stretched (so the flat-case short-circuit does not fire), the difference between the periodic and the open-boundary Regge action equals the explicit boundary-hinge contribution to within a few `R::epsilon()` (computed by summing `cell_volume(h, D-2) · deficit_angle(h)` over the boundary hinges that exist on the open lattice but wrap on the periodic one)
 - [ ] 4.10 Write property test: `regge_action` on a metric with `timelike_axes = Some(...)` equals the same metric with `timelike_axes = None` (Lorentzian path is deferred)
 
 ## 5. Public API export and documentation

--- a/openspec/changes/add-cubical-regge-calculus-core/tasks.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/tasks.md
@@ -1,20 +1,21 @@
 ## 1. Scaffolding and shared helpers
 
-- [ ] 1.1 Convert `LatticeComplex<D, R>::coboundary_cache` from `Mutex<HashMap<usize, CsrMatrix<i8>>>` to `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1` (one slot per grade `0..=D`). Initialize in `new()` via `(0..=D).map(|_| OnceLock::new()).collect::<Vec<_>>().into_boxed_slice()`. Update `coboundary_matrix(k)` to use `self.coboundary_cache[k].get_or_init(...)` and return `Cow::Borrowed`. Update `Clone` impl to construct fresh empty `OnceLock`s. Drop the `HashMap` and `Mutex` imports.
+- [ ] 1.1 Convert `LatticeComplex<D, R>::coboundary_cache` from `Mutex<HashMap<usize, CsrMatrix<i8>>>` to `Box<[OnceLock<CsrMatrix<i8>>]>` of length `D + 1` (one slot per grade `0..=D`). Initialize in `new()` via `(0..=D).map(|_| OnceLock::new()).collect::<Vec<_>>().into_boxed_slice()`. Update `coboundary_matrix(k)` to use `self.coboundary_cache[k].get_or_init(...)` and return `Cow::Borrowed`. Update `Clone` impl to construct fresh empty `OnceLock`s. Drop the `Mutex` import.
 - [ ] 1.2 Add `src/types/cubical_regge_geometry/volumes.rs` and `curvature.rs` as new submodules; register both in `src/types/cubical_regge_geometry/mod.rs`
-- [ ] 1.3 Add private associated function `LatticeComplex<D, R>::edge_index(position: [usize; D], axis: usize) -> usize` mapping a `(position, axis)` pair to a flat `Vec<R>` index for `PerEdge` metrics; cover with unit tests for open and periodic boundaries
-- [ ] 1.4 Add `tests/types/cubical_regge_geometry/{mod.rs, volumes_tests.rs, curvature_tests.rs}` skeletons; register in `tests/types/cubical_regge_geometry/mod.rs` and `tests/types/mod.rs`
-- [ ] 1.5 Update `deep_causality_topology/tests/BUILD.bazel` to include the new test folder module
-- [ ] 1.6 Add any shared test fixtures (small lattices with known geometry) under `src/utils_tests/cubical_regge_fixtures.rs`
+- [ ] 1.3 Add `tests/types/cubical_regge_geometry/{volumes_tests.rs, curvature_tests.rs}` skeletons (SPDX-header only; populated in R1–R3); register in `tests/types/cubical_regge_geometry/mod.rs`
+- [ ] 1.4 Update `deep_causality_topology/tests/BUILD.bazel` to add a `types/cubical_regge_geometry` `rust_test_suite` entry
+- [ ] 1.5 *Deferred:* `LatticeComplex::edge_index` and `src/utils_tests/cubical_regge_fixtures.rs` are introduced in §2 (R1) where they have a real consumer (`cell_volume`'s `PerEdge` arm). Introducing them in §1 generates `dead_code` warnings on `edge_index`, `edges_along`, `valid_positions` until R1 lands, and the project policy forbids `#[allow(dead_code)]` suppression.
 
 ## 2. Phase R1 — Cell volumes
 
-- [ ] 2.1 Implement `CubicalReggeGeometry<D, R>::cell_volume(&self, complex: &LatticeComplex<D, R>, cell_id: CellId, grade: usize) -> R` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`)
-- [ ] 2.2 Implement `CubicalReggeGeometry<D, R>::top_cell_volume(&self, complex, cell_id) -> R` as the `grade = D` convenience
-- [ ] 2.3 Add `debug_assert!` in the `PerEdge` path documenting the axis-aligned-cell assumption (cross-terms vanish)
-- [ ] 2.4 Write unit-edge property tests: every k-cube has volume exactly `R::one()` for every grade (instantiate over `f64` and `f32`)
-- [ ] 2.5 Write per-axis property tests: top-cube volume equals the fold-product of `axis_lengths` over `R`; k-cell volume equals product of active-axis lengths
-- [ ] 2.6 Write per-edge property test: a `PerEdge` metric with uniform-per-axis lengths reproduces the per-axis result to within `R::epsilon() * <small constant>`
+- [ ] 2.1 Add `pub(crate) fn LatticeComplex<D, R>::edge_index(position: [usize; D], axis: usize) -> usize` mapping a `(position, axis)` pair to a flat `Vec<R>` index in the canonical `iter_cells(1)` ordering, with `pub(crate)` helpers `edges_along(axis)` and `valid_positions(d, orientation)`. Cover with an inline `#[cfg(test)] mod edge_index_tests` checking open/periodic/mixed-boundary lattices and end-to-end agreement with `iter_cells(1)` enumeration.
+- [ ] 2.2 Implement `CubicalReggeGeometry<D, R>::cell_volume(&self, complex: &LatticeComplex<D, R>, cell: &LatticeCell<D>, grade: usize) -> R` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`)
+- [ ] 2.3 Implement `CubicalReggeGeometry<D, R>::top_cell_volume(&self, complex, cell) -> R` as the `grade = D` convenience
+- [ ] 2.4 Add `debug_assert!` in the `PerEdge` path documenting the axis-aligned-cell assumption (cross-terms vanish)
+- [ ] 2.5 Write unit-edge property tests: every k-cube has volume exactly `R::one()` for every grade (instantiate over `f64` and `f32`)
+- [ ] 2.6 Write per-axis property tests: top-cube volume equals the fold-product of `axis_lengths` over `R`; k-cell volume equals product of active-axis lengths
+- [ ] 2.7 Write per-edge property test: a `PerEdge` metric with uniform-per-axis lengths reproduces the per-axis result to within `R::epsilon() * <small constant>`
+- [ ] 2.8 Add `src/utils_tests/cubical_regge_fixtures.rs` (and register in `src/utils_tests/mod.rs`) with shared fixtures for the R1–R3 tests (small open/periodic lattices with known geometry).
 
 ## 3. Phase R2 — Hinge enumeration + dihedral angles
 

--- a/openspec/changes/add-cubical-regge-calculus-core/tasks.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/tasks.md
@@ -32,16 +32,17 @@
 
 ## 4. Phase R3 — Deficit angles + Regge action
 
-- [ ] 4.1 Implement `CubicalReggeGeometry<D, R>::deficit_angle(&self, complex, hinge_id) -> R` in `curvature.rs` as `(R::pi() + R::pi()) − Σ dihedral_angle(c, h)` summed over `hinge_top_cube_neighbors(hinge_id)`
-- [ ] 4.2 Short-circuit `UnitEdge` (and `Uniform`, and `PerAxis` with all-equal lengths) at the entry of `deficit_angle` to return exact `R::zero()`, avoiding floating-point noise
-- [ ] 4.3 Implement `CubicalReggeGeometry<D, R>::regge_action(&self, complex) -> R` as `Σ_h cell_volume(h, D-2) · deficit_angle(h)` over every (D−2)-hinge, accumulated from `R::zero()`
-- [ ] 4.4 Apply the same flat-case short-circuit to `regge_action`, returning exact `R::zero()`
+- [ ] 4.1 Implement `CubicalReggeGeometry<D, R>::deficit_angle(&self, complex, hinge_id) -> R` in `curvature.rs` as `(R::pi() + R::pi()) − Σ dihedral_angle(c, h)` summed over `hinge_top_cube_neighbors(hinge_id)`. Per the R2 correction, dihedral is the constant `R::pi() / (R::one() + R::one())`, so this reduces to `(4 − n) · π/2` where `n` is the incident-top-cube count.
+- [ ] 4.2 Short-circuit `n == 4` (full incidence) at the entry of `deficit_angle` to return exact `R::zero()`, avoiding floating-point noise from `2π − 2π`. This replaces the original "variant-based" short-circuit, which the R2 correction makes redundant — deficit no longer depends on edge-length variant, only on hinge incidence count.
+- [ ] 4.3 Implement `CubicalReggeGeometry<D, R>::regge_action(&self, complex) -> R` as `Σ_h cell_volume(h) · deficit_angle(h)` over every (D−2)-hinge enumerated by `iter_cells(D − 2)`, accumulated from `R::zero()`. Returns `R::zero()` for `D < 2`.
+- [ ] 4.4 Skip the volume×deficit multiplication when `deficit_angle` returns `R::zero()` (saves a `cell_volume` call per interior hinge — a meaningful win on large periodic lattices where most hinges are interior).
 - [ ] 4.5 Document in the doc comment that `timelike_axes` is ignored in this change set; the Lorentzian variant is deferred to a follow-up change
-- [ ] 4.6 Write property test: unit-edge open lattice → every deficit angle is exactly `R::zero()`
+- [ ] 4.6 Write property test: unit-edge open lattice → interior hinges (with 4 incident cubes) have deficit exactly `R::zero()`; boundary hinges have deficit equal to `(4 − n) · π/2` where `n` is the incidence count (`1` at a 2D corner, `2` on a 2D edge, etc.). The original task expecting "every deficit is 0 on an open lattice" was based on the incorrect arctan2 dihedral formula; open boundaries carry real intrinsic curvature that the corrected geometry preserves.
 - [ ] 4.7 Write property test: unit-edge periodic lattice → every deficit angle is exactly `R::zero()`; total `regge_action` is exactly `R::zero()`
-- [ ] 4.8 Write property test: single-edge perturbation has bounded support — hinges not in any incident top cube of the perturbed edge still report `deficit_angle == R::zero()`
-- [ ] 4.9 Write property test: on a `PerAxis` metric with one axis stretched (so the flat-case short-circuit does not fire), the difference between the periodic and the open-boundary Regge action equals the explicit boundary-hinge contribution to within a few `R::epsilon()` (computed by summing `cell_volume(h, D-2) · deficit_angle(h)` over the boundary hinges that exist on the open lattice but wrap on the periodic one)
+- [ ] 4.8 Write property test: edge-length perturbation does NOT change any deficit angle (under the axis-aligned cubical assumption, deficit depends only on the lattice's topology, not on its metric). Verifies the R2 geometric simplification holds end-to-end.
+- [ ] 4.9 Write property test: on a 2D unit-edge open 3×3 lattice the regge_action equals the explicit closed-form sum `4 · 1 · 3π/2 + 4 · 1 · π + 1 · 1 · 0 = 10π` (4 corners with deficit 3π/2, 4 edge-vertices with deficit π, 1 interior vertex with deficit 0). On a 2D periodic 3×3 lattice it equals exactly 0. Difference = 10π = boundary-hinge contribution.
 - [ ] 4.10 Write property test: `regge_action` on a metric with `timelike_axes = Some(...)` equals the same metric with `timelike_axes = None` (Lorentzian path is deferred)
+- [ ] 4.11 Write property test: on a 3D `PerAxis` lattice with stretched axis lengths, regge_action picks up the per-axis edge volumes on boundary hinges — verifying the volume factor flows through to the action (the only edge-length sensitivity the axis-aligned R3 implementation has).
 
 ## 5. Public API export and documentation
 

--- a/openspec/changes/add-cubical-regge-calculus-core/tasks.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/tasks.md
@@ -21,14 +21,14 @@
 
 - [ ] 3.1 Implement `LatticeComplex<D, R>::hinge_top_cube_neighbors(&self, hinge_id) -> impl Iterator<Item = CellId>` by walking the cached `coboundary_matrix(D-2)` and `coboundary_matrix(D-1)`; deduplicate the result. Borrows the cached matrices directly (cache returns `Cow::Borrowed` after the §1.1 conversion).
 - [ ] 3.2 Add unit tests for hinge enumeration: 2D interior vertex → 4 squares; 3D interior edge → 4 cubes; 4D interior 2-cell → 4 4-cubes; periodic-boundary wrap-around; open-boundary corner / face hinges produce the correct reduced counts (1 / 2); determinism / no duplicates
-- [ ] 3.3 Implement `CubicalReggeGeometry<D, R>::dihedral_angle(&self, complex, top_cube_id, hinge_id) -> R` in `curvature.rs`, dispatching on the edge-length variant
-- [ ] 3.4 Short-circuit `UnitEdge` and `Uniform` to `R::pi() / (R::one() + R::one())` without touching the lattice
-- [ ] 3.5 Implement per-axis case using `R::atan2(lengths[j], lengths[i])` where `i, j` are the two axes inactive in the hinge but active in the top cube
-- [ ] 3.6 Implement per-edge case: read the two edge lengths of the top cube at the hinge along axes `i` and `j` (via `edge_index`) and apply the same `atan2` formula
-- [ ] 3.7 Document the contract for non-incident `(top_cube_id, hinge_id)` pairs in the doc comment (return `R::nan()`, `Err`, or panic — choose one and document it)
+- [ ] 3.3 Implement `CubicalReggeGeometry<D, R>::dihedral_angle(&self, complex, top_cube: &LatticeCell<D>, hinge: &LatticeCell<D>) -> R` in `curvature.rs`. Returns `R::pi() / (R::one() + R::one())` uniformly — the dihedral on an axis-aligned cubical complex is π/2 regardless of edge-length variant (see design.md Decision 4 correction).
+- [ ] 3.4 Add debug-assertions that `top_cube.cell_dim() == D` and `hinge.cell_dim() == D - 2`. The function does not validate incidence — callers are responsible for enumerating only incident pairs.
+- [ ] 3.5 *Superseded by 3.3.* The arctan2 per-axis formula in the original design note was geometrically incorrect; no per-axis-specific code path is needed.
+- [ ] 3.6 *Superseded by 3.3.* No per-edge-specific dihedral code path under the axis-aligned assumption.
+- [ ] 3.7 Document the non-incident-pair contract in the doc comment: misuse degrades to the geometric constant `π/2` rather than NaN or panic in release; debug builds catch grade mismatches via assertions.
 - [ ] 3.8 Write unit-edge property test: every dihedral angle equals `R::pi() / (R::one() + R::one())` to `R::epsilon()` tolerance
-- [ ] 3.9 Write per-axis property test: dihedral angles around any interior vertex on a 2D lattice sum to `R::pi() + R::pi()` (i.e. 2π) to a few `R::epsilon()`
-- [ ] 3.10 Write per-edge / per-axis agreement test: matching uniform-per-axis edge lengths produce identical dihedral angles to within a few `R::epsilon()`
+- [ ] 3.9 Write per-axis property test: dihedral angles around any interior vertex on a periodic 2D lattice sum to `R::pi() + R::pi()` (i.e. 2π) to a few `R::epsilon()`
+- [ ] 3.10 Write per-edge / per-axis agreement test: matching uniform-per-axis edge lengths produce identical dihedral angles to within a few `R::epsilon()` (trivially true now — both return π/2 — but kept as a regression guard against any future variant-specific code path)
 
 ## 4. Phase R3 — Deficit angles + Regge action
 

--- a/openspec/changes/add-cubical-regge-calculus-core/tasks.md
+++ b/openspec/changes/add-cubical-regge-calculus-core/tasks.md
@@ -9,8 +9,8 @@
 ## 2. Phase R1 — Cell volumes
 
 - [ ] 2.1 Add `pub(crate) fn LatticeComplex<D, R>::edge_index(position: [usize; D], axis: usize) -> usize` mapping a `(position, axis)` pair to a flat `Vec<R>` index in the canonical `iter_cells(1)` ordering, with `pub(crate)` helpers `edges_along(axis)` and `valid_positions(d, orientation)`. Cover with an inline `#[cfg(test)] mod edge_index_tests` checking open/periodic/mixed-boundary lattices and end-to-end agreement with `iter_cells(1)` enumeration.
-- [ ] 2.2 Implement `CubicalReggeGeometry<D, R>::cell_volume(&self, complex: &LatticeComplex<D, R>, cell: &LatticeCell<D>, grade: usize) -> R` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`)
-- [ ] 2.3 Implement `CubicalReggeGeometry<D, R>::top_cell_volume(&self, complex, cell) -> R` as the `grade = D` convenience
+- [ ] 2.2 Implement `CubicalReggeGeometry<D, R>::cell_volume(&self, complex: &LatticeComplex<D, R>, cell: &LatticeCell<D>) -> R` in `volumes.rs`, dispatching on the edge-length variant (`UnitEdge`, `Uniform`, `PerAxis`, `PerEdge`). Grade is derived from `cell.cell_dim()` — dropping the redundant `grade: usize` argument from the original design-note signature.
+- [ ] 2.3 Implement `CubicalReggeGeometry<D, R>::top_cell_volume(&self, complex, cell) -> R` as the `cell.cell_dim() == D` convenience (debug-asserts the dimension)
 - [ ] 2.4 Add `debug_assert!` in the `PerEdge` path documenting the axis-aligned-cell assumption (cross-terms vanish)
 - [ ] 2.5 Write unit-edge property tests: every k-cube has volume exactly `R::one()` for every grade (instantiate over `f64` and `f32`)
 - [ ] 2.6 Write per-axis property tests: top-cube volume equals the fold-product of `axis_lengths` over `R`; k-cell volume equals product of active-axis lengths


### PR DESCRIPTION

## Describe your changes

feat(deep_causality_topology): Added Cubical Regge Calculus 

## Issue ticket number and link

closes https://github.com/deepcausality-rs/deep_causality/issues/564

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the core of Cubical Regge Calculus to `deep_causality_topology` (cell volumes, hinge enumeration, dihedral/deficit angles, and Regge action) for axis‑aligned cubical lattices, and speeds up coboundary access with a lock‑free cache. Includes broad test additions, doc updates, and small cleanups across crates.

- **New Features**
  - `CubicalReggeGeometry<D, R>`: `cell_volume`/`top_cell_volume` (R1), `dihedral_angle` (π/2 on axis‑aligned cubes), `deficit_angle`, and `regge_action` (R2–R3).
  - `LatticeComplex<D, R>`: `hinge_top_cube_neighbors(hinge_id)` to list top D‑cubes incident to a (D−2) hinge.
  - New test utilities (`src/utils_tests/cubical_regge_utils.rs`) and a Bazel test suite for `types/cubical_regge_geometry`.
  - Docs/spec updates: clarify π/2 dihedral, update tasks/design for the axis‑aligned model.

- **Refactors**
  - `LatticeComplex` coboundary cache replaced with `OnceLock` slots (`Box<[OnceLock<CsrMatrix<i8>>; D+1]>`), returning borrowed matrices to avoid clones and remove runtime locks after first init.
  - `link_variable` U(1)/SU(2)×U(1) initialization simplified by dimension dispatch; removed dead name‑based branch.
  - `deep_causality_physics`: GR ops now expand Lie‑algebra field strength to a geometric Riemann tensor before Ricci/Einstein calculations.
  - Widespread test coverage improvements across crates; minor README/AGENTS tweaks, trivial `deep_causality_effects` keyword cleanup, and a repo formatting/lint pass.

<sup>Written for commit cf3156d905bdd1dce55cae3b01f85367b5ed1b72. Summary will update on new commits. <a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

