### PR TITLE
Added social OG image to documentation page.

### DIFF
--- a/website/docs/astro.config.mjs
+++ b/website/docs/astro.config.mjs
@@ -49,6 +49,13 @@ export default defineConfig({
           content:
             "addEventListener('DOMContentLoaded',function(){document.querySelectorAll('.social-icons a').forEach(function(a){a.target='_blank';a.rel='me noopener noreferrer';});});",
         },
+        // Default social-share (Open Graph + Twitter) image for every docs page.
+        { tag: 'meta', attrs: { property: 'og:image', content: 'https://docs.deepcausality.com/img/social-share.jpg' } },
+        { tag: 'meta', attrs: { property: 'og:image:width', content: '1200' } },
+        { tag: 'meta', attrs: { property: 'og:image:height', content: '630' } },
+        { tag: 'meta', attrs: { property: 'og:image:alt', content: 'DeepCausality' } },
+        { tag: 'meta', attrs: { name: 'twitter:card', content: 'summary_large_image' } },
+        { tag: 'meta', attrs: { name: 'twitter:image', content: 'https://docs.deepcausality.com/img/social-share.jpg' } },
       ],
       social: [
         { icon: 'discord', label: 'Discord', href: 'https://discord.gg/Bxj9P7JXSj' },


### PR DESCRIPTION


## Describe your changes

Added social OG image to documentation page.

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a default social-share image (Open Graph and Twitter) to all docs pages so shared links show a consistent, branded preview card.

Implemented `og:image`, `twitter:image`, and `twitter:card=summary_large_image` in `website/docs/astro.config.mjs` using an absolute URL to a 1200x630 `social-share.jpg`.

<sup>Written for commit 3b6bf39c82893a7232feda3038ceec53e5550705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/595?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

