### PR TITLE
feat(website): 301-redirect old /docs section paths to docs.deepcausality.com

### DIFF
--- a/website/web/public/_redirects
+++ b/website/web/public/_redirects
@@ -1,0 +1,9 @@
+# Cloudflare redirects for documentation that moved to docs.deepcausality.com.
+#
+# The /docs/ overview page still lives on this site, so only the old section
+# sub-paths are redirected. The splat (:splat) preserves the path tail,
+# including its trailing slash, e.g. /docs/concepts/causaloid/ maps to
+# https://docs.deepcausality.com/concepts/causaloid/. First match wins.
+/docs/concepts/*        https://docs.deepcausality.com/concepts/:splat        301
+/docs/getting-started/* https://docs.deepcausality.com/getting-started/:splat 301
+/docs/overview/*        https://docs.deepcausality.com/overview/:splat        301


### PR DESCRIPTION

## Describe your changes

The concept, getting-started, and overview docs moved to the standalone docs
site. Add a Cloudflare _redirects file (copied to dist/ on build, picked up by
Workers Static Assets) so the old sub-paths permanently redirect 1:1:

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cloudflare `_redirects` to 301-redirect old /docs section paths to docs.deepcausality.com. Redirects `/docs/concepts/*`, `/docs/getting-started/*`, and `/docs/overview/*` 1:1 (splat preserves the path and trailing slash); the bare `/docs/` page stays local.

<sup>Written for commit a3b2d29382b25049a11ac1efcaa9c734d7fb3cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/597?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

