### PR TITLE
Fixed miri reported issues.

### DIFF
--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -54,6 +54,8 @@ jobs:
         include:
           - crate: deep_causality
             extra_flags: -Zmiri-disable-isolation       # clock_gettime in test setup
+          - crate: deep_causality_core
+            extra_flags: -Zmiri-disable-isolation       # EffectLog::add_entry calls SystemTime::now (log_effect.rs:57)
           - crate: deep_causality_discovery
             extra_flags: -Zmiri-disable-isolation       # DSL opens files
           - crate: deep_causality_uncertain

--- a/deep_causality/tests/types/context_node_types/space/ned_space/ned_space_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space/ned_space/ned_space_tests.rs
@@ -39,6 +39,10 @@ fn test_display_trait() {
 }
 
 #[test]
+// Disabled under Miri: soft-float emulation produces last-bit differences
+// for `sqrt`, so the exact-equality assertion fails. Test is correct under
+// normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_metric_trait() {
     let n1 = NedSpace::new(1, 0.0, 0.0, 0.0);
     let n2 = NedSpace::new(2, 100.0, 50.0, 10.0);

--- a/deep_causality/tests/types/context_node_types/space_time/lorentzian/lorentzian_spacetime_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space_time/lorentzian/lorentzian_spacetime_tests.rs
@@ -87,6 +87,11 @@ fn test_interval_squared_spacelike_is_positive() {
 }
 
 #[test]
+// Disabled under Miri: the null-like interval is `-(c·Δt)² + Δx²` with both
+// terms ~9e16, so the result is catastrophic cancellation around zero. The
+// 1e-6 tolerance holds on hardware FP but is exceeded by ~1 ULP of soft-float
+// drift under Miri. Test is correct under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_interval_squared_null_like() {
     let c = 299_792_458.0;
     let a = LorentzianSpacetime::new(1, c, 0.0, 0.0, 1.0, TimeScale::Second);

--- a/deep_causality/tests/types/context_node_types/space_time/minkowski/minkowski_spacetime_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space_time/minkowski/minkowski_spacetime_tests.rs
@@ -72,6 +72,12 @@ fn test_interval_squared_space_like() {
 }
 
 #[test]
+// Disabled under Miri: the light-like interval is `-(c·dt)² + dx²` with both
+// terms ~9e16, so the result is catastrophic cancellation around zero. The
+// 1e-6 tolerance holds on hardware FP but is exceeded by ~1 ULP of soft-float
+// drift under Miri (observed |s²| ~ 96, i.e. ~1 ULP of 9e16). Test is correct
+// under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_interval_squared_light_like() {
     let c = 299_792_458.0;
     let dt = 1.0;

--- a/deep_causality/tests/types/context_node_types/space_time/tangent_spacetime/tangent_spacetime_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space_time/tangent_spacetime/tangent_spacetime_tests.rs
@@ -142,6 +142,10 @@ fn test_time_velocity() {
 }
 
 #[test]
+// Disabled under Miri: soft-float emulation produces last-bit differences for
+// `sqrt`, so the exact-equality assertion fails. Test is correct under normal
+// CI.
+#[cfg_attr(miri, ignore)]
 fn test_spatial_velocity() {
     let t = TangentSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, 1.0, 3.0, 4.0, 12.0);
     let expected = (3.0_f64.powi(2) + 4.0_f64.powi(2) + 12.0_f64.powi(2)).sqrt();
@@ -155,6 +159,10 @@ fn test_velocity_vector() {
 }
 
 #[test]
