### PR TITLE
doc: Added an official statement on the usage of AI coding assistance

### DIFF
--- a/Ai-Coding-Assistants.md
+++ b/Ai-Coding-Assistants.md
@@ -1,0 +1,61 @@
+[//]: # (---)
+
+[//]: # (SPDX-License-Identifier: MIT)
+
+[//]: # (---)
+
+# AI Coding Assistants
+
+This document provides guidance for AI tools and developers using AI assistance when contributing to DeepCausality.
+
+## Conventions
+
+All contributors are asked to adhere to the project's convention laid out in the following document:
+* [Contributing Guide](CONTRIBUTING.md)
+* [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Development Process
+
+Regardless of what tools are used, please adhere to the following standard development process during your contribution.
+
+1) Propose a change or patch as a GitHub issue. Feel free to discuss the issue in the community Discord or open a GitHub discussion.
+2) Break larger changes into multiple issues as appropriate to structure the work in a way that it can be reviewed.
+3) Please ensure that after completing your work, that the entire code base builds, all tests are passing, and neither Clippy nor Rustfmt reporting any issues on the latest stable Rust tool chain. If you added new test, make sure that Bazel test still executes without errors. And in case it does not, ensure that the required test dependencies are declared in Bazel.
+4) When you fill up ER, please make a concise summary of the change set and a link to the related issue. Also, please mention any preceding discussion. 
+5) Test coverage is expected to stay at the preceding level. If not, please close gaps in the test coverage. The code review can only complete when all PR checks, including test coverage, are green.
+
+## Licensing and Legal Requirements
+
+All contributions must comply with the DeepCausality licensing requirements:
+
+* All code must be compatible with MIT Licence
+* Use appropriate SPDX license identifiers in all files: SPDX-License-Identifier: MIT
+
+## Signed-off-by and Developer Certificate of Origin
+
+AI agents MUST NOT add Signed-off-by tags. Only humans can legally
+certify the Developer Certificate of Origin (DCO). The human submitter
+is responsible for:
+
+* Reviewing all AI-generated code
+* Ensuring compliance with licensing requirements
+* Adding their own Signed-off-by tag to certify the DCO
+* Taking full responsibility for the contribution
+
+## Ai Attribution
+
+When AI tools contribute to the DeepCausality development, proper attribution
+helps track the evolving role of AI in the development process.
+
+Contributions should include an Assisted-by tag in the following format:
+
+Assisted-by: AGENT_NAME:MODEL_VERSION 
+
+Where:
+
+* ``AGENT_NAME`` is the name of the AI tool or framework
+* ``MODEL_VERSION`` is the specific model version used
+
+Example::
+
+Assisted-by: Claude:claude-4.8

--- a/Ai-Coding-Assistants.md
+++ b/Ai-Coding-Assistants.md
@@ -10,7 +10,7 @@ This document provides guidance for AI tools and developers using AI assistance 
 
 ## Conventions
 
-All contributors are asked to adhere to the project's convention laid out in the following document:
+All contributors are asked to adhere to the project's conventions laid out in the following documents:
 * [Contributing Guide](CONTRIBUTING.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 
@@ -20,15 +20,15 @@ Regardless of what tools are used, please adhere to the following standard devel
 
 1) Propose a change or patch as a GitHub issue. Feel free to discuss the issue in the community Discord or open a GitHub discussion.
 2) Break larger changes into multiple issues as appropriate to structure the work in a way that it can be reviewed.
-3) Please ensure that after completing your work, that the entire code base builds, all tests are passing, and neither Clippy nor Rustfmt reporting any issues on the latest stable Rust tool chain. If you added new test, make sure that Bazel test still executes without errors. And in case it does not, ensure that the required test dependencies are declared in Bazel.
-4) When you fill up ER, please make a concise summary of the change set and a link to the related issue. Also, please mention any preceding discussion. 
+3) Please ensure that after completing your work, the entire code base builds, all tests pass, and neither Clippy nor Rustfmt reports any issues on the latest stable Rust toolchain. If you added new tests, make sure the Bazel tests still execute without errors. If they do not, ensure that the required test dependencies are declared in Bazel.
+4) When you file a PR, please provide a concise summary of the change set and a link to the related issue. Also, please mention any preceding discussion.
 5) Test coverage is expected to stay at the preceding level. If not, please close gaps in the test coverage. The code review can only complete when all PR checks, including test coverage, are green.
 
 ## Licensing and Legal Requirements
 
 All contributions must comply with the DeepCausality licensing requirements:
 
-* All code must be compatible with MIT Licence
+* All code must be compatible with the MIT License
 * Use appropriate SPDX license identifiers in all files: SPDX-License-Identifier: MIT
 
 ## Signed-off-by and Developer Certificate of Origin
@@ -42,9 +42,9 @@ is responsible for:
 * Adding their own Signed-off-by tag to certify the DCO
 * Taking full responsibility for the contribution
 
-## Ai Attribution
+## AI Attribution
 
-When AI tools contribute to the DeepCausality development, proper attribution
+When AI tools contribute to DeepCausality development, proper attribution
 helps track the evolving role of AI in the development process.
 
 Contributions should include an Assisted-by tag in the following format:
@@ -56,6 +56,6 @@ Where:
 * ``AGENT_NAME`` is the name of the AI tool or framework
 * ``MODEL_VERSION`` is the specific model version used
 
-Example::
+Example:
 
 Assisted-by: Claude:claude-4.8

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ bazel test  //...
 
 Contributions are welcome! Please read:
 
+* [AI Coding Assistants](Ai-Coding-Assistants.md)
 * [Contributing Guide](CONTRIBUTING.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
-* [Project Charter](DeepCausalityProjectCharter.pdf)
 
 ```bash
 # Before submitting a PR
@@ -335,7 +335,7 @@ make check
 
 ---
 
-## Credits
+## Acknowledgement
 
 Inspired by research from:
 


### PR DESCRIPTION

## Describe your changes

Added an official statement on the usage of AI coding assistance

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an official policy for coding assistants with clear rules on process, licensing, DCO sign-offs, and attribution. Links the policy in the README and renames the "Credits" section to "Acknowledgement".

- **New Features**
  - New policy document covering contribution workflow, MIT/SPDX requirements, human-only Signed-off-by, and the Assisted-by attribution format.
  - README update: added link to the policy; retitled "Credits" to "Acknowledgement".

<sup>Written for commit 42d689ce5a63404be4650b6955e9a4018b8778f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

