### PR TITLE
feat(website): add end-to-end causal stack diagram to front page

### DIFF
--- a/website/docs/src/content/docs/concepts/deployment.md
+++ b/website/docs/src/content/docs/concepts/deployment.md
@@ -1,0 +1,78 @@
+---
+title: Deployment
+description: A DeepCausality model carries no runtime of its own. It runs synchronously, asynchronously on Tokio, and concurrently across threads behind a shared lock that does not become a bottleneck.
+sidebar:
+  order: 14
+---
+
+A DeepCausality model may run in a normal binary, on a background thread, or across a pool of Tokio worker threads.
+
+This page works through the deployment story using the [`tokio_example`](https://github.com/deepcausality-rs/deep_causality/tree/main/examples/tokio_example) crate.
+
+## A runtime-agnostic core
+
+A [Causaloid](/concepts/causaloid/) is evaluated through `evaluate(&self, ...)`. The call borrows the Causaloid; it does not consume or mutate it. The rule itself is a function pointer, so evaluation allocates nothing on the heap and dispatches nothing through a vtable. One value goes in, one `PropagatingEffect` comes out.
+
+Two consequences follow. A single Causaloid can be evaluated any number of times. And because evaluation is a shared read, it can be evaluated from many places at once and is therefore the thread-safe.
+
+## Asynchronous serving with Tokio
+
+For a service that ingests a stream of events, pair the model with [Tokio](https://tokio.rs) and run inference on a task. The example's entry point is just twelve lines:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let event_handler = EventHandler::new(build_causal_model());
+
+    tokio::spawn(async move {
+        if let Err(e) = event_handler.run_background_inference().await {
+            eprintln!("inference error: {e}");
+        }
+    })
+    .await
+    .expect("Failed to spawn async background task");
+
+    Ok(())
+}
+```
+
+The model is built once, the handler takes ownership, and inference runs on a spawned task while the main task stays free. In a real service the task is long-lived: it reads events off a channel and the `.await` becomes a graceful-shutdown handle.
+
+The inference inside the task is synchronous. There is no `.await` in the evaluation path, no async Causaloid, no futures threaded through the causal logic. The asynchrony sits at the runtime boundary. This keeps the causal code simple and keeps the hot path free of executor overhead.
+
+## Multi-threaded serving
+
+The model is shareable across threads, and the lock that makes it shareable does not serialize the work. The handler holds the model behind an `Arc<RwLock<...>>`, and the Causaloid inside it is itself an `Arc`:
+
+```rust
+pub struct EventHandler {
+    model: Arc<RwLock<BaseModelTokio>>,
+}
+
+pub async fn run_background_inference(&self) -> Result<(), Box<dyn Error + Send>> {
+    let causaloid = {
+        let model = self.model.read().unwrap();
+        Arc::clone(model.causaloid())
+        // read guard dropped here
+    };
+
+    for d in data.into_iter() {
+        self.handle_inference(d, &causaloid)?;
+    }
+    Ok(())
+}
+```
+
+The pattern is deliberate. A worker takes the read lock, clones the inner `Arc<Causaloid>`, and drops the guard immediately. The lock is held for the few microseconds it takes to copy a pointer. After that, the worker evaluates against its own `Arc` clone with no lock at all.
+
+That is what allows concurrent serving. An `RwLock` admits many readers at once, so any number of Tokio worker threads can clone the pointer in parallel; none of them blocks on inference because none of them holds the lock while inferring. The same model answers one request or a million, and the Causaloid's `evaluate(&self)` signature guarantees the shared access is safe. A writer takes the lock only when the model or its [Context](/concepts/context/) must be updated, and only then do readers wait.
+
+## Run the example
+
+```bash
+git clone https://github.com/deepcausality-rs/deep_causality
+cd deep_causality
+cargo run --release -p tokio_example
+```
+
+The program builds the handler, starts the background task, and prints one line per inference before exiting cleanly.

--- a/website/docs/src/content/docs/concepts/deployment.md
+++ b/website/docs/src/content/docs/concepts/deployment.md
@@ -13,7 +13,7 @@ This page works through the deployment story using the [`tokio_example`](https:/
 
 A [Causaloid](/concepts/causaloid/) is evaluated through `evaluate(&self, ...)`. The call borrows the Causaloid; it does not consume or mutate it. The rule itself is a function pointer, so evaluation allocates nothing on the heap and dispatches nothing through a vtable. One value goes in, one `PropagatingEffect` comes out.
 
-Two consequences follow. A single Causaloid can be evaluated any number of times. And because evaluation is a shared read, it can be evaluated from many places at once and is therefore the thread-safe.
+Two consequences follow. A single Causaloid can be evaluated any number of times. And because evaluation is a shared read, it can be evaluated from many places at once, which makes it thread-safe.
 
 ## Asynchronous serving with Tokio
 
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The model is built once, the handler takes ownership, and inference runs on a spawned task while the main task stays free. In a real service the task is long-lived: it reads events off a channel and the `.await` becomes a graceful-shutdown handle.
+The model is built once, the handler takes ownership, and inference runs on a spawned task. Here the main task awaits that task, so the program runs to completion and exits cleanly. In a real service the task is long-lived: it reads events off a channel, the main task is free to do other work, and the `.await` becomes a graceful-shutdown handle.
 
 The inference inside the task is synchronous. There is no `.await` in the evaluation path, no async Causaloid, no futures threaded through the causal logic. The asynchrony sits at the runtime boundary. This keeps the causal code simple and keeps the hot path free of executor overhead.
 

--- a/website/web/src/components/examples/CategoryList.astro
+++ b/website/web/src/components/examples/CategoryList.astro
@@ -1,53 +1,92 @@
 ---
-import { getCollection } from 'astro:content';
+import {getCollection} from 'astro:content';
 import ExamplesList from './ExamplesList.astro';
 
 type Category = 'foundations' | 'aerospace' | 'physics' | 'medicine' | 'mathematics';
 
 interface Props {
-  category: Category;
-  title: string;
-  description: string;
-  eyebrow: string;
+    category: Category;
+    title: string;
+    description: string;
+    eyebrow: string;
 }
 
-const { category, title, description, eyebrow } = Astro.props;
+const {category, title, description, eyebrow} = Astro.props;
 
 const entries = (await getCollection('examples'))
-  .filter((e) => e.data.category === category)
-  .sort((a, b) => a.data.order - b.data.order);
+    .filter((e) => e.data.category === category)
+    .sort((a, b) => a.data.order - b.data.order);
 ---
 <section class="cat-page">
-  <header>
-    <p class="eyebrow">{eyebrow}</p>
-    <h1>{title}</h1>
-    <p class="lede">{description}</p>
-  </header>
+    <header>
+        <p class="eyebrow">{eyebrow}</p>
+        <h1>{title}</h1>
+        <p class="lede">{description}</p>
+    </header>
 
-  {entries.length > 0
-    ? <ExamplesList entries={entries} />
-    : <p class="empty">No examples in this category yet.</p>}
+    {entries.length > 0
+        ?
+            <ExamplesList entries={entries}/>
+        : <p class="empty">No examples in this category yet.</p>}
 
-  <nav class="back" aria-label="Back to all examples">
-    <a href="/examples/">&larr; All examples</a>
-  </nav>
+    <nav class="back" aria-label="Back to all examples">
+        <a href="/examples/">&larr; All examples</a>
+    </nav>
 </section>
 
 <style>
-  .cat-page { max-width: var(--w-page); margin: 0 auto; padding: var(--space-7) var(--space-4); }
-  @media (min-width: 720px) { .cat-page { padding: var(--space-9) var(--space-5); } }
-  .cat-page header { max-width: 60ch; margin-bottom: var(--space-7); }
-  .eyebrow {
-    margin: 0;
-    font-size: var(--t-eyebrow); letter-spacing: var(--ls-eyebrow);
-    text-transform: uppercase; color: var(--fg-2);
-  }
-  h1 { margin: var(--space-2) 0 var(--space-3) 0; }
-  .lede { color: var(--fg-1); margin: 0; max-width: var(--measure); }
+    .cat-page {
+        max-width: var(--w-page);
+        margin: 0 auto;
+        padding: var(--space-7) var(--space-4);
+    }
 
-  .empty { color: var(--fg-1); padding: var(--space-6) 0; border-top: 1px solid var(--line-1); margin: 0; }
+    @media (min-width: 720px) {
+        .cat-page {
+            padding: var(--space-9) var(--space-5);
+        }
+    }
 
-  .back { margin-top: var(--space-8); }
-  .back a { color: var(--fg-1); border-bottom: none; }
-  .back a:hover { color: var(--fg-0); }
+    .cat-page header {
+        max-width: 60ch;
+        margin-bottom: var(--space-7);
+    }
+
+    .eyebrow {
+        margin: 0;
+        font-size: var(--t-eyebrow);
+        letter-spacing: var(--ls-eyebrow);
+        text-transform: uppercase;
+        color: var(--fg-2);
+    }
+
+    h1 {
+        margin: var(--space-2) 0 var(--space-3) 0;
+    }
+
+    .lede {
+        color: var(--fg-1);
+        margin: 0;
+        max-width: var(--measure);
+    }
+
+    .empty {
+        color: var(--fg-1);
+        padding: var(--space-6) 0;
+        border-top: 1px solid var(--line-1);
+        margin: 0;
+    }
+
+    .back {
+        margin-top: var(--space-8);
+    }
+
+    .back a {
+        color: var(--fg-1);
+        border-bottom: none;
+    }
+
+    .back a:hover {
+        color: var(--fg-0);
+    }
 </style>

--- a/website/web/src/components/examples/ExampleDetail.astro
+++ b/website/web/src/components/examples/ExampleDetail.astro
@@ -1,16 +1,16 @@
 ---
-import { GITHUB_URL, DOCSRS_BASE, DOCS_URL } from '../../consts';
+import {GITHUB_URL, DOCSRS_BASE, DOCS_URL} from '../../consts';
 
 interface Props {
-  title: string;
-  domain: string;
-  summary: string;
-  crates: string[];
-  source?: string;
-  further: { label: string; href: string }[];
+    title: string;
+    domain: string;
+    summary: string;
+    crates: string[];
+    source?: string;
+    further: { label: string; href: string }[];
 }
 
-const { title, domain, summary, crates, source, further } = Astro.props;
+const {title, domain, summary, crates, source, further} = Astro.props;
 const repoBase = `${GITHUB_URL}/blob/main`;
 const sourceHref = source ? `${repoBase}/${source}` : undefined;
 
@@ -18,150 +18,253 @@ const sourceHref = source ? `${repoBase}/${source}` : undefined;
 // further-reading links to DOCS_URL, dropping the `/docs` prefix; other hrefs
 // pass through unchanged.
 const resolveFurther = (href: string) =>
-  href.startsWith('/docs/') ? `${DOCS_URL}${href.slice('/docs'.length)}` : href;
+    href.startsWith('/docs/') ? `${DOCS_URL}${href.slice('/docs'.length)}` : href;
 ---
 <article class="ex-detail">
-  <header class="ex-head">
-    <p class="eyebrow">{domain}</p>
-    <h1>{title}</h1>
-    <p class="summary">{summary}</p>
-    {crates.length > 0 && (
-      <ul class="crate-row" aria-label="Related crates">
-        {crates.map((c) => <li><a href={`${DOCSRS_BASE}/${c}`}><code>{c}</code></a></li>)}
-      </ul>
+    <header class="ex-head">
+        <p class="eyebrow">{domain}</p>
+        <h1>{title}</h1>
+        <p class="summary">{summary}</p>
+        {crates.length > 0 && (
+                <ul class="crate-row" aria-label="Related crates">
+                    {crates.map((c) =>
+                            <li><a href={`${DOCSRS_BASE}/${c}`}><code>{c}</code></a></li>)}
+                </ul>
+        )}
+        {sourceHref && (
+                <p class="src-line">
+                    Source: <a href={sourceHref}><code>{source}</code></a>
+                </p>
+        )}
+    </header>
+
+    <section class="ex-body">
+        <slot/>
+    </section>
+
+    {further.length > 0 && (
+            <aside class="ex-further">
+                <h2>Further reading</h2>
+                <ul>
+                    {further.map((f) =>
+                            <li><a href={resolveFurther(f.href)}>{f.label}</a></li>)}
+                </ul>
+            </aside>
     )}
-    {sourceHref && (
-      <p class="src-line">
-        Source: <a href={sourceHref}><code>{source}</code></a>
-      </p>
-    )}
-  </header>
 
-  <section class="ex-body">
-    <slot />
-  </section>
-
-  {further.length > 0 && (
-    <aside class="ex-further">
-      <h2>Further reading</h2>
-      <ul>
-        {further.map((f) => <li><a href={resolveFurther(f.href)}>{f.label}</a></li>)}
-      </ul>
-    </aside>
-  )}
-
-  <nav class="ex-back" aria-label="Back to examples">
-    <a href="/examples/">&larr; All examples</a>
-  </nav>
+    <nav class="ex-back" aria-label="Back to examples">
+        <a href="/examples/">&larr; All examples</a>
+    </nav>
 </article>
 
 <style>
-  .ex-detail { max-width: var(--w-prose); margin: 0 auto; padding: var(--space-7) var(--space-4); }
-  @media (min-width: 720px) { .ex-detail { padding: var(--space-9) var(--space-5); } }
-  .ex-head { display: flex; flex-direction: column; gap: var(--space-3); margin-bottom: var(--space-7); max-width: 60ch; }
-  .eyebrow {
-    margin: 0;
-    font-size: var(--t-eyebrow); letter-spacing: var(--ls-eyebrow);
-    text-transform: uppercase; color: var(--fg-2);
-  }
-  h1 { margin: 0; font-size: var(--t-h1); line-height: var(--lh-h1); letter-spacing: var(--ls-h1); }
-  .summary { margin: 0; color: var(--fg-1); font-size: var(--t-h4); line-height: var(--lh-h3); max-width: 56ch; }
+    .ex-detail {
+        max-width: var(--w-prose);
+        margin: 0 auto;
+        padding: var(--space-7) var(--space-4);
+    }
 
-  .crate-row {
-    list-style: none; padding: 0; margin: var(--space-2) 0 0 0;
-    display: flex; flex-wrap: wrap; gap: var(--space-2);
-  }
-  .crate-row a {
-    display: inline-block;
-    padding: var(--space-1) var(--space-3);
-    border: 1px solid var(--line-1);
-    border-radius: var(--radius-pill);
-    color: var(--fg-1);
-    border-bottom: 1px solid var(--line-1);
-    font-size: var(--t-body-sm);
-  }
-  .crate-row code { background: transparent; padding: 0; }
-  .crate-row a:hover { color: var(--fg-0); border-color: var(--line-2); }
+    @media (min-width: 720px) {
+        .ex-detail {
+            padding: var(--space-9) var(--space-5);
+        }
+    }
 
-  .src-line {
-    margin: var(--space-3) 0 0 0;
-    color: var(--fg-2);
-    font-size: var(--t-body-sm);
-  }
-  .src-line code { background: transparent; padding: 0; }
-  .src-line a { color: var(--fg-1); border-bottom: none; }
-  .src-line a:hover { color: var(--fg-0); }
+    .ex-head {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        margin-bottom: var(--space-7);
+        max-width: 60ch;
+    }
 
-  .ex-body { max-width: var(--w-prose); }
-  .ex-body :global(h2) { margin: var(--space-7) 0 var(--space-3); }
-  .ex-body :global(h3) { margin: var(--space-6) 0 var(--space-2); }
-  .ex-body :global(p) { color: var(--fg-1); max-width: var(--measure); }
-  /* Code listings get the same HUD-frame treatment as the home-page
-     example panel and the community cards: subtle vertical gradient
-     (via background-image to bypass the global `!important`
-     background-color on pre.astro-code), border + shadow, scoped
-     scrollbars, and an accent-colored L-bracket on all four corners. */
-  .ex-body :global(pre) {
-    position: relative;
-    background-image: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--bg-2) 80%, transparent) 0%,
-      var(--bg-2) 100%
-    );
-    border: 1px solid var(--line-1);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-1);
-    padding: var(--space-5);
-    overflow-x: auto;
-    overflow-y: hidden;
-    margin: var(--space-4) 0;
-    font-size: var(--t-mono-block);
-    line-height: var(--lh-body);
-    /* Hide scrollbars completely on both axes while keeping scroll
-       capability — matches the front-page panel that never shows a bar. */
-    scrollbar-width: none;
-  }
-  .ex-body :global(pre)::-webkit-scrollbar { display: none; }
+    .eyebrow {
+        margin: 0;
+        font-size: var(--t-eyebrow);
+        letter-spacing: var(--ls-eyebrow);
+        text-transform: uppercase;
+        color: var(--fg-2);
+    }
 
-  /* One ::before paints all four accent L-brackets via a four-layer mask
-     filled with --accent. */
-  .ex-body :global(pre)::before {
-    content: '';
-    position: absolute;
-    inset: -1px;
-    pointer-events: none;
-    z-index: 1;
-    background-color: var(--accent);
-    --l-tl: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M15 1 H1 V15' fill='none' stroke='black' stroke-width='2'/></svg>");
-    --l-tr: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M1 1 H15 V15' fill='none' stroke='black' stroke-width='2'/></svg>");
-    --l-bl: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M15 15 H1 V1' fill='none' stroke='black' stroke-width='2'/></svg>");
-    --l-br: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M1 15 H15 V1' fill='none' stroke='black' stroke-width='2'/></svg>");
-    -webkit-mask:
-      var(--l-tl) top left / 14px 14px no-repeat,
-      var(--l-tr) top right / 14px 14px no-repeat,
-      var(--l-bl) bottom left / 14px 14px no-repeat,
-      var(--l-br) bottom right / 14px 14px no-repeat;
-    mask:
-      var(--l-tl) top left / 14px 14px no-repeat,
-      var(--l-tr) top right / 14px 14px no-repeat,
-      var(--l-bl) bottom left / 14px 14px no-repeat,
-      var(--l-br) bottom right / 14px 14px no-repeat;
-  }
-  .ex-body :global(pre code) { background: transparent; padding: 0; }
-  .ex-body :global(ul) { color: var(--fg-1); }
-  .ex-body :global(li) { margin: var(--space-2) 0; }
+    h1 {
+        margin: 0;
+        font-size: var(--t-h1);
+        line-height: var(--lh-h1);
+        letter-spacing: var(--ls-h1);
+    }
 
-  .ex-further {
-    margin-top: var(--space-8);
-    padding-top: var(--space-6);
-    border-top: 1px solid var(--line-1);
-    max-width: var(--w-prose);
-  }
-  .ex-further h2 { margin: 0 0 var(--space-3); font-size: var(--t-h3); }
-  .ex-further ul { list-style: none; padding: 0; margin: 0; }
-  .ex-further li { margin: var(--space-2) 0; }
+    .summary {
+        margin: 0;
+        color: var(--fg-1);
+        font-size: var(--t-h4);
+        line-height: var(--lh-h3);
+        max-width: 56ch;
+    }
 
-  .ex-back { margin-top: var(--space-8); }
-  .ex-back a { color: var(--fg-1); border-bottom: none; }
-  .ex-back a:hover { color: var(--fg-0); }
+    .crate-row {
+        list-style: none;
+        padding: 0;
+        margin: var(--space-2) 0 0 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+
+    .crate-row a {
+        display: inline-block;
+        padding: var(--space-1) var(--space-3);
+        border: 1px solid var(--line-1);
+        border-radius: var(--radius-pill);
+        color: var(--fg-1);
+        border-bottom: 1px solid var(--line-1);
+        font-size: var(--t-body-sm);
+    }
+
+    .crate-row code {
+        background: transparent;
+        padding: 0;
+    }
+
+    .crate-row a:hover {
+        color: var(--fg-0);
+        border-color: var(--line-2);
+    }
+
+    .src-line {
+        margin: var(--space-3) 0 0 0;
+        color: var(--fg-2);
+        font-size: var(--t-body-sm);
+    }
+
+    .src-line code {
+        background: transparent;
+        padding: 0;
+    }
+
+    .src-line a {
+        color: var(--fg-1);
+        border-bottom: none;
+    }
+
+    .src-line a:hover {
+        color: var(--fg-0);
+    }
+
+    .ex-body {
+        max-width: var(--w-prose);
+    }
+
+    .ex-body :global(h2) {
+        margin: var(--space-7) 0 var(--space-3);
+    }
+
+    .ex-body :global(h3) {
+        margin: var(--space-6) 0 var(--space-2);
+    }
+
+    .ex-body :global(p) {
+        color: var(--fg-1);
+        max-width: var(--measure);
+    }
+
+    /* Code listings get the same HUD-frame treatment as the home-page
+       example panel and the community cards: subtle vertical gradient
+       (via background-image to bypass the global `!important`
+       background-color on pre.astro-code), border + shadow, scoped
+       scrollbars, and an accent-colored L-bracket on all four corners. */
+    .ex-body :global(pre) {
+        position: relative;
+        background-image: linear-gradient(
+                180deg,
+                color-mix(in srgb, var(--bg-2) 80%, transparent) 0%,
+                var(--bg-2) 100%
+        );
+        border: 1px solid var(--line-1);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-1);
+        padding: var(--space-5);
+        overflow-x: auto;
+        overflow-y: hidden;
+        margin: var(--space-4) 0;
+        font-size: var(--t-mono-block);
+        line-height: var(--lh-body);
+        /* Hide scrollbars completely on both axes while keeping scroll
+           capability — matches the front-page panel that never shows a bar. */
+        scrollbar-width: none;
+    }
+
+    .ex-body :global(pre)::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* One ::before paints all four accent L-brackets via a four-layer mask
+       filled with --accent. */
+    .ex-body :global(pre)::before {
+        content: '';
+        position: absolute;
+        inset: -1px;
+        pointer-events: none;
+        z-index: 1;
+        background-color: var(--accent);
+        --l-tl: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M15 1 H1 V15' fill='none' stroke='black' stroke-width='2'/></svg>");
+        --l-tr: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M1 1 H15 V15' fill='none' stroke='black' stroke-width='2'/></svg>");
+        --l-bl: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M15 15 H1 V1' fill='none' stroke='black' stroke-width='2'/></svg>");
+        --l-br: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M1 15 H15 V1' fill='none' stroke='black' stroke-width='2'/></svg>");
+        -webkit-mask: var(--l-tl) top left / 14px 14px no-repeat,
+        var(--l-tr) top right / 14px 14px no-repeat,
+        var(--l-bl) bottom left / 14px 14px no-repeat,
+        var(--l-br) bottom right / 14px 14px no-repeat;
+        mask: var(--l-tl) top left / 14px 14px no-repeat,
+        var(--l-tr) top right / 14px 14px no-repeat,
+        var(--l-bl) bottom left / 14px 14px no-repeat,
+        var(--l-br) bottom right / 14px 14px no-repeat;
+    }
+
+    .ex-body :global(pre code) {
+        background: transparent;
+        padding: 0;
+    }
+
+    .ex-body :global(ul) {
+        color: var(--fg-1);
+    }
+
+    .ex-body :global(li) {
+        margin: var(--space-2) 0;
+    }
+
+    .ex-further {
+        margin-top: var(--space-8);
+        padding-top: var(--space-6);
+        border-top: 1px solid var(--line-1);
+        max-width: var(--w-prose);
+    }
+
+    .ex-further h2 {
+        margin: 0 0 var(--space-3);
+        font-size: var(--t-h3);
+    }
+
+    .ex-further ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .ex-further li {
+        margin: var(--space-2) 0;
+    }
+
+    .ex-back {
+        margin-top: var(--space-8);
+    }
+
+    .ex-back a {
+        color: var(--fg-1);
+        border-bottom: none;
+    }
+
+    .ex-back a:hover {
+        color: var(--fg-0);
+    }
 </style>

--- a/website/web/src/components/examples/ExamplesList.astro
+++ b/website/web/src/components/examples/ExamplesList.astro
@@ -1,47 +1,77 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import type {CollectionEntry} from 'astro:content';
 
 interface Props {
-  entries: CollectionEntry<'examples'>[];
+    entries: CollectionEntry<'examples'>[];
 }
-const { entries } = Astro.props;
+const {entries} = Astro.props;
 ---
 <ul class="ex-list" role="list">
-  {entries.map((e) => (
-    <li>
-      <a href={`/examples/${e.id.replace(/^en\//, '')}/`}>
-        <div class="meta">
-          <span class="dom">{e.data.domain}</span>
-          <span class="open" aria-hidden="true">→</span>
-        </div>
-        <h2>{e.data.title}</h2>
-        <p>{e.data.summary}</p>
-      </a>
-    </li>
-  ))}
+    {entries.map((e) => (
+            <li>
+                <a href={`/examples/${e.id.replace(/^en\//, '')}/`}>
+                    <div class="meta">
+                        <span class="dom">{e.data.domain}</span>
+                        <span class="open" aria-hidden="true">→</span>
+                    </div>
+                    <h2>{e.data.title}</h2>
+                    <p>{e.data.summary}</p>
+                </a>
+            </li>
+    ))}
 </ul>
 
 <style>