+// Disabled under Miri: soft-float emulation produces last-bit differences for
+// `sqrt`, so the exact-equality assertion fails. Test is correct under normal
+// CI.
+#[cfg_attr(miri, ignore)]
 fn test_euclidean_distance() {
     let t1 = TangentSpacetime::new(1, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0);
     let t2 = TangentSpacetime::new(2, 4.0, 6.0, 3.0, 0.0, 1.0, 0.0, 0.0, 0.0);

--- a/deep_causality_algorithms/tests/causal_discovery/surd/mod.rs
+++ b/deep_causality_algorithms/tests/causal_discovery/surd/mod.rs
@@ -3,8 +3,17 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 mod surd_algo_cdl_info_leak_tests;
+// `surd_algo_cdl_max_order_tests` and `surd_algo_cdl_tests` are skipped under
+// Miri: the CDL (`Option<f64>`) path branches on tight (`< 1e-14`) thresholds
+// and uses float-keyed sort tie-breaking. Miri's soft-float emulation drifts
+// intermediate results by ~1 ULP, which crosses those threshold/tie edges and
+// causes `ShapeMismatch` errors or wrong state-bucket classification. The
+// non-CDL SURD coverage above still runs under Miri. Tests are correct and
+// pass under normal CI.
+#[cfg(not(miri))]
 mod surd_algo_cdl_max_order_tests;
 mod surd_algo_cdl_none_tests;
+#[cfg(not(miri))]
 mod surd_algo_cdl_tests;
 #[cfg(test)]
 mod surd_algo_tests;

--- a/deep_causality_num/tests/algebra/field_real_f32_tests.rs
+++ b/deep_causality_num/tests/algebra/field_real_f32_tests.rs
@@ -46,6 +46,10 @@ fn test_round() {
 }
 
 #[test]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_exp() {
     let x = 1.0_f32;
     assert_eq!(RealField::exp(x), x.exp());
@@ -65,6 +69,10 @@ fn test_log() {
 }
 
 #[test]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_powf() {
     let x = 2.0_f32;
     let n = 3.0_f32;

--- a/deep_causality_num/tests/algebra/field_real_f64_tests.rs
+++ b/deep_causality_num/tests/algebra/field_real_f64_tests.rs
@@ -70,6 +70,10 @@ fn test_log() {
 }
 
 #[test]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_powf() {
     let x = 2.0_f64;
     let n = 3.0_f64;

--- a/deep_causality_num/tests/complex/quaternion_number/quaternion_number_tests.rs
+++ b/deep_causality_num/tests/complex/quaternion_number/quaternion_number_tests.rs
@@ -20,6 +20,10 @@ fn test_norm_sqr() {
 }
 
 #[test]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops (sqrt/powi here), so exact equality cannot
+// hold. The test itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_norm() {
     let q = Quaternion::new(1.0, 2.0, 3.0, 4.0);
     assert_eq!(

--- a/deep_causality_num/tests/complex/quaternion_number/rotation_tests.rs
+++ b/deep_causality_num/tests/complex/quaternion_number/rotation_tests.rs
@@ -43,6 +43,10 @@ fn test_to_axis_angle_y_180() {
 }
 
 #[test]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so the tight EPSILON tolerance is exceeded.
+// The test itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_to_axis_angle_z_360() {
     // 360 degrees around Z axis (equivalent to 0 degrees)
     let q_z_360 = Quaternion::from_axis_angle([0.0, 0.0, 1.0], std::f64::consts::TAU);

--- a/deep_causality_num/tests/float/float_32_tests.rs
+++ b/deep_causality_num/tests/float/float_32_tests.rs
@@ -164,6 +164,7 @@ fn powi_val() {
     assert_eq!(Float::powi(2.0f32, 3), 8.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn powf_val() {
     assert_eq!(Float::powf(2.0f32, 3.0), 8.0);
 }
@@ -176,10 +177,12 @@ fn sqrt_neg() {
     assert!(Float::sqrt(-1.0f32).is_nan());
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn exp_val() {
     assert_eq!(Float::exp(1.0f32), std::f32::consts::E);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn exp2_val() {
     assert_eq!(Float::exp2(3.0f32), 8.0);
 }
@@ -188,14 +191,17 @@ fn ln_val() {
     assert!((Float::ln(std::f32::consts::E) - 1.0).abs() < 1e-6);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn log_val() {
     assert_eq!(Float::log(10.0f32, 10.0), 1.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn log2_val() {
     assert_eq!(Float::log2(8.0f32), 3.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn log10_val() {
     assert_eq!(Float::log10(100.0f32), 2.0);
 }
@@ -228,6 +234,7 @@ fn clamp_high() {
     assert_eq!(Float::clamp(2.5f32, 1.0, 2.0), 2.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn cbrt_val() {
     assert_eq!(Float::cbrt(8.0f32), 2.0);
 }

--- a/deep_causality_num/tests/float/float_64_tests.rs
+++ b/deep_causality_num/tests/float/float_64_tests.rs
@@ -160,10 +160,12 @@ fn recip_val() {
     assert_eq!(Float::recip(2.0f64), 0.5);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn powi_val() {
     assert_eq!(Float::powi(2.0f64, 3), 8.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn powf_val() {
     assert_eq!(Float::powf(2.0f64, 3.0), 8.0);
 }
@@ -184,10 +186,12 @@ fn exp_val() {
     assert!((Float::exp(1.0f64) - std::f64::consts::E).abs() < 1e-10);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn exp2_val() {
     assert_eq!(Float::exp2(3.0f64), 8.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn ln_val() {
     assert_eq!(Float::ln(std::f64::consts::E), 1.0);
 }
@@ -196,10 +200,12 @@ fn log_val() {
     assert_eq!(Float::log(10.0f64, 10.0), 1.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn log2_val() {
     assert_eq!(Float::log2(8.0f64), 3.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn log10_val() {
     assert_eq!(Float::log10(100.0f64), 2.0);
 }
@@ -232,14 +238,17 @@ fn clamp_high() {
     assert_eq!(Float::clamp(2.5f64, 1.0, 2.0), 2.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn cbrt_val() {
     assert_eq!(Float::cbrt(8.0f64), 2.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn hypot_val() {
     assert_eq!(Float::hypot(3.0f64, 4.0), 5.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn sin_val() {
     assert_eq!(Float::sin(std::f64::consts::PI / 2.0), 1.0);
 }
@@ -252,18 +261,22 @@ fn tan_val() {
     assert!((Float::tan(std::f64::consts::PI / 4.0) - 1.0).abs() < 1e-15);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn asin_val() {
     assert_eq!(Float::asin(1.0f64), std::f64::consts::PI / 2.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn acos_val() {
     assert_eq!(Float::acos(0.0f64), std::f64::consts::PI / 2.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn atan_val() {
     assert_eq!(Float::atan(1.0f64), std::f64::consts::PI / 4.0);
 }
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn atan2_val() {
     assert_eq!(Float::atan2(1.0f64, 1.0), std::f64::consts::PI / 4.0);
 }

--- a/deep_causality_num/tests/float_double/double_transcendental_tests.rs
+++ b/deep_causality_num/tests/float_double/double_transcendental_tests.rs
@@ -159,6 +159,7 @@ fn test_powi_negative() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri's soft-float emulation produces last-bit differences vs hardware; test is correct under normal CI.
 fn test_powf() {
     let result = <Float106 as Float>::powf(d(2.0), d(3.0));
     assert!(approx_eq(result, d(8.0), 1e-14));

--- a/deep_causality_rand/tests/types/dist/normal/standard_normal_tests.rs
+++ b/deep_causality_rand/tests/types/dist/normal/standard_normal_tests.rs
@@ -33,6 +33,10 @@ macro_rules! standard_normal_tests {
         }
 
         #[test]
+        // Disabled under Miri: soft-float emulation skews the statistical
+        // sampling enough to exceed the symmetry tolerance. Test is correct
+        // under normal CI.
+        #[cfg_attr(miri, ignore)]
         fn test_symmetry() {
             let mut rng = rng();
             let distr = StandardNormal;

--- a/deep_causality_tensor/src/extensions/ext_math.rs
+++ b/deep_causality_tensor/src/extensions/ext_math.rs
@@ -22,6 +22,7 @@ pub trait CausalTensorMathExt<T> {
     /// ```
     /// use deep_causality_tensor::{CausalTensor, CausalTensorMathExt};
     ///
+    /// # if cfg!(miri) { return; } // Miri's soft-float emulation perturbs last bits.
     /// let tensor = CausalTensor::new(vec![1.0, std::f32::consts::E, 10.0], vec![3, 1]).unwrap();
     /// let result = tensor.log_nat().unwrap();
     ///
@@ -45,6 +46,7 @@ pub trait CausalTensorMathExt<T> {
     /// ```
     /// use deep_causality_tensor::{CausalTensor, CausalTensorMathExt};
     ///
+    /// # if cfg!(miri) { return; } // Miri's soft-float emulation perturbs last bits.
     /// let tensor = CausalTensor::new(vec![1.0, 2.0, 4.0, 8.0], vec![4, 1]).unwrap();
     /// let result = tensor.log2().unwrap();
     ///
@@ -68,6 +70,7 @@ pub trait CausalTensorMathExt<T> {
     /// ```
     /// use deep_causality_tensor::{CausalTensor, CausalTensorMathExt};
     ///
+    /// # if cfg!(miri) { return; } // Miri's soft-float emulation perturbs last bits.
     /// let tensor = CausalTensor::new(vec![1.0, 10.0, 100.0], vec![3, 1]).unwrap();
     /// let result = tensor.log10().unwrap();
     ///

--- a/deep_causality_uncertain/tests/algos/hypothesis/mod.rs
+++ b/deep_causality_uncertain/tests/algos/hypothesis/mod.rs
@@ -2,5 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-#[cfg(test)]
+// Skipped under Miri: this module uses `rusty_fork_test!`, which spawns a
+// subprocess via `posix_spawn`. Miri does not implement the `posix_spawn*`
+// libc shims, so any test wrapped in `rusty_fork_test!` aborts under Miri.
+// The tests themselves are correct and run under normal CI.
+#[cfg(all(test, not(miri)))]
 mod sprt_eval_tests;

--- a/deep_causality_uncertain/tests/errors/mod.rs
+++ b/deep_causality_uncertain/tests/errors/mod.rs
@@ -3,5 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-#[cfg(test)]
+// Skipped under Miri: this module uses `rusty_fork_test!`, which spawns a
+// subprocess via `posix_spawn`. Miri does not implement the `posix_spawn*`
+// libc shims, so any test wrapped in `rusty_fork_test!` aborts under Miri.
+// The tests themselves are correct and run under normal CI.
+#[cfg(all(test, not(miri)))]
 mod uncertain_error_tests;

--- a/deep_causality_uncertain/tests/integration_tests/mod.rs
+++ b/deep_causality_uncertain/tests/integration_tests/mod.rs
@@ -2,5 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-#[cfg(test)]
+// Skipped under Miri: this module uses `rusty_fork_test!`, which spawns a
+// subprocess via `posix_spawn`. Miri does not implement the `posix_spawn*`
+// libc shims, so any test wrapped in `rusty_fork_test!` aborts under Miri.
+// The tests themselves are correct and run under normal CI.
+#[cfg(all(test, not(miri)))]
 mod complex_operations_tests;

--- a/deep_causality_uncertain/tests/types/cache/mod.rs
+++ b/deep_causality_uncertain/tests/types/cache/mod.rs
@@ -2,7 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-#[cfg(test)]
+// `cache_tests` is skipped under Miri: it uses `rusty_fork_test!`, which
+// spawns a subprocess via `posix_spawn`. Miri does not implement the
+// `posix_spawn*` libc shims, so it aborts. The tests are correct and run
+// under normal CI.
+#[cfg(all(test, not(miri)))]
 mod cache_tests;
 #[cfg(test)]
 mod sampled_value_tests;

--- a/deep_causality_uncertain/tests/types/uncertain/mod.rs
+++ b/deep_causality_uncertain/tests/types/uncertain/mod.rs
@@ -2,17 +2,21 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-#[cfg(test)]
+// Modules using `rusty_fork_test!` are skipped under Miri: that macro spawns
+// a subprocess via `posix_spawn`, and Miri does not implement the
+// `posix_spawn*` libc shims, so the tests abort. They are correct and run
+// under normal CI.
+#[cfg(all(test, not(miri)))]
 mod uncertain_arithmetic_tests;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_comparison_tests;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_default;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_logic_tests;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_sampling_tests;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_statistics_tests;
 #[cfg(test)]
 mod uncertain_tests;

--- a/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
+++ b/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
@@ -2,10 +2,14 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+// `uncertain_maybe_f64_*` modules are skipped under Miri: they use
+// `rusty_fork_test!`, which spawns a subprocess via `posix_spawn`. Miri does
+// not implement the `posix_spawn*` libc shims, so the tests abort. They are
+// correct and run under normal CI.
 #[cfg(test)]
 mod uncertain_maybe_bool_tests;
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_maybe_f64_tests;
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod uncertain_maybe_f64_arithmetic_tests;


### PR DESCRIPTION
## Describe your changes

Fixed miri reported issues.

## Issue ticket number and link

https://github.com/deepcausality-rs/deep_causality/issues/554

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized Miri runs by skipping float-sensitive and forked tests under Miri and by disabling isolation for `deep_causality_core`. This makes Miri green across crates without changing runtime behavior; normal CI stays the same.

- **Bug Fixes**
  - Gated float-sensitive tests/doctests under Miri in `deep_causality`, `deep_causality_num`, `deep_causality_rand`, `deep_causality_tensor`, and the CDL SURD path in `deep_causality_algorithms` to avoid soft-float last-bit drift and cancellation edge cases; non-CDL coverage still runs.
  - Skipped `rusty_fork_test!` modules under Miri in `deep_causality_uncertain` to avoid missing `posix_spawn*` shims.
  - CI: disabled Miri isolation for `deep_causality_core` so `SystemTime::now()` calls in effect logging can run while keeping UB checks active.

<sup>Written for commit f26463fc3227173a1ee60d4aa996b4c4c2bb3ccd. Summary will update on new commits. <a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

