### PR TITLE
chore(release): bump haft and num to 0.3.3 to unblock calculus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "deep_causality_macros"
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libm",
 ]

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -33,12 +33,12 @@ alloc = ["deep_causality_haft/alloc"]
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.3.3"
 
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.3.3"
 
 [lints]
 workspace = true

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.3.2"
+version = "0.3.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num/Cargo.toml
+++ b/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.3.2"
+version = "0.3.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION


## Describe your changes

bump haft and num to 0.3.3 to unblock calculus

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `deep_causality_haft` and `deep_causality_num` to 0.3.3 and aligned `deep_causality_calculus` dependencies to unblock the calculus build.

- **Dependencies**
  - `deep_causality_haft`: 0.3.2 → 0.3.3
  - `deep_causality_num`: 0.3.2 → 0.3.3
  - `deep_causality_calculus`: depend on `deep_causality_haft` and `deep_causality_num` at 0.3.3

<sup>Written for commit 67737ffe7d5cd0344f2f0245a61678fc0aadab38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