-  .ex-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0; }
-  .ex-list li + li { border-top: 1px solid var(--line-1); }
-  .ex-list a {
-    display: grid;
-    gap: var(--space-2);
-    padding: var(--space-6) 0;
-    color: var(--fg-0);
-    border-bottom: none;
-    transition: padding-left var(--dur-med) var(--ease-out);
-  }
-  .ex-list a:hover { padding-left: var(--space-3); }
-  .meta {
-    display: flex; justify-content: space-between; align-items: baseline;
-    color: var(--fg-2);
-  }
-  .dom {
-    font-size: var(--t-eyebrow); letter-spacing: var(--ls-eyebrow);
-    text-transform: uppercase;
-  }
-  .open { color: var(--accent); }
-  .ex-list h2 { margin: 0; font-size: var(--t-h3); }
-  .ex-list p { margin: 0; color: var(--fg-1); max-width: var(--measure); }
+    .ex-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 0;
+    }
+
+    .ex-list li + li {
+        border-top: 1px solid var(--line-1);
+    }
+
+    .ex-list a {
+        display: grid;
+        gap: var(--space-2);
+        padding: var(--space-6) 0;
+        color: var(--fg-0);
+        border-bottom: none;
+        transition: padding-left var(--dur-med) var(--ease-out);
+    }
+
+    .ex-list a:hover {
+        padding-left: var(--space-3);
+    }
+
+    .meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        color: var(--fg-2);
+    }
+
+    .dom {
+        font-size: var(--t-eyebrow);
+        letter-spacing: var(--ls-eyebrow);
+        text-transform: uppercase;
+    }
+
+    .open {
+        color: var(--accent);
+    }
+
+    .ex-list h2 {
+        margin: 0;
+        font-size: var(--t-h3);
+    }
+
+    .ex-list p {
+        margin: 0;
+        color: var(--fg-1);
+        max-width: var(--measure);
+    }
 </style>

