### PR TITLE
Added or update Readme files for the new example.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -120,11 +120,13 @@ See [causal_counterfactual_examples/README.md](causal_counterfactual_examples/RE
 
 **Location:** `examples/causal_correction_examples`
 
-Four worked examples in the control-theory tradition: monitor a trajectory
+Five worked examples in the control-theory tradition: monitor a trajectory
 tick by tick; when the value drifts outside the safe envelope, `intervene`
-snaps it back and the chain continues from the corrected state. Each runs
-the same chain twice: open loop (no monitor, catastrophic failure) and
-closed loop (monitor + `intervene`, failure averted).
+snaps it back and the chain continues from the corrected state. The first
+four run the same chain twice: open loop (no monitor, catastrophic failure)
+and closed loop (monitor + `intervene`, failure averted). The fifth,
+`corrective_ddos_detector`, runs closed loop only. Its point is the stateful
+sliding-window detector that drives the intervention.
 
 | Example | Monad | Topic | Command |
 |---|---|---|---|
@@ -132,6 +134,7 @@ closed loop (monitor + `intervene`, failure averted).
 | corrective_glucose_pump           | PropagatingProcess (stateful) | Glucose climbs across three meals; corrective bolus fires above 180 mg/dL          | `cargo run -p causal_correction_examples --example corrective_glucose_pump` |
 | corrective_decompression_stops    | PropagatingProcess (stateful) | Diver ascends from 30 m; decompression stop inserted when N2 supersaturation rises | `cargo run -p causal_correction_examples --example corrective_decompression_stops` |
 | corrective_network_failover       | PropagatingProcess (stateful) | Primary switch fails; monitor detects zero delivery; standby switch takes over     | `cargo run -p causal_correction_examples --example corrective_network_failover` |
+| corrective_ddos_detector          | PropagatingProcess (stateful) | Volumetric DDoS; sliding-window z-score detector in `State`; 5 consecutive 3σ seconds engage the NIC throttle | `cargo run -p causal_correction_examples --example corrective_ddos_detector` |
 
 See [causal_correction_examples/README.md](causal_correction_examples/README.md) for detailed documentation.
 

--- a/examples/causal_correction_examples/README.md
+++ b/examples/causal_correction_examples/README.md
@@ -23,11 +23,11 @@ program.
 
 | Property | Demonstrated by |
 |---|---|
-| Same chain, different worlds. Replay the same `bind` pipeline under several interventions without branching code. | All four examples |
-| Audit trail in `EffectLog`. Every `intervene` appends `!!Intervention!!: <old> replaced with <new>`. The intervention history becomes inspectable. | All four examples |
+| Same chain, different worlds. Replay the same `bind` pipeline under several interventions without branching code. | All five examples |
+| Audit trail in `EffectLog`. Every `intervene` appends `!!Intervention!!: <old> replaced with <new>`. The intervention history becomes inspectable. | All five examples |
 | Error-state preservation. If the chain is already in error, `intervene` is a no-op. Intervention cannot paper over an upstream bug. | (Property of the trait; not the punchline of a dedicated example.) |
-| State and Context preservation. On `PropagatingProcess`, only the value swaps. Accumulated `State` and read-only `Context` are untouched. | All four examples |
-| Interventions compose into chains. A cascade is a chain of interventions, each applied to the result of the previous one. | All four examples |
+| State and Context preservation. On `PropagatingProcess`, only the value swaps. Accumulated `State` and read-only `Context` are untouched. | All five examples |
+| Interventions compose into chains. A cascade is a chain of interventions, each applied to the result of the previous one. | All five examples |
 | Closed-loop correction. The monitor decides each tick whether to intervene; the chain advances from the corrected value. Failure averted instead of measured. | `corrective_lane_keeping`, `corrective_glucose_pump`, `corrective_decompression_stops`, `corrective_network_failover`, `corrective_ddos_detector` |
 
 ## Examples
@@ -92,11 +92,11 @@ The codebase already has small demonstrations of `intervene` in:
 * [`material_examples/structural_health_monitor`](../material_examples/structural_health_monitor),
   which asks what would have happened without the observed crack.
 
-Those are the *what is `intervene`* examples. The four here are the
+Those are the *what is `intervene`* examples. The five here are the
 *what does `intervene` give you that `bind` cannot* examples, drawn from
 domains that were not built around intervention from the start: vehicle
-control, closed-loop medical pumps, decompression theory, and enterprise
-networking.
+control, closed-loop medical pumps, decompression theory, enterprise
+networking, and network-security anomaly detection.
 
 ## Adding New Examples
 

--- a/examples/causal_correction_examples/corrective_ddos_detector/README.md
+++ b/examples/causal_correction_examples/corrective_ddos_detector/README.md
@@ -1,0 +1,107 @@
+# corrective_ddos_detector
+
+Volumetric DDoS detection and mitigation as a closed-loop corrective
+`intervene` over the causal monad.
+
+```
+cargo run -p causal_correction_examples --example corrective_ddos_detector
+```
+
+## What it shows
+
+A virtual network interface carries traffic from a deterministic generator.
+An array-backed sliding window, carried as Markovian `State`, holds the
+recent throughput as a rolling baseline. Each second the new measured
+throughput is scored as a z-score against that baseline. When the score
+stays above the parametric threshold (`sigma_threshold`, 3σ) for
+`trigger_slots` consecutive seconds (5), a volumetric attack is declared and
+the loop fires `.intervene(THROTTLE_ON)`. The NIC's regulator reads that
+command from the value channel and rate-limits the interface to the throttle
+ceiling, mitigating the flood from the next tick.
+
+Unlike the other four corrective examples, this one runs **closed loop
+only**; there is no open-loop variant. The point is not a setpoint
+controller. It is a stateful, real-time anomaly detector embedded in the
+correction loop.
+
+## The three channels
+
+| Channel | Type | Carries |
+|---|---|---|
+| Value | `ThrottleState` (`u8`) | the NIC regulator command (`THROTTLE_OFF` / `THROTTLE_ON`); the intervention flips it |
+| State | `DetectorState` | the sliding-window baseline plus per-tick accounting (counters, detection markers, history) |
+| Context | `DetectorConfig` | read-only baseline, attack schedule, thresholds, and mitigation ceiling |
+
+```rust
+type DetectorProcess<T> = PropagatingProcess<T, DetectorState, DetectorConfig>;
+```
+
+## Detecting a *sustained* surge
+
+The detector scores each incoming sample against the baseline and admits
+only non-anomalous samples to the window. That withholding is deliberate.
+The naive alternative pushes every sample, then tests whether the window max
+exceeds the window's own mean + 3σ. That self-masks. As flood samples
+accumulate they inflate the window's mean and σ, so the z-score of the max
+collapses back under the threshold within a few ticks, and "3σ for 5
+consecutive seconds" never holds. Keeping the baseline clean lets the flood
+read as anomalous for its full duration.
+
+A wider window (30 one-second samples, capacity over-allocated 2× to 60)
+keeps the baseline mean and σ steady; the attack starts only after the window
+has filled with clean traffic.
+
+## Control flow
+
+The whole loop is one fluent `iterate_n` over the monad:
+
+```rust
+CausalFlow::from(initial_process())
+    .iterate_n(N_TICKS as usize, |tick| {
+        tick.bind(analyze_tick).branch_with(
+            // trigger: 5 consecutive anomalies, and not already throttled
+            |throttle, state, ctx| {
+                let cfg = ctx.expect("DetectorConfig present");
+                state.consecutive_anomalies >= cfg.trigger_slots && *throttle == THROTTLE_OFF
+            },
+            // mitigate: record it, then intervene the throttle ON
+            |anomaly| anomaly.update_state(record_mitigation).intervene(THROTTLE_ON),
+            // no detection: business as usual
+            |normal| normal,
+        )
+    })
+    .into_process()
+```
+
+The `throttle == OFF` guard makes the mitigation fire exactly once.
+
+## Reading the output
+
+The run prints the per-tick throughput, z-score, and throttle trajectories, a
+summary line, and the per-tick `EffectLog` (including the `!!Intervention!!`
+entry). With the default configuration:
+
+- the baseline holds ~385–415 Mbps (z ≈ 0) while nominal;
+- the attack begins at tick 40 and throughput climbs to ~900 Mbps;
+- the z-score reads 10.9 → 46.2 across the surge (the withheld samples keep
+  the baseline clean);
+- the 5th consecutive anomalous second trips the trigger: `first anomaly at
+  tick 42`, `detected/mitigated at tick 46`;
+- from tick 47 the regulator clamps throughput to the 420 Mbps ceiling;
+- overload is bounded to 5 ticks, inside the 8-tick service objective.
+
+Onset (`first_anomaly_at`, tick 42) and confirmed detection (the trigger,
+`mitigated_at`, tick 46) are reported separately; they sit `trigger_slots`
+apart by construction.
+
+## Extending it: standing down after the attack abates
+
+The example latches the throttle ON and leaves it on. A production detector
+would also *release* mitigation once the attack is over. The robust rule is
+to confirm abatement on the **offered (raw inbound) load**, not the throttled
+delivered rate. A rate-limiter forces the delivered signal normal, so judging
+recovery on it is circular. A scrubbing appliance still observes the
+true inbound rate while limiting what it forwards; release the throttle once
+that raw signal has been normal for, say, twice the detection duration
+(`2 × trigger_slots`). The exact policy depends on the deployment and is
+intentionally left out of this minimal example.

--- a/examples/causal_correction_examples/corrective_ddos_detector/main.rs
+++ b/examples/causal_correction_examples/corrective_ddos_detector/main.rs
@@ -82,7 +82,7 @@ fn main() {
         })
         .into_process();
 
-    // Verbose detailed.
+    // Verbose details. Comment out to trim the output.
     model_utils::print_section("Closed loop", &result);
 
     println!("=== Summary ===");


### PR DESCRIPTION

## Describe your changes

Added or update Readme files for the new example.

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for the new `corrective_ddos_detector` example and updates the examples index to include it. The corrective set now has five examples; the new README explains the sliding-window z-score detector and throttle intervention.

- **New Features**
  - Added `examples/causal_correction_examples/corrective_ddos_detector/README.md` with run command, detector design, control flow, and output notes.
  - Updated `examples/README.md` and `examples/causal_correction_examples/README.md` to reflect five examples and add the `corrective_ddos_detector` row.
  - Minor comment tweak in `examples/causal_correction_examples/corrective_ddos_detector/main.rs`.

<sup>Written for commit 3502f61631599213d5e785bfb1eea764b3ec3718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