--- a/website/web/src/components/home/CausalStack.astro
+++ b/website/web/src/components/home/CausalStack.astro
@@ -1,0 +1,249 @@
+---
+// The end-to-end story rendered as a layered platform diagram: one reticle-framed
+// module holding five stacked layer-bands, top (discovery) to bottom (deployment).
+// The stage verbs carry the lifecycle direction; no enumeration. Concept links
+// point to the docs; where a worked example exists, an Example chip sits beside it.
+// Single-column bands on phones. Entrance is the shared `data-anim-draw` idiom.
+import { DOCS_URL } from '../../consts';
+
+type Link = { href: string };
+type Layer = {
+  stage: string;
+  title: string;
+  body: string;
+  concept: Link;
+  example?: Link;
+};
+
+const layers: Layer[] = [
+  {
+    stage: 'Discover',
+    title: 'Causal Discovery Language',
+    body: 'Surface causal structure straight from raw observational data.',
+    concept: { href: `${DOCS_URL}/concepts/cdl/` },
+    example: { href: '/examples/causal-discovery/' },
+  },
+  {
+    stage: 'Model',
+    title: 'Causaloid & Context',
+    body: 'Encode that structure as composable causal logic with an explicit context.',
+    concept: { href: `${DOCS_URL}/concepts/causaloid/` },
+    example: { href: '/examples/pearl-counterfactual/' },
+  },
+  {
+    stage: 'Act',
+    title: 'Causal State Machine',
+    body: 'Turn a causal verdict into an action and interact with the outside world.',
+    concept: { href: `${DOCS_URL}/concepts/csm/` },
+    example: { href: '/examples/sensor-monitoring-csm/' },
+  },
+  {
+    stage: 'Govern',
+    title: 'Effect Ethos',
+    body: 'Verify deterministically what is allowed to happen.',
+    concept: { href: `${DOCS_URL}/concepts/effect-ethos/` },
+    example: { href: '/examples/effect-ethos/' },
+  },
+  {
+    stage: 'Run',
+    title: 'Async Runtime',
+    body: 'Run the model thread-safe and asynchronously at scale.',
+    concept: { href: `${DOCS_URL}/concepts/deployment/` },
+    example: { href: '/examples/async-event-inference/' },
+  },
+];
+---
+<section class="stack-section">
+  <div class="stack-inner">
+    <h2>One Causal Stack: From Discovery to Deployment</h2>
+    <p class="lede">
+      DeepCausality is one uniform stack for the whole causal lifecycle.
+    </p>
+
+    <div class="platform reticle-host" data-anim-draw>
+      <span class="reticle reticle-tl" aria-hidden="true"></span>
+      <span class="reticle reticle-tr" aria-hidden="true"></span>
+      <span class="reticle reticle-bl" aria-hidden="true"></span>
+      <span class="reticle reticle-br" aria-hidden="true"></span>
+
+      <ol class="layers">
+        {layers.map((layer, i) => (
+          <li class="layer" style={`--i:${i}`}>
+            <div class="head">
+              <span class="stage">{layer.stage}</span>
+              <h3 class="title">{layer.title}</h3>
+            </div>
+            <div class="body">
+              <p class="desc">{layer.body}</p>
+              <div class="links">
+                <a class="chip" href={layer.concept.href}>
+                  <span class="chip-kind">Concept</span>
+                  <span class="chip-arrow" aria-hidden="true">↗</span>
+                </a>
+                {layer.example && (
+                  <a class="chip chip-ex" href={layer.example.href}>
+                    <span class="chip-kind">Example</span>
+                    <span class="chip-arrow" aria-hidden="true">→</span>
+                  </a>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  </div>
+</section>
+
+<style>
+  .stack-section { padding: var(--space-8) 0; }
+  .stack-inner {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 var(--space-4);
+  }
+  @media (min-width: 720px) {
+    .stack-section { padding: var(--space-9) 0; }
+    .stack-inner { padding: 0 var(--space-5); }
+  }
+
+  .stack-inner > h2 { margin: 0; text-align: center; }
+  .lede {
+    margin: var(--space-4) auto var(--space-7) auto;
+    color: var(--fg-1);
+    max-width: var(--measure);
+    text-align: center;
+  }
+
+  /* The platform: one framed module. The top-down gradient gives the stack
+     depth, so the bands read as layers receding rather than flat cards. */
+  .platform {
+    background: linear-gradient(180deg,
+      color-mix(in srgb, var(--bg-1) 70%, transparent) 0%,
+      var(--bg-1) 100%);
+    border: 1px solid var(--line-1);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    overflow: hidden;
+  }
+
+  .layers { list-style: none; margin: 0; padding: 0; }
+
+  /* Each layer is a full-width band: a label head on the left, detail on the
+     right, divided from the next band by a hairline. */
+  .layer {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2) var(--space-5);
+    padding: var(--space-5);
+    transition: background var(--dur-med) var(--ease-out);
+  }
+  .layer:not(:last-child) { border-bottom: 1px solid var(--line-1); }
+  /* A short accent tick on the left edge marks each layer of the stack. */
+  .layer::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: var(--space-5);
+    width: 3px;
+    height: 18px;
+    background: color-mix(in srgb, var(--accent) 55%, transparent);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    transition: height var(--dur-med) var(--ease-out),
+                background var(--dur-med) var(--ease-out);
+  }
+  /* The bottom band is the runtime the whole platform sits on. */
+  .layer:last-child { background: color-mix(in srgb, var(--bg-2) 55%, transparent); }
+  .layer:hover { background: color-mix(in srgb, var(--accent) 5%, transparent); }
+  .layer:hover::before {
+    height: 28px;
+    background: var(--accent);
+  }
+  @media (min-width: 720px) {
+    .layer {
+      grid-template-columns: 184px 1fr;
+      align-items: start;
+      padding: var(--space-5) var(--space-6);
+    }
+    .layer::before { top: var(--space-5); }
+  }
+  .layer > * { min-width: 0; }
+
+  /* Head: stage verb + layer title. */
+  .head { display: flex; flex-direction: column; gap: 6px; }
+  .stage {
+    font-family: var(--font-mono);
+    font-size: var(--t-eyebrow);
+    letter-spacing: var(--ls-eyebrow);
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .title {
+    margin: 0;
+    font-size: var(--t-h4);
+    line-height: var(--lh-h4);
+    font-weight: 600;
+    color: var(--fg-0);
+  }
+
+  .body { display: flex; flex-direction: column; gap: var(--space-3); }
+  .desc { margin: 0; color: var(--fg-1); max-width: var(--measure); }
+
+  /* Concept / Example chips. */
+  .links { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 5px var(--space-3);
+    border: 1px solid var(--line-1);
+    border-radius: var(--radius-pill);
+    background: var(--bg-2);
+    color: var(--fg-1);
+    font-size: var(--t-body-sm);
+    line-height: 1.2;
+    text-decoration: none;
+    transition: border-color var(--dur-fast) var(--ease-out),
+                background var(--dur-fast) var(--ease-out),
+                color var(--dur-fast) var(--ease-out);
+  }
+  .chip-kind {
+    font-size: var(--t-eyebrow);
+    letter-spacing: var(--ls-eyebrow);
+    text-transform: uppercase;
+  }
+  .chip-arrow { color: var(--fg-2); transition: transform var(--dur-fast) var(--ease-out); }
+  .chip:hover { border-color: var(--line-2); background: var(--bg-3); color: var(--fg-0); }
+  .chip:hover .chip-arrow { transform: translate3d(2px, -1px, 0); }
+
+  /* The Example chip carries the single accent so it reads as the live artifact. */
+  .chip-ex { color: var(--accent); }
+  .chip-ex .chip-arrow { color: var(--accent); }
+  .chip-ex:hover {
+    border-color: color-mix(in srgb, var(--accent) 45%, var(--line-2));
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    color: var(--accent);
+  }
+
+  /* Entrance: bands fade up top-to-bottom, reticles resolve in. `.in-view` is
+     flipped by the shared IntersectionObserver in BaseLayout. Motion is gated on
+     prefers-reduced-motion; the static state is fully visible. */
+  .platform .reticle { opacity: 0; }
+  .platform.in-view .reticle { opacity: 0.55; }
+  @media (prefers-reduced-motion: no-preference) {
+    .platform .layer {
+      transform: translate3d(0, 16px, 0);
+      opacity: 0;
+      transition: transform var(--dur-slow) var(--ease-out),
+                  opacity var(--dur-slow) var(--ease-out),
+                  background var(--dur-med) var(--ease-out);
+    }
+    .platform.in-view .layer { transform: translate3d(0, 0, 0); opacity: 1; }
+    .platform.in-view .layer { transition-delay: calc(var(--i) * 110ms); }
+    .platform .reticle { transition: opacity var(--dur-slow) var(--ease-out) 280ms; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .platform .reticle { opacity: 0.55; }
+  }
+</style>

--- a/website/web/src/content/examples/en/causal-discovery.mdx
+++ b/website/web/src/content/examples/en/causal-discovery.mdx
@@ -13,7 +13,7 @@ further:
     href: /docs/concepts/algorithms/
 ---
 
-The full examole lives at [`causal_discovery_examples`](https://github.com/deepcausality-rs/deep_causality/tree/main/examples/causal_discovery_examples).
+The full example lives at [`causal_discovery_examples`](https://github.com/deepcausality-rs/deep_causality/tree/main/examples/causal_discovery_examples).
 
 The Causal Discovery Language (CDL) is a typestate DSL wrapped in a monad that encodes an end-to-end pipeline:
 raw CSV in, causal analysis, and a ranked causal report out.

--- a/website/web/src/content/examples/en/causal-discovery.mdx
+++ b/website/web/src/content/examples/en/causal-discovery.mdx
@@ -1,0 +1,104 @@
+---
+title: "Causal discovery: MRMR feature selection, then SURD"
+domain: Causal discovery
+summary: The Causal Discovery Language walks a CSV through load, clean, feature selection, discovery, and analysis as one monadic pipeline. Each stage is a typestate the compiler enforces in order.
+order: 4
+category: foundations
+crates:
+  - deep_causality_discovery
+further:
+  - label: CDL concept page
+    href: /docs/concepts/cdl/
+  - label: Algorithms (SURD, MRMR)
+    href: /docs/concepts/algorithms/
+---
+
+The full examole lives at [`causal_discovery_examples`](https://github.com/deepcausality-rs/deep_causality/tree/main/examples/causal_discovery_examples).
+
+The Causal Discovery Language (CDL) is a typestate DSL wrapped in a monad that encodes an end-to-end pipeline:
+raw CSV in, causal analysis, and a ranked causal report out.
+
+The CDL enforces stage order at compile time; the monad sequences the stages and short-circuits on the first error.
+You cannot run discovery before selecting features, because the method that runs discovery
+only exists on the typestate that has features selected.
+
+## The pipeline
+
+```rust
+use deep_causality_discovery::*;
+
+fn main() {
+    // A CSV with columns: s1, s2, s3, target.
+    let file_path = "./test_data.csv";
+    let target_index = 3; // the target column
+
+    let result_effect = CdlBuilder::build()
+        // Load the data with an inline config.
+        .bind(|cdl| cdl.load_data(&file_path, target_index, vec![]))
+
+        // Clean it: drop rows with missing values.
+        .bind(|cdl| cdl.clean_data(OptionNoneDataCleaner))
+
+        // Select the top 3 features by MRMR, scored against the target.
+        .bind(|cdl| {
+        cdl.feature_select(|tensor| mrmr_features_selector(
+                tensor,
+                3,
+                target_index)
+           )
+        })
+
+        // Discover the causal structure with SURD.
+        .bind(|cdl| {
+            cdl.causal_discovery(|tensor| {
+                surd_states_cdl(tensor, MaxOrder::Max).map_err(Into::into)
+            })
+        })
+        // Analyze the result.
+        .bind(|cdl| cdl.analyze())
+        // Then format and finalize.
+        .bind(|cdl| cdl.finalize());
+
+    result_effect.print_results();
+}
+```
+
+[`discovery/main.rs:14`](https://github.com/deepcausality-rs/deep_causality/blob/main/examples/causal_discovery_examples/discovery/main.rs#L14) onward.
+
+Each `bind` takes the pipeline in one typestate and returns it in the next. The closure body is the only place you supply a strategy;
+everything else is fixed by the type.
+
+## What each stage does
+
+`load_data` reads the CSV into a tensor and records which column is the target. The third argument is a column filter; an empty `vec![]` keeps every column. For a file that needs a header map or a custom delimiter, `load_data_with_config` takes an explicit configuration instead.
+
+`clean_data` takes a cleaning strategy. `OptionNoneDataCleaner` drops rows that carry a missing value. The strategy is a parameter, so a project that prefers imputation supplies its own cleaner here without touching the rest of the pipeline.
+
+`feature_select` runs MRMR (Minimum Redundancy, Maximum Relevance). `mrmr_features_selector(tensor, 3, target_index)` keeps the three features that carry the most information about the target while overlapping the least with each other. Feature selection before discovery keeps the combinatorics tractable; SURD over every raw column is expensive, SURD over three chosen features is cheap.
+
+`causal_discovery` runs SURD (Synergistic, Unique, Redundant Decomposition). `MaxOrder::Max` tells it to compute interactions up to the highest order the feature set allows, so synergies between features are not missed. The `map_err(Into::into)` lifts the algorithm's error type into the pipeline's error channel.
+
+`analyze` reads the SURD decomposition and ranks each causal contribution. `finalize` formats the ranked result for output. `print_results` writes the report to stdout.
+
+## Run it
+
+```bash
+git clone https://github.com/deepcausality-rs/deep_causality
+cd deep_causality
+cargo run --release -p causal_discovery_examples --example example_discovery
+```
+
+The example ships with a small synthetic CSV where `s2` tracks the target closely and `s1`, `s3` track it loosely.
+Expect MRMR to rank `s2` first and SURD to report it as the dominant causal contributor.
+
+## Where to take it next
+
+Point `load_data` at your own CSV and set `target_index` to your label column; the pipeline does not change.
+Raise or lower the feature count in `mrmr_features_selector` to trade breadth for speed.
+Swap `OptionNoneDataCleaner` for an imputing cleaner when dropping rows loses too much data.
+The output of this pipeline feeds the next layer of the stack: the discovered structure becomes the rules you encode as a causal model.
+
+## Why this is the first layer
+
+Every causal model starts with a structure. You either know it from domain knowledge or you discover it from data.
+CDL is the discovery path that delivers a report about the causal structure you can act on.

--- a/website/web/src/content/examples/en/effect-ethos.mdx
+++ b/website/web/src/content/examples/en/effect-ethos.mdx
@@ -1,0 +1,126 @@
+---
+title: A Programmable Effect Ethos that vetoes impermissible actions
+domain: Governance
+summary: A causal verdict says an alert should fire. A separate deontic layer, the Effect Ethos, checks whether the alert is allowed to fire and forbids it. Two questions, two engines, one decision.
+order: 5
+category: foundations
+crates:
+  - deep_causality
+  - deep_causality_ethos
+further:
+  - label: Effect Ethos concept page
+    href: /docs/concepts/effect-ethos/
+  - label: Causal State Machine concept page
+    href: /docs/concepts/csm/
+---
+
+The full example lives at [`csm_examples`](https://github.com/deepcausality-rs/deep_causality/tree/main/examples/csm_examples);
+this page covers `Effect Ethos`. It is the *Governance* layer; the part that decides what is allowed to happen.
+
+Causal reasoning answers one question: given the inputs, does the alert condition hold?
+For strictly deterministic s, you have an implicit safeguard that nothing unexpected can happen outside the encoded model.Ethos
+For dynamic systems, however, that safeguard is not guaranteed any longer.
+
+Deontic reasoning answers a different one: given the rules we operate under,
+is executing a specific action permitted?
+
+The Effect Ethos encodes operational rules that are applied dynamically, depending on whether a triggered action needs
+ verification under the governing rules. If governance is mandatory, the effect ethos queries its rule sets and ultimately determines which rules are applied and what decision
+ will be inferred based on the applied rules and supplied context of the action.
+
+## The norm
+
+An Ethos is a set of norms. Each norm marks an action as permitted, required, or forbidden under a stated condition.
+This example defines one norm, and it forbids emitting an alert outright.
+
+```rust
+use deep_causality_ethos::{EffectEthos, TeloidModal};
+
+fn get_effect_ethos() -> CsmEthos {
+    let mut ethos = EffectEthos::new()
+        .add_deterministic_norm(
+            1,                          // norm id
+            "high_temp_alert",          // the action this norm governs
+            &["temperature"],           // the context tags it reads
+            |_context, _action| true,   // when the norm is active
+            TeloidModal::Impermissible, // the verdict when active
+            1, 1, 1,                    // priority, version, author
+        )
+        .unwrap();
+    ethos.verify_graph().unwrap();
+    ethos
+}
+```
+
+[`model.rs:26`](https://github.com/deepcausality-rs/deep_causality/blob/main/examples/csm_examples/csm_effect_ethos/model.rs#L26).
+
+`TeloidModal` has three values: `Impermissible` (forbidden), `Obligatory` (required), and `Optional` (permitted).
+This norm always evaluates active and returns `Impermissible`, so the action `high_temp_alert`
+is forbidden whenever the Ethos is consulted. `verify_graph` checks the norm set for contradictions before the Ethos is used;
+
+
+## The verdict
+
+The action that would otherwise fire is wrapped as a `ProposedAction` and handed to the Ethos,
+along with the context and the tags the norms may read.
+
+```rust
+use deep_causality::ProposedAction;
+use std::collections::HashMap;
+
+let proposed_action = ProposedAction::new(1, "high_temp_alert".to_string(), HashMap::new());
+
+let context = context_arc.read().unwrap();
+let verdict = ethos.evaluate_action(&proposed_action, &context, &["temperature"])?;
+
+match verdict.outcome() {
+    TeloidModal::Impermissible => {
+        println!(">>> Action is FORBIDDEN by the ethos.");
+        // The alert does not fire; the Causaloid said it should, the Ethos says it does not.
+    }
+    TeloidModal::Obligatory => println!(">>> Action is REQUIRED by the ethos."),
+    TeloidModal::Optional(_) => println!(">>> Action is PERMITTED by the ethos."),
+}
+```
+
+[`main.rs:46`](https://github.com/deepcausality-rs/deep_causality/blob/main/examples/csm_examples/csm_effect_ethos/main.rs#L46).
+
+`evaluate_action` returns a verdict, and the verdict carries more than an outcome.
+Its `justification()` lists the norm ids that produced the result, so you can trace a forbidden action back
+to the exact rule that forbade it and print the rule in plain language.
+
+## Run it
+
+```bash
+git clone https://github.com/deepcausality-rs/deep_causality
+cd deep_causality
+cargo run --release -p csm_examples --example csm_effect_ethos_example
+```
+
+Expected output: the CSM evaluates the temperature reading and reports that the alert condition holds;
+the Ethos then returns `Impermissible` and the alert is suppressed, with the governing norm named in the justification.
+
+## Where to take it next
+
+The example norm here Only serves for illustration. A real norm reads the context:
+forbid the evacuation alarm while the building is occupied, require a second sign-off outside
+the operator's approval window, permit the notification otherwise.
+Add norms with `add_deterministic_norm` and let `verify_graph` catch the conflicts.
+Wire the verdict into a CSM so the action fires only when the Causaloid says it should and the Ethos says it may.
+
+## Why governance is its own layer
+
+The Effect Ethos keeps reasoning and the permissibility of actions apart.
+The Causaloid stays a pure statement about cause and effect;
+the Ethos holds the policy, and the CSM encodes the action.
+
+With all three layers separated, the reasoning can be verified and audited for internal consistency by the
+appropriate  causal reasoning experts. The applicable actions can be designed, for example, by integration engineers
+that determine how to wire s together via causal action based on reasoning insights.
+The effect ethos is a separate layer because that allows the applicable rules to be separated from the to ensure that
+governance and development are not conflated. For example, an external auditor can certify the effect ethos layer as
+compliant with applicable regulations without even looking at the underlying, because the effect ethos enforces what is permissible,
+regardless of how the underlying software architecture may work or evolve over time.Ethos
+
+
+

--- a/website/web/src/content/examples/en/effect-ethos.mdx
+++ b/website/web/src/content/examples/en/effect-ethos.mdx
@@ -18,8 +18,8 @@ The full example lives at [`csm_examples`](https://github.com/deepcausality-rs/d
 this page covers `Effect Ethos`. It is the *Governance* layer; the part that decides what is allowed to happen.
 
 Causal reasoning answers one question: given the inputs, does the alert condition hold?
-For strictly deterministic s, you have an implicit safeguard that nothing unexpected can happen outside the encoded model.Ethos
-For dynamic systems, however, that safeguard is not guaranteed any longer.
+For a strictly deterministic system, the encoded model is its own safeguard; nothing unexpected can happen outside it.
+For a dynamic system, that safeguard no longer holds.
 
 Deontic reasoning answers a different one: given the rules we operate under,
 is executing a specific action permitted?
@@ -114,13 +114,11 @@ The Effect Ethos keeps reasoning and the permissibility of actions apart.
 The Causaloid stays a pure statement about cause and effect;
 the Ethos holds the policy, and the CSM encodes the action.
 
-With all three layers separated, the reasoning can be verified and audited for internal consistency by the
-appropriate  causal reasoning experts. The applicable actions can be designed, for example, by integration engineers
-that determine how to wire s together via causal action based on reasoning insights.
-The effect ethos is a separate layer because that allows the applicable rules to be separated from the to ensure that
-governance and development are not conflated. For example, an external auditor can certify the effect ethos layer as
-compliant with applicable regulations without even looking at the underlying, because the effect ethos enforces what is permissible,
-regardless of how the underlying software architecture may work or evolve over time.Ethos
+With the three layers separated, causal reasoning experts can verify and audit the reasoning for internal consistency,
+while integration engineers design the actions and decide how to wire them to the reasoning. The Effect Ethos is a
+separate layer so that governance and development stay distinct. An external auditor can certify the Ethos layer as
+compliant with the applicable regulations without reading the rest of the system, because the Ethos enforces what is
+permissible regardless of how the underlying architecture works or evolves over time.
 
 
 

--- a/website/web/src/pages/index.astro
+++ b/website/web/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import SiteHeader from '../components/nav/SiteHeader.astro';
 import Hero from '../components/home/Hero.astro';
 import ExampleGrid from '../components/home/ExampleGrid.astro';
+import CausalStack from '../components/home/CausalStack.astro';
 import WhyDeepCausality from '../components/home/WhyDeepCausality.astro';
 import PillarRow from '../components/home/PillarRow.astro';
 import JoinCommunity from '../components/home/JoinCommunity.astro';
@@ -50,6 +51,8 @@ const jsonLd = [
   <script type="application/ld+json" is:inline set:html={JSON.stringify(jsonLd)} />
   <SiteHeader />
   <Hero />
+  <SectionDivider />
+  <CausalStack />
   <SectionDivider />
   <PillarRow />
   <SectionDivider />


### PR DESCRIPTION

## Describe your changes

feat(website): add end-to-end causal stack diagram and fill its missing links


## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end‑to‑end causal stack diagram to the homepage, linking each layer from discovery to deployment with concept docs and worked examples. Also adds a new Deployment concept page and two examples, plus minor copy and style fixes.

- **New Features**
  - Homepage: new stacked “Causal Stack” diagram after the hero; links each layer to its concept doc and example; responsive with reduced‑motion support.
  - Docs: new Deployment concept explaining the runtime‑agnostic core, Tokio serving, and multi‑threaded cloning of `Arc<Causaloid>`.
  - Examples: new pages for causal discovery (CDL pipeline: load → clean → MRMR → SURD) and Effect Ethos (vetoing impermissible actions).

- **Refactors**
  - Examples UI polish: improved headers, related‑crate chips, source line, “Further reading” aside, and consistent list/detail styling with clearer back nav; minor copy/style fixes across the site.

<sup>Written for commit a4ffb1551217f55fe3e1c1a80c160f8ec7f090a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

