### PR TITLE
feat(examples): Added integrated DeepCausality and Candle (ML) example  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -33,6 +34,12 @@ checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -84,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,16 +109,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "git+https://github.com/huggingface/candle.git#65ecb58c11d2244a7e60c71bdcdb19b15b0a4343"
+dependencies = [
+ "byteorder",
+ "float8",
+ "gemm",
+ "half",
+ "libc",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror 2.0.18",
+ "tokenizers",
+ "yoke",
+ "zip",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "causal_correction_examples"
@@ -129,8 +201,11 @@ dependencies = [
 name = "causal_discovery_examples"
 version = "0.1.0"
 dependencies = [
+ "candle-core",
  "deep_causality_algorithms",
+ "deep_causality_core",
  "deep_causality_discovery",
+ "deep_causality_haft",
  "deep_causality_num",
  "deep_causality_tensor",
 ]
@@ -245,6 +320,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +369,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,7 +389,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -310,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -371,6 +470,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -583,10 +726,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -605,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +825,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +847,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -650,6 +876,125 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
 ]
 
 [[package]]
@@ -694,9 +1039,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "rand",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -706,7 +1054,20 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -720,6 +1081,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -752,6 +1119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +1141,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -830,6 +1212,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "material_examples"
 version = "0.1.0"
 dependencies = [
@@ -874,6 +1272,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,12 +1299,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -914,10 +1370,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "oorandom"
@@ -1006,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1554,29 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "quantum_examples"
@@ -1092,6 +1618,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1673,17 @@ checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
 ]
 
 [[package]]
@@ -1110,6 +1695,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -1185,6 +1776,17 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -1295,11 +1897,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "starter_example"
 version = "0.1.0"
 dependencies = [
  "deep_causality_core",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1313,6 +1945,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1980,46 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1342,6 +2039,39 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
 ]
 
 [[package]]
@@ -1387,6 +2117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "ultragraph"
 version = "0.9.1"
 dependencies = [
@@ -1401,10 +2137,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "version_check"
@@ -1738,6 +2495,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +2535,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -51,7 +51,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.10.0"
+version = "0.10"
 default-features = true
 
 [dependencies.deep_causality_data_structures]

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -28,6 +28,7 @@ exclude = [
 
 [features]
 default = ["std"]
+
 # This crate is std-only
 std = [
     "deep_causality_core/std",
@@ -35,6 +36,7 @@ std = [
     "deep_causality_physics/std",
     "dep:deep_causality_uncertain",
 ]
+
 # Opt-in CPU parallelism. Forwards to the topology crate's Rayon-backed DEC
 # operator loops and the shared `MaybeParallel` marker. Serial by default;
 parallel = [
@@ -45,7 +47,7 @@ parallel = [
 
 [dependencies.deep_causality_physics]
 path = "../deep_causality_physics"
-version = "0.6.2"
+version = "0.6"
 default-features = false
 
 [dependencies.deep_causality_calculus]
@@ -54,7 +56,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.10.0"
+version = "0.10"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.3"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3.2"
+version = "0.3"
 
 
 [dependencies.deep_causality_tensor]

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,7 @@ pipeline.
 | CDL (SURD)   | Load -> clean -> mRMR -> SURD -> analyze              | `cargo run -p causal_discovery_examples --example example_surd_discovery` |
 | CDL (BRCD)   | Root-cause ranking with a supplied CPDAG (real Sock Shop data) | `cargo run -p causal_discovery_examples --example example_brcd_discovery` |
 | CDL (BRCD/BOSS) | Root-cause ranking, CPDAG learned via BOSS         | `cargo run -p causal_discovery_examples --example example_brcd_boss_discovery` |
+| ML × Causal RCA | Candle anomaly detector gates the BRCD root-cause explainer via a `PropagatingProcess` (ML detects, causality explains) | `cargo run -p causal_discovery_examples --example example_ml_rca` |
 
 See [causal_discovery_examples/README.md](causal_discovery_examples/README.md) for detailed documentation.
 

--- a/examples/causal_discovery_examples/Cargo.toml
+++ b/examples/causal_discovery_examples/Cargo.toml
@@ -12,9 +12,15 @@ path = "no_lib.rs"
 
 [dependencies]
 deep_causality_algorithms =  { path = "../../deep_causality_algorithms" }
+deep_causality_core =  { path = "../../deep_causality_core" }
+deep_causality_haft =  { path = "../../deep_causality_haft" }
 deep_causality_discovery =  { path = "../../deep_causality_discovery" }
 deep_causality_num =  { path = "../../deep_causality_num" }
 deep_causality_tensor =  { path = "../../deep_causality_tensor" }
+
+# Example-only ML dependency (the `example_ml_rca` Candle integration).
+# CPU-only, default features.
+candle-core = { git = "https://github.com/huggingface/candle.git" }
 
 
 [[example]]
@@ -40,6 +46,10 @@ path = "cdl/brcd_discovery/main.rs"
 [[example]]
 name = "example_brcd_boss_discovery"
 path = "cdl/brcd_boss_discovery/main.rs"
+
+[[example]]
+name = "example_ml_rca"
+path = "ml/ml_rca/main.rs"
 
 [lints]
 workspace = true

--- a/examples/causal_discovery_examples/README.md
+++ b/examples/causal_discovery_examples/README.md
@@ -17,6 +17,7 @@ Causal Discovery Language (CDL) pipeline.
 | CDL (SURD)      | Full SURD pipeline: load -> clean -> mRMR -> SURD -> analyze          | `cargo run -p causal_discovery_examples --example example_surd_discovery`     |
 | CDL (BRCD)      | BRCD root-cause ranking with a supplied CPDAG (real Sock Shop data)  | `cargo run -p causal_discovery_examples --example example_brcd_discovery`     |
 | CDL (BRCD/BOSS) | BRCD root-cause ranking, CPDAG learned from data via BOSS            | `cargo run -p causal_discovery_examples --example example_brcd_boss_discovery` |
+| ML × Causal RCA | Candle anomaly detector gates the BRCD root-cause explainer through a `PropagatingProcess` ("ML detects, causality explains"); verdict checked against shipped ground truth | `cargo run -p causal_discovery_examples --example example_ml_rca` |
 
 ---
 

--- a/examples/causal_discovery_examples/ml/ml_rca/README.md
+++ b/examples/causal_discovery_examples/ml/ml_rca/README.md
@@ -1,0 +1,113 @@
+# ML-gated Causal Root-Cause Analysis (Candle × DeepCausality)
+
+**"ML detects, causality explains."** This example combines the [Candle](https://github.com/huggingface/candle)
+machine-learning framework with DeepCausality on a problem each one solves only halfway:
+
+- A small **Candle** classifier learns, from labeled telemetry, to *detect* that a microservice
+  system is anomalous. It is fast and cheap, yet it cannot say *which* service is at fault.
+- The existing DeepCausality **BRCD** causal-discovery pipeline *explains* the anomaly by ranking the
+  culprit service or metric, but it needs a detector to decide *when* to run.
+
+The two stages are sequenced through a `PropagatingProcess` monad. The Candle anomaly score **gates**
+the causal stage, the carried value becomes the root-cause verdict, and the escalation is recorded in
+the `EffectLog`. This is the canonical AIOps "detect, triage, root-cause" split, expressed as one
+typed, auditable causal chain.
+
+```text
+ telemetry row ──► Candle detector ──► anomaly score ──► gate (PropagatingProcess.bind)
+                    (logistic reg.)                         │
+                                          score < θ ────────┤───► Healthy   (short-circuit, no RCA)
+                                          score ≥ θ ────────┘───► BRCD causal RCA ──► ranked culprit
+                                                                          │
+                                                                          └─► checked vs ground truth
+```
+
+## Why both, and why it is not redundant
+
+A classifier reduces 44 noisy signals to a single "is something wrong?" probability. A positive is an
+alarm, not a diagnosis. The causal pipeline consumes the *normal* and *anomalous* windows plus the
+service-call graph (CPDAG) and returns a *ranked, posterior-weighted* set of candidate root causes.
+Running the more expensive causal stage only when the learned detector fires is how you would wire an
+on-call pipeline: cheap detection everywhere, causal explanation on escalation.
+
+## Architecture (three files)
+
+| File | Responsibility |
+|------|----------------|
+| [`model.rs`](model.rs) | The value/state/context types (`RcaSignal`, `RcaState`, `RcaConfig`), the Candle `Detector` (training and scoring), the reused BRCD explainer, and the `PropagatingProcess` **gate** that bridges detect to explain. |
+| [`utils.rs`](utils.rs) | Dataset loading (`load_csv`, `load_truth_index`), preparation (`build_training_set`, `fit_standardizer`), and all console-reporting functions. |
+| [`main.rs`](main.rs) | A lean orchestration: load, train, calibrate the gate, run both windows, print. |
+
+### The detector (Candle, `candle-core` only)
+
+A logistic regression written directly on `candle-core`, with **no `candle-nn`**:
+
+- forward pass: `x.matmul(w) + b`, then a `sigmoid` built from `affine`/`exp`/`recip`;
+- binary-cross-entropy loss over the standardized feature matrix;
+- a **hand-rolled gradient-descent step**: `loss.backward()`, then `GradStore::get` and `Var::set`.
+
+Weights are zero-initialized and the split is fixed, so the run is deterministic.
+
+### The explainer (DeepCausality BRCD)
+
+Reuses the exact CDL surface as [`example_brcd_discovery`](../../cdl/brcd_discovery/main.rs):
+`CdlConfigBuilder::build_brcd_config(...)` feeds `CdlBuilder::build_brcd(&cfg).brcd_load_input().brcd_discover()`,
+and the top-ranked culprit column is read from `BrcdResult::ranks()` and `::posterior()`.
+
+### The bridge (`PropagatingProcess`)
+
+A single `bind` stage gates on the score. Below threshold it short-circuits to `Healthy` and the
+causal stage never runs. At or above threshold it escalates, runs BRCD, compares the culprit to
+ground truth, and carries a `RootCause` verdict. Every decision is appended to the process
+`EffectLog`.
+
+## Data
+
+The shipped RCAEval Sock Shop case [`data/sock-shop-2/carts_cpu_1/`](../../data/sock-shop-2/carts_cpu_1/):
+
+- `normal.csv` (label 0) and `anomalous.csv` (label 1): 44 service metrics (CPU, memory, workload,
+  latency), about 720 labeled rows in total. This is a ready-made supervised training set.
+- `expected.txt`: the ground-truth root-cause ranking; `shipping_latency` (column 42) is first.
+- `cpdag.csv`: the supplied service-call causal graph the BRCD stage consumes.
+
+No new data is added. Candle is an **example-only** dependency (latest `main`, CPU-only); no
+`deep_causality_*` library crate depends on it.
+
+## Run
+
+```bash
+cargo run -p causal_discovery_examples --example example_ml_rca
+```
+
+## Expected output (abridged)
+
+```text
+Ground-truth root cause: shipping_latency (col 42).
+
+Candle detector, held-out mean anomaly score:
+  normal window    : 0.569
+  anomalous window : 1.000
+Gate threshold (calibrated midpoint): 0.784
+
+--- Window: normal-window ---
+  verdict: HEALTHY (score 0.569); causal stage not run.
+
+--- Window: anomalous-window ---
+  verdict: ROOT CAUSE = shipping_latency (col 42, posterior 1.0000)
+  ground-truth check: MATCH ✓ (ML detected, causality explained, ground truth confirmed)
+```
+
+The normal window stays below the gate and short-circuits. The anomalous window escalates, and the
+causal stage recovers `shipping_latency`, matching the shipped ground truth.
+
+## Notes
+
+- **Gate calibration.** The threshold is set at runtime to the midpoint between the held-out normal
+  and anomalous mean scores (the detector's operating point), so both branches are exercised: the
+  healthy short-circuit and the escalate-to-explain path. The point of the example is the
+  integration pattern, not detector accuracy. The held-out normal tail sits near the boundary, which
+  is realistic for windows close to a regime change and is exactly why a calibrated gate matters.
+- **Determinism.** Zero weight init plus a fixed data split make the printed numbers reproducible.
+- **Extending it.** Swap the logistic regression for an MLP (add `candle-nn`), iterate over
+  `carts_cpu_2` as well, or replace the midpoint gate with a learned threshold. None of these changes
+  the detect, gate, explain shape.

--- a/examples/causal_discovery_examples/ml/ml_rca/main.rs
+++ b/examples/causal_discovery_examples/ml/ml_rca/main.rs
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! # ML-gated causal root-cause analysis (Candle × DeepCausality)
+//!
+//! **"ML detects, causality explains."** A small **Candle** classifier learns to *detect* that a
+//! microservice system is anomalous; when it fires, the existing **DeepCausality** BRCD
+//! causal-discovery pipeline *explains* the anomaly by ranking the culprit service/metric. The two
+//! stages are sequenced through a `PropagatingProcess` monad: the Candle anomaly score gates the
+//! causal stage, the carried value becomes the root-cause verdict, and the escalation is recorded in
+//! the `EffectLog`.
+//!
+//! Both halves run on the shipped, labeled RCAEval Sock Shop case (`data/sock-shop-2/carts_cpu_1`):
+//! 44 service metrics, a `normal.csv` window (label 0) and an `anomalous.csv` window (label 1), and
+//! a supplied service-call CPDAG. The detector is a logistic regression written directly on
+//! `candle-core` (manual forward pass, binary-cross-entropy, hand-rolled gradient descent, no
+//! `candle-nn`). The explainer reuses the same CDL BRCD pipeline as `example_brcd_discovery`; its
+//! top-ranked culprit is checked against the case's shipped ground truth (`expected.txt`), which
+//! ranks `shipping_latency` (column 42) first.
+//!
+//! Candle is an example-only dependency; no `deep_causality_*` library crate depends on it.
+//!
+//! The detector + causal/monad logic lives in [`model`]; data loading and console reporting live in
+//! [`utils`]; this file is the lean orchestration.
+//!
+//! Run: `cargo run -p causal_discovery_examples --example example_ml_rca`
+
+mod model;
+mod utils;
+
+use candle_core::Device;
+use model::{RcaConfig, run_window, train_detector};
+use utils::{
+    build_training_set, fit_standardizer, load_csv, load_truth_index, print_banner,
+    print_dataset_summary, print_detector_scores, print_ground_truth, print_threshold,
+    print_window_result,
+};
+
+fn main() -> Result<(), String> {
+    print_banner();
+
+    let base = concat!(env!("CARGO_MANIFEST_DIR"), "/data/sock-shop-2/carts_cpu_1");
+    let normal_path = format!("{base}/normal.csv");
+    let anomalous_path = format!("{base}/anomalous.csv");
+    let cpdag_path = format!("{base}/cpdag.csv");
+    let expected_path = format!("{base}/expected.txt");
+
+    // 1. Load the labeled dataset (normal = 0, anomalous = 1) and the ground-truth root cause.
+    let (header, normal_rows) = load_csv(&normal_path)?;
+    let (_, anomalous_rows) = load_csv(&anomalous_path)?;
+    print_dataset_summary(normal_rows.len(), anomalous_rows.len());
+
+    let truth_index = load_truth_index(&expected_path)?;
+    print_ground_truth(&header, truth_index);
+
+    // 2. Split, standardize, and train the Candle detector (detect stage).
+    let dev = Device::Cpu;
+    let (train_rows, train_labels, norm_te, anom_te) =
+        build_training_set(&normal_rows, &anomalous_rows);
+    let (mean, std) = fit_standardizer(&train_rows);
+    let detector = train_detector(&train_rows, &train_labels, mean, std, &dev)
+        .map_err(|e| format!("training: {e}"))?;
+
+    let normal_score = detector
+        .mean_score(&norm_te, &dev)
+        .map_err(|e| format!("score: {e}"))?;
+    let anomalous_score = detector
+        .mean_score(&anom_te, &dev)
+        .map_err(|e| format!("score: {e}"))?;
+    print_detector_scores(normal_score, anomalous_score);
+
+    // 3. Calibrate the gate to the detector's operating point (midpoint of the class scores).
+    let threshold = (normal_score + anomalous_score) / 2.0;
+    print_threshold(threshold);
+
+    let cfg = RcaConfig {
+        normal_path,
+        anomalous_path,
+        cpdag_path,
+        header,
+        truth_index,
+        threshold,
+    };
+
+    // 4. Drive the causal-monad bridge twice: a normal window (short-circuits) and an anomalous
+    //    window (escalates to the causal explainer).
+    for (label, score) in [
+        ("normal-window", normal_score),
+        ("anomalous-window", anomalous_score),
+    ] {
+        let result = run_window(label, score, &cfg);
+        print_window_result(label, &result);
+    }
+
+    Ok(())
+}

--- a/examples/causal_discovery_examples/ml/ml_rca/model.rs
+++ b/examples/causal_discovery_examples/ml/ml_rca/model.rs
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Model layer: the value/state/context types, the Candle anomaly **detector**, the reused BRCD
+//! causal **explainer**, and the `PropagatingProcess` **gate** that bridges them.
+
+use candle_core::{DType, Device, Tensor, Var};
+use deep_causality_core::{EffectLog, EffectValue, PropagatingProcess};
+use deep_causality_discovery::{BrcdConfig, CdlBuilder, CdlConfigBuilder};
+use deep_causality_haft::LogAddEntry;
+
+/// Number of metric columns in the Sock Shop case.
+pub const N_FEATURES: usize = 44;
+/// Gradient-descent epochs for the logistic-regression detector.
+const EPOCHS: usize = 800;
+/// Learning rate.
+const LR: f64 = 0.3;
+
+// ---------------------------------------------------------------------------
+// Value / State / Context for the causal-monad bridge
+// ---------------------------------------------------------------------------
+
+/// The value channel carried through the `PropagatingProcess`.
+#[derive(Debug, Clone)]
+pub enum RcaSignal {
+    /// Detector output before the gate decides (the anomaly score in `[0, 1]`).
+    Score(f64),
+    /// Below threshold: no escalation, no causal verdict.
+    Healthy { score: f64 },
+    /// Escalated: the causal stage named a culprit.
+    RootCause {
+        metric: String,
+        index: usize,
+        posterior: f64,
+        matches_truth: bool,
+    },
+}
+
+/// Carried state: the window label, for the narrative.
+#[derive(Debug, Clone)]
+pub struct RcaState {
+    pub window_label: String,
+}
+
+/// Read-only context: data paths, the column header, and the shipped ground truth.
+#[derive(Debug, Clone)]
+pub struct RcaConfig {
+    pub normal_path: String,
+    pub anomalous_path: String,
+    pub cpdag_path: String,
+    pub header: Vec<String>,
+    /// Ground-truth root-cause column index (first line of `expected.txt`).
+    pub truth_index: usize,
+    /// Gate threshold, calibrated at runtime to the detector's operating point (the midpoint
+    /// between the held-out normal and anomalous mean scores). At/above this, the gate escalates.
+    pub threshold: f64,
+}
+
+/// The process type threaded through the detect → gate → explain chain.
+pub type RcaProcess = PropagatingProcess<RcaSignal, RcaState, RcaConfig>;
+
+// ---------------------------------------------------------------------------
+// Detect stage: a logistic-regression anomaly classifier on candle-core
+// ---------------------------------------------------------------------------
+
+/// The trained detector: weights + the standardization statistics fit on the training rows.
+pub struct Detector {
+    w: Tensor,
+    b: Tensor,
+    mean: Vec<f64>,
+    std: Vec<f64>,
+}
+
+impl Detector {
+    /// Score a single 44-feature row, returning the anomaly probability in `[0, 1]`.
+    fn score_row(&self, row: &[f64], dev: &Device) -> Result<f64, candle_core::Error> {
+        let z: Vec<f32> = standardize(row, &self.mean, &self.std)
+            .into_iter()
+            .map(|v| v as f32)
+            .collect();
+        let x = Tensor::from_vec(z, (1, N_FEATURES), dev)?;
+        let logit = x.matmul(&self.w)?.broadcast_add(&self.b)?;
+        let p = sigmoid(&logit)?;
+        Ok(p.flatten_all()?.to_vec1::<f32>()?[0] as f64)
+    }
+
+    /// Mean anomaly score over a set of rows.
+    pub fn mean_score(&self, rows: &[Vec<f64>], dev: &Device) -> Result<f64, candle_core::Error> {
+        let mut acc = 0.0;
+        for r in rows {
+            acc += self.score_row(r, dev)?;
+        }
+        Ok(acc / rows.len() as f64)
+    }
+}
+
+/// `sigmoid(z) = 1 / (1 + exp(-z))`, written with `candle-core` tensor ops only.
+fn sigmoid(z: &Tensor) -> Result<Tensor, candle_core::Error> {
+    // exp(-z), then (1·exp(-z) + 1), then reciprocal.
+    z.neg()?.exp()?.affine(1.0, 1.0)?.recip()
+}
+
+/// Per-feature z-score standardization using fitted statistics.
+pub fn standardize(row: &[f64], mean: &[f64], std: &[f64]) -> Vec<f64> {
+    row.iter()
+        .zip(mean.iter().zip(std.iter()))
+        .map(|(&x, (&m, &s))| if s > 1e-12 { (x - m) / s } else { 0.0 })
+        .collect()
+}
+
+/// Train the logistic-regression detector on the labeled, standardized rows.
+///
+/// Manual gradient descent on `candle-core` (no `candle-nn`): forward pass, binary-cross-entropy
+/// loss, `loss.backward()`, then a hand-rolled `Var::set` update. Zero weight init keeps it
+/// deterministic.
+pub fn train_detector(
+    train_rows: &[Vec<f64>],
+    train_labels: &[f64],
+    mean: Vec<f64>,
+    std: Vec<f64>,
+    dev: &Device,
+) -> Result<Detector, candle_core::Error> {
+    let n = train_rows.len();
+    let mut x_flat = Vec::with_capacity(n * N_FEATURES);
+    for r in train_rows {
+        for v in standardize(r, &mean, &std) {
+            x_flat.push(v as f32);
+        }
+    }
+    let x = Tensor::from_vec(x_flat, (n, N_FEATURES), dev)?;
+    let y = Tensor::from_vec(
+        train_labels.iter().map(|&v| v as f32).collect::<Vec<_>>(),
+        (n, 1),
+        dev,
+    )?;
+
+    let w = Var::from_tensor(&Tensor::zeros((N_FEATURES, 1), DType::F32, dev)?)?;
+    let b = Var::from_tensor(&Tensor::zeros((1, 1), DType::F32, dev)?)?;
+
+    for _ in 0..EPOCHS {
+        let logit = x.matmul(w.as_tensor())?.broadcast_add(b.as_tensor())?;
+        let p = sigmoid(&logit)?.clamp(1e-7, 1.0 - 1e-7)?;
+        // Binary cross-entropy: -mean( y·log(p) + (1-y)·log(1-p) ).
+        let log_p = p.log()?;
+        let log_1mp = p.affine(-1.0, 1.0)?.log()?;
+        let term = (y.mul(&log_p)? + y.affine(-1.0, 1.0)?.mul(&log_1mp)?)?;
+        let loss = term.mean_all()?.neg()?;
+
+        let grads = loss.backward()?;
+        let gw = grads.get(w.as_tensor()).expect("grad w");
+        let gb = grads.get(b.as_tensor()).expect("grad b");
+        w.set(&w.as_tensor().sub(&gw.affine(LR, 0.0)?)?)?;
+        b.set(&b.as_tensor().sub(&gb.affine(LR, 0.0)?)?)?;
+    }
+
+    Ok(Detector {
+        w: w.as_tensor().clone(),
+        b: b.as_tensor().clone(),
+        mean,
+        std,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Explain stage: the existing CDL BRCD root-cause pipeline (reused verbatim)
+// ---------------------------------------------------------------------------
+
+/// Run the BRCD causal-discovery pipeline and return the top-ranked culprit column index and its
+/// posterior weight. Reuses the same surface as `example_brcd_discovery`.
+fn brcd_top_culprit(cfg: &RcaConfig) -> Result<(usize, f64), String> {
+    let config = CdlConfigBuilder::build_brcd_config()
+        .with_normal_path(&cfg.normal_path)
+        .with_anomalous_path(&cfg.anomalous_path)
+        .with_brcd_config(BrcdConfig::<f64>::continuous(0))
+        .with_cpdag_path(&cfg.cpdag_path)
+        .build()
+        .map_err(|e| format!("BRCD config: {e}"))?;
+
+    let effect = CdlBuilder::build_brcd(&config)
+        .brcd_load_input()
+        .brcd_discover();
+
+    let cdl = effect.inner.map_err(|e| format!("BRCD discover: {e}"))?;
+    let result = &cdl.state.brcd_result;
+    let ranks = result.ranks();
+    let posterior = result.posterior();
+    let top = ranks
+        .first()
+        .and_then(|set| set.first())
+        .copied()
+        .ok_or_else(|| "BRCD ranked no candidates".to_string())?;
+    let weight = posterior.first().copied().unwrap_or(f64::NAN);
+    Ok((top, weight))
+}
+
+// ---------------------------------------------------------------------------
+// The gate: a single PropagatingProcess bind stage bridging detect -> explain
+// ---------------------------------------------------------------------------
+
+/// The gate bind stage. Reads the detector score from the value channel; below threshold it
+/// short-circuits to `Healthy` (no causal stage); at/above threshold it escalates, runs the BRCD
+/// explainer, compares the culprit against the shipped ground truth, and carries a `RootCause`
+/// verdict, recording the escalation in the `EffectLog`.
+fn gate_stage(
+    value: EffectValue<RcaSignal>,
+    state: RcaState,
+    ctx: Option<RcaConfig>,
+) -> RcaProcess {
+    let cfg = ctx.as_ref().expect("RcaConfig required");
+    let score = match value.into_value() {
+        Some(RcaSignal::Score(s)) => s,
+        _ => 0.0,
+    };
+    let threshold = cfg.threshold;
+    let mut logs = EffectLog::new();
+
+    if score < threshold {
+        logs.add_entry(&format!(
+            "[{}] anomaly score {:.3} < {:.3} → healthy, no escalation (causal stage skipped)",
+            state.window_label, score, threshold
+        ));
+        return RcaProcess {
+            value: EffectValue::Value(RcaSignal::Healthy { score }),
+            state,
+            context: ctx,
+            error: None,
+            logs,
+        };
+    }
+
+    logs.add_entry(&format!(
+        "[{}] anomaly score {:.3} ≥ {:.3} → ESCALATE to causal root-cause analysis",
+        state.window_label, score, threshold
+    ));
+
+    match brcd_top_culprit(cfg) {
+        Ok((index, posterior)) => {
+            let metric = cfg
+                .header
+                .get(index)
+                .cloned()
+                .unwrap_or_else(|| format!("col_{index}"));
+            let matches_truth = index == cfg.truth_index;
+            logs.add_entry(&format!(
+                "[{}] causal verdict: root cause = {} (col {}, posterior {:.4}); ground-truth match = {}",
+                state.window_label, metric, index, posterior, matches_truth
+            ));
+            RcaProcess {
+                value: EffectValue::Value(RcaSignal::RootCause {
+                    metric,
+                    index,
+                    posterior,
+                    matches_truth,
+                }),
+                state,
+                context: ctx,
+                error: None,
+                logs,
+            }
+        }
+        Err(e) => {
+            logs.add_entry(&format!(
+                "[{}] causal stage failed: {e}",
+                state.window_label
+            ));
+            RcaProcess {
+                value: EffectValue::None,
+                state,
+                context: ctx,
+                error: None,
+                logs,
+            }
+        }
+    }
+}
+
+/// Run one window through the causal-monad bridge: seed the process with the detector score, then
+/// `bind` the gate (which escalates to the explainer or short-circuits to healthy).
+pub fn run_window(label: &str, score: f64, cfg: &RcaConfig) -> RcaProcess {
+    let start = RcaProcess {
+        value: EffectValue::Value(RcaSignal::Score(score)),
+        state: RcaState {
+            window_label: label.to_string(),
+        },
+        context: Some(cfg.clone()),
+        error: None,
+        logs: EffectLog::new(),
+    };
+    start.bind(gate_stage)
+}

--- a/examples/causal_discovery_examples/ml/ml_rca/model.rs
+++ b/examples/causal_discovery_examples/ml/ml_rca/model.rs
@@ -7,7 +7,9 @@
 //! causal **explainer**, and the `PropagatingProcess` **gate** that bridges them.
 
 use candle_core::{DType, Device, Tensor, Var};
-use deep_causality_core::{EffectLog, EffectValue, PropagatingProcess};
+use deep_causality_core::{
+    CausalityError, CausalityErrorEnum, EffectLog, EffectValue, PropagatingProcess,
+};
 use deep_causality_discovery::{BrcdConfig, CdlBuilder, CdlConfigBuilder};
 use deep_causality_haft::LogAddEntry;
 
@@ -261,6 +263,9 @@ fn gate_stage(
             }
         }
         Err(e) => {
+            // Propagate the causal-stage failure into the process error channel so the chain
+            // enters an error state. Logging alone would leave a failed run looking like a normal,
+            // empty result.
             logs.add_entry(&format!(
                 "[{}] causal stage failed: {e}",
                 state.window_label
@@ -269,7 +274,9 @@ fn gate_stage(
                 value: EffectValue::None,
                 state,
                 context: ctx,
-                error: None,
+                error: Some(CausalityError::new(CausalityErrorEnum::Custom(format!(
+                    "causal root-cause analysis failed: {e}"
+                )))),
                 logs,
             }
         }

--- a/examples/causal_discovery_examples/ml/ml_rca/utils.rs
+++ b/examples/causal_discovery_examples/ml/ml_rca/utils.rs
@@ -137,6 +137,11 @@ pub fn print_threshold(threshold: f64) {
 /// Print one window's verdict (healthy / root cause) and its `EffectLog`.
 pub fn print_window_result(label: &str, result: &RcaProcess) {
     println!("--- Window: {label} ---");
+    if let Some(err) = &result.error {
+        println!("  verdict: ERROR (causal stage failed): {err}");
+        println!("  {}", result.logs);
+        return;
+    }
     match &result.value {
         EffectValue::Value(RcaSignal::Healthy { score }) => {
             println!("  verdict: HEALTHY (score {score:.3}); causal stage not run.");

--- a/examples/causal_discovery_examples/ml/ml_rca/utils.rs
+++ b/examples/causal_discovery_examples/ml/ml_rca/utils.rs
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Utility layer: dataset loading / preparation and the console-reporting functions. Keeping I/O
+//! and presentation here leaves `main` a lean orchestration of the model stages.
+
+use crate::model::{N_FEATURES, RcaProcess, RcaSignal};
+use deep_causality_core::EffectValue;
+use std::fs;
+
+// ---------------------------------------------------------------------------
+// Data loading & preparation
+// ---------------------------------------------------------------------------
+
+/// Parse a Sock Shop metrics CSV into (header, rows). Each row is 44 f64 features.
+pub fn load_csv(path: &str) -> Result<(Vec<String>, Vec<Vec<f64>>), String> {
+    let text = fs::read_to_string(path).map_err(|e| format!("read {path}: {e}"))?;
+    let mut lines = text.lines();
+    let header: Vec<String> = lines
+        .next()
+        .ok_or_else(|| format!("{path}: empty file"))?
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect();
+    let mut rows = Vec::new();
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row: Vec<f64> = line
+            .split(',')
+            .map(|s| s.trim().parse::<f64>().unwrap_or(0.0))
+            .collect();
+        if row.len() >= N_FEATURES {
+            rows.push(row[..N_FEATURES].to_vec());
+        }
+    }
+    Ok((header, rows))
+}
+
+/// Read the ground-truth root-cause column index (first line of `expected.txt`).
+pub fn load_truth_index(path: &str) -> Result<usize, String> {
+    fs::read_to_string(path)
+        .map_err(|e| format!("read {path}: {e}"))?
+        .lines()
+        .next()
+        .and_then(|l| l.trim().parse().ok())
+        .ok_or_else(|| "expected.txt: no root-cause index".to_string())
+}
+
+/// Build the labeled training set (normal = 0, anomalous = 1) and a held-out evaluation split.
+/// Deterministic: the last 20% of each class is held out.
+#[allow(clippy::type_complexity)]
+pub fn build_training_set(
+    normal_rows: &[Vec<f64>],
+    anomalous_rows: &[Vec<f64>],
+) -> (Vec<Vec<f64>>, Vec<f64>, Vec<Vec<f64>>, Vec<Vec<f64>>) {
+    let split = |rows: &[Vec<f64>]| -> (Vec<Vec<f64>>, Vec<Vec<f64>>) {
+        let cut = rows.len() * 4 / 5;
+        (rows[..cut].to_vec(), rows[cut..].to_vec())
+    };
+    let (norm_tr, norm_te) = split(normal_rows);
+    let (anom_tr, anom_te) = split(anomalous_rows);
+
+    let mut train_rows = norm_tr.clone();
+    train_rows.extend(anom_tr.clone());
+    let mut train_labels = vec![0.0; norm_tr.len()];
+    train_labels.extend(vec![1.0; anom_tr.len()]);
+
+    (train_rows, train_labels, norm_te, anom_te)
+}
+
+/// Column-wise mean and standard deviation over the given rows.
+pub fn fit_standardizer(rows: &[Vec<f64>]) -> (Vec<f64>, Vec<f64>) {
+    let n = rows.len() as f64;
+    let mut mean = vec![0.0; N_FEATURES];
+    for r in rows {
+        for (m, &v) in mean.iter_mut().zip(r.iter()) {
+            *m += v / n;
+        }
+    }
+    let mut var = vec![0.0; N_FEATURES];
+    for r in rows {
+        for (j, &v) in r.iter().enumerate() {
+            var[j] += (v - mean[j]).powi(2) / n;
+        }
+    }
+    let std = var.iter().map(|v| v.sqrt()).collect();
+    (mean, std)
+}
+
+// ---------------------------------------------------------------------------
+// Console reporting
+// ---------------------------------------------------------------------------
+
+/// The example banner.
+pub fn print_banner() {
+    println!("=== ML-gated Causal Root-Cause Analysis (Candle × DeepCausality) ===\n");
+}
+
+/// Summarize the loaded dataset.
+pub fn print_dataset_summary(n_normal: usize, n_anomalous: usize) {
+    println!("Loaded {n_normal} normal + {n_anomalous} anomalous rows, {N_FEATURES} features.");
+}
+
+/// Report the shipped ground-truth root cause.
+pub fn print_ground_truth(header: &[String], truth_index: usize) {
+    let metric = header
+        .get(truth_index)
+        .cloned()
+        .unwrap_or_else(|| format!("col_{truth_index}"));
+    println!("Ground-truth root cause: {metric} (col {truth_index}).\n");
+}
+
+/// Report the detector's held-out mean scores and their separation.
+pub fn print_detector_scores(normal_score: f64, anomalous_score: f64) {
+    println!("Candle detector, held-out mean anomaly score:");
+    println!("  normal window    : {normal_score:.3}");
+    println!("  anomalous window : {anomalous_score:.3}");
+    println!(
+        "  separation       : anomalous {} normal\n",
+        if anomalous_score > normal_score {
+            ">"
+        } else {
+            "≤ (!)"
+        }
+    );
+}
+
+/// Report the calibrated gate threshold.
+pub fn print_threshold(threshold: f64) {
+    println!("Gate threshold (calibrated midpoint): {threshold:.3}\n");
+}
+
+/// Print one window's verdict (healthy / root cause) and its `EffectLog`.
+pub fn print_window_result(label: &str, result: &RcaProcess) {
+    println!("--- Window: {label} ---");
+    match &result.value {
+        EffectValue::Value(RcaSignal::Healthy { score }) => {
+            println!("  verdict: HEALTHY (score {score:.3}); causal stage not run.");
+        }
+        EffectValue::Value(RcaSignal::RootCause {
+            metric,
+            index,
+            posterior,
+            matches_truth,
+            ..
+        }) => {
+            println!("  verdict: ROOT CAUSE = {metric} (col {index}, posterior {posterior:.4})");
+            println!(
+                "  ground-truth check: {}",
+                if *matches_truth {
+                    "MATCH ✓ (ML detected, causality explained, ground truth confirmed)"
+                } else {
+                    "no match; see the ranking vs expected.txt"
+                }
+            );
+        }
+        other => println!("  verdict: {other:?}"),
+    }
+    println!("  {}", result.logs);
+}

--- a/openspec/changes/archive/2026-06-17-add-ml-rca-example/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-17-add-ml-rca-example/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/archive/2026-06-17-add-ml-rca-example/design.md
+++ b/openspec/changes/archive/2026-06-17-add-ml-rca-example/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`causal_discovery_examples` already ships `example_brcd_discovery`, which runs the CDL BRCD
+root-cause pipeline on the real Sock Shop `carts_cpu_1` case (44 metrics; a `normal.csv` window and
+an `anomalous.csv` window; a supplied `cpdag.csv`) and ranks `shipping_latency` (column 42) as the
+top root cause, matching the case's `expected.txt`. That pipeline is the *explain* half. It has no
+learned detector in front of it — the operator must already know the system is anomalous and hand it
+the anomalous window.
+
+This change adds the *detect* half with **Candle** (the HuggingFace Rust ML framework) and bridges
+the two stages with a `PropagatingProcess`. The dataset is already labeled (normal rows vs anomalous
+rows), which makes it a ready-made supervised training set with shipped ground truth — no new data is
+needed. Candle would be the repository's first machine-learning dependency, so it must stay confined
+to the example crate.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Demonstrate the Candle ↔ `deep_causality` integration pattern: a learned anomaly detector gates a
+  causal root-cause explanation, sequenced through a causal monad.
+- Reuse the shipped Sock Shop data, the existing CSV ingestion, and the existing CDL BRCD pipeline
+  unchanged.
+- Keep Candle an example-only dependency; leave all `deep_causality_*` library crates ML-free.
+- Be small, fast, deterministic enough to run from `cargo run` and read like the other examples.
+
+**Non-Goals:**
+- Production model accuracy, hyperparameter tuning, cross-validation, or streaming/online training.
+- GPU / feature-flagged Candle backends.
+- Any change to the causal-discovery algorithms or to library crates.
+- A general ML-in-`deep_causality` abstraction; this is one worked example.
+
+## Decisions
+
+### D1: Candle scope and features — CPU-only, example-crate-only
+Add `candle-core` (and, if the model needs a layer/optimizer abstraction, `candle-nn`) under the
+`causal_discovery_examples` crate's `[dependencies]` with **default features only** (no `cuda`,
+`metal`, `mkl`, `accelerate`). Rationale: portability and CI build time; the example must run on any
+developer machine. Alternative considered: a workspace-level optional ML feature — rejected as
+over-engineering for a single example and as risking ML leaking toward library crates.
+
+### D2: Model — logistic regression first (single linear layer + sigmoid)
+The detector is a logistic regression over the 44 standardized features, trained with binary
+cross-entropy by gradient descent in Candle. Rationale: ~720 rows × 44 features with a clean
+normal/anomalous split is linearly separable enough; logistic regression is the smallest Candle
+surface that still exercises tensors, a forward pass, a loss, and an optimizer, and it reads clearly.
+Alternative considered: a one-hidden-layer MLP — kept as an optional upgrade (`candle-nn`), but not
+required; it adds code without changing the integration story. The spec permits either.
+
+### D3: Reuse the CDL BRCD pipeline verbatim for the explain stage
+The explain stage calls the same public surface as `example_brcd_discovery`:
+`CdlConfigBuilder::build_brcd_config().with_normal_path(..).with_anomalous_path(..)`
+`.with_brcd_config(BrcdConfig::continuous(0)).with_cpdag_path(..).build()`, then
+`CdlBuilder::build_brcd(&config).brcd_load_input().brcd_discover().brcd_analyze().finalize()`.
+Rationale: zero new causal code, and the example demonstrably agrees with the existing reference run.
+The BRCD pipeline performs its own CSV loading internally; the Candle stage loads the same files
+separately for training (two read paths over the same shipped files is acceptable for an example).
+
+### D4: Bridge with `PropagatingProcess`, not an `if`
+The two stages are sequenced as a `PropagatingProcess` chain: stage 1 scores the window with Candle
+and carries the anomaly score; a bind stage gates on the threshold — below threshold it
+short-circuits to a "healthy" terminal value, at/above threshold it binds to stage 2, which runs the
+BRCD ranking and carries the root-cause verdict forward; the escalation is appended to the
+`EffectLog`. Rationale: the example's purpose is to show the integration *through the monad*, so the
+control flow must be the monad, mirroring `corrective_ddos_detector` (detector-in-`State` driving an
+escalation). A plain branch would defeat the point.
+
+### D5: Standardize features on training statistics
+Fit per-feature mean/standard-deviation on the training split and apply the same transform at scoring
+time. Rationale: the 44 metrics span very different scales (CPU %, MB of memory, latencies); without
+standardization the linear model is dominated by large-magnitude columns. Stored stats travel with
+the model so scoring is consistent.
+
+### D6: Ground-truth comparison via the CSV header and `expected.txt`
+Map the BRCD top-ranked column index to a metric name using the CSV header row, then compare against
+the shipped ground truth: `expected.txt` (the rank permutation; index 42 = `shipping_latency` first)
+and/or `notes.txt` (the named ranking). The example prints whether the top-ranked culprit matches the
+ground-truth top cause and whether it falls within the reported top-k. Rationale: makes the
+"detected → explained → confirmed" narrative concrete and checkable.
+
+### D7: Deterministic, small run
+Use a fixed RNG seed for weight initialization and a deterministic train/evaluation split so the
+printed scores are reproducible across runs. The default case is `carts_cpu_1` (the reference case),
+matching `example_brcd_discovery`.
+
+## Risks / Trade-offs
+
+- **First ML dependency in the repo → build time / CI surface.** → Confine to the example crate,
+  CPU-only default features; library crates stay ML-free (verified by D1's placement).
+- **Tiny dataset → overfitting / run-to-run variance in training.** → Logistic regression +
+  standardization + fixed seed; the example explicitly frames accuracy as illustrative, not a
+  benchmark. The integration pattern, not the model, is the deliverable.
+- **Two CSV read paths (Candle loads for training; BRCD loads internally).** → Acceptable for an
+  example; both read the same shipped files relative to `CARGO_MANIFEST_DIR`, so they cannot diverge.
+- **Candle API churn across versions.** → Pin an exact, current Candle version (see Open Questions)
+  and keep the surface minimal (tensors, one linear layer, a loss, an optimizer).
+- **`no_lib.rs` crate layout / example registration.** → Follow the existing `[[example]]` entries
+  in `causal_discovery_examples/Cargo.toml`; the example is exempt from the coverage requirement
+  (verified by running, not unit tests), per the examples policy.
+
+## Migration Plan
+
+Additive only. No existing example, data file, or library crate changes. Rollback is deletion of the
+new example directory plus its `[[example]]` entry and the two README rows. No published artifact or
+API is affected.
+
+## Resolved Decisions (was Open Questions)
+
+- **Candle version** — RESOLVED: use the latest `main` via a git dependency
+  (`candle-core = { git = "https://github.com/huggingface/candle.git" }`), default branch.
+- **`candle-core` only vs `candle-nn`** — RESOLVED: `candle-core` only. The logistic regression is
+  written directly on `candle-core` — manual forward pass (`matmul` + bias + sigmoid via tensor ops),
+  binary-cross-entropy loss, and a hand-rolled gradient-descent step using `loss.backward()` +
+  `Var::set`. No `candle-nn` optimizer/layer abstraction is pulled in.
+- **Single case or both** — RESOLVED: default to `carts_cpu_1` (the reference case), matching
+  `example_brcd_discovery`. Iterating over `carts_cpu_2` is a possible later addition, not in scope.
+
+### Explain-stage extraction (implementation note)
+The CDL pipeline is run to `brcd_discover()`, yielding `CdlEffect<CDL<BrcdResults<T>>>`. `CdlEffect`
+exposes a public `inner: Result<T, CdlError>`, so the ranked result is read as
+`effect.inner?.state.brcd_result.ranks()` (with `.posterior()` for weights) — `BrcdResult::ranks()`
+returns candidate root-cause sets best-first (top candidate = column index, e.g. 42 = `shipping_latency`).
+This reuses the causal-discovery machinery and yields structured data for the gate and the
+ground-truth comparison without a bespoke algorithm-layer call.

--- a/openspec/changes/archive/2026-06-17-add-ml-rca-example/proposal.md
+++ b/openspec/changes/archive/2026-06-17-add-ml-rca-example/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The repository has no example that integrates a mainstream Rust ML framework with `deep_causality`. The two are complementary on a problem they each solve only halfway: a supervised classifier can cheaply **detect** that a distributed system is anomalous but cannot say *which* component is at fault, while `deep_causality`'s causal-discovery pipeline **explains** the root cause but has no learned anomaly detector to gate it. The shipped, labeled Sock Shop microservice dataset (`examples/causal_discovery_examples/data/sock-shop-2/`) already powers the BRCD root-cause example and is a ready-made supervised training set, so the integration can be shown end to end with zero new data and no changes to any library crate.
+
+## What Changes
+
+- Add a new runnable example `example_ml_rca` to the **`causal_discovery_examples`** crate demonstrating the **"ML detects, causality explains"** pattern by combining **Candle** (the HuggingFace Rust ML framework) with `deep_causality`.
+- **Detect stage (Candle):** train a small classifier (logistic regression / one-hidden-layer MLP) on the labeled Sock Shop CSVs (`normal.csv` label 0, `anomalous.csv` label 1; 44 numeric features, ~720 rows) and emit a per-window **anomaly score**.
+- **Explain stage (`deep_causality`):** when the anomaly score crosses a threshold, run the **existing** BRCD/SURD causal root-cause ranking over the anomalous window to rank the culprit microservice/metric, and compare the top-ranked result against the shipped ground truth (`expected.txt` / `notes.txt`).
+- **Bridge:** sequence the two stages through a `PropagatingProcess` monad — the Candle gate decides whether to fire the causal stage; the carried value becomes the root-cause verdict; the `EffectLog` records the escalation.
+- Add **Candle as an example-only dependency** of `causal_discovery_examples` (dev/example scope). No library crate gains an ML dependency.
+- Add a `README.md` for the example following the standard example template, and register the example in the crate's `Cargo.toml` and the top-level `examples/README.md` + `causal_discovery_examples/README.md` tables.
+
+## Capabilities
+
+### New Capabilities
+- `ml-causal-rca-example`: a runnable, toy-scale example that trains a Candle anomaly classifier on the shipped Sock Shop dataset and feeds its gated output into the existing `deep_causality` causal root-cause ranking through a `PropagatingProcess`, demonstrating the Candle ↔ `deep_causality` integration pattern (ML detection escalating to causal explanation) with a verdict checked against shipped ground truth.
+
+### Modified Capabilities
+<!-- None. No existing spec in openspec/specs/ changes its requirements. This is an
+     examples-only addition; the BRCD / causal-discovery library behavior is reused unchanged. -->
+
+## Impact
+
+- **New code:** one example binary under `examples/causal_discovery_examples/` (Candle data-loading + training + scoring, the gate, and the call into the existing causal root-cause pipeline) plus its `README.md`.
+- **Dependencies:** `candle-core` (and likely `candle-nn`) added under the `causal_discovery_examples` example crate only. Examples are exempt from the repo's no-external-runtime-dependency rule; library crates (`deep_causality*`) remain ML-free and unchanged.
+- **No behavior change** to any library crate or existing example. The Sock Shop dataset, the CSV ingestion, and the BRCD/SURD root-cause machinery are reused as-is.
+- **Docs:** new example row in `examples/README.md` and `examples/causal_discovery_examples/README.md`.
+- **Out of scope:** production-grade model accuracy, GPU/feature-flagged Candle backends, streaming/online training, and any change to the causal-discovery algorithms themselves.

--- a/openspec/changes/archive/2026-06-17-add-ml-rca-example/specs/ml-causal-rca-example/spec.md
+++ b/openspec/changes/archive/2026-06-17-add-ml-rca-example/specs/ml-causal-rca-example/spec.md
@@ -1,0 +1,121 @@
+## ADDED Requirements
+
+### Requirement: Labeled dataset loading
+
+The example SHALL load the shipped Sock Shop dataset from
+`examples/causal_discovery_examples/data/sock-shop-2/<case>/` and construct a labeled
+feature matrix in which every row of `normal.csv` is labeled `0` and every row of
+`anomalous.csv` is labeled `1`. The 44 numeric metric columns SHALL be used as features and the
+column order SHALL be preserved so that a feature index maps back to a named metric. The example
+MUST NOT add or ship any new data file.
+
+#### Scenario: Both label classes loaded from the shipped CSVs
+
+- **WHEN** the example loads the chosen Sock Shop case
+- **THEN** it reads `normal.csv` and `anomalous.csv` from the existing data directory
+- **AND** produces a feature matrix of 44 columns with a label vector containing both `0` (normal) and `1` (anomalous) rows
+
+#### Scenario: Missing data is reported, not panicked past silently
+
+- **WHEN** a required CSV file is absent or unreadable
+- **THEN** the example terminates with a clear error message naming the missing path
+- **AND** does not proceed to training on partial data
+
+### Requirement: Candle anomaly classifier (detect stage)
+
+The example SHALL train a Candle model (logistic regression or a one-hidden-layer MLP) on the
+labeled feature matrix and SHALL emit a scalar anomaly score in `[0, 1]` for an input window. The
+model, training loop, and inference SHALL use the Candle framework. Candle SHALL be a dependency of
+the `causal_discovery_examples` example crate only; no `deep_causality*` library crate may gain an
+ML dependency.
+
+#### Scenario: Trained classifier separates the two classes
+
+- **WHEN** the classifier is trained on the labeled matrix and then scored on held-back normal and anomalous rows
+- **THEN** anomalous rows receive a higher mean anomaly score than normal rows
+- **AND** the model produces scores within `[0, 1]`
+
+#### Scenario: ML dependency confined to the example
+
+- **WHEN** the workspace is inspected
+- **THEN** `candle-*` appears only under the `causal_discovery_examples` example crate's manifest
+- **AND** no `deep_causality_*` library crate declares a Candle dependency
+
+### Requirement: Anomaly gate
+
+The example SHALL apply a documented threshold to the Candle anomaly score to decide whether to
+escalate to the causal explanation stage. When the score is below the threshold the example SHALL
+report "healthy / no escalation" and SHALL NOT run the causal root-cause ranking; when the score is
+at or above the threshold the example SHALL escalate.
+
+#### Scenario: Anomalous window escalates
+
+- **WHEN** the anomaly score for an anomalous window is at or above the threshold
+- **THEN** the example escalates to the causal explanation stage
+
+#### Scenario: Normal window does not escalate
+
+- **WHEN** the anomaly score for a normal window is below the threshold
+- **THEN** the example reports a healthy verdict and skips the causal stage
+
+### Requirement: Causal root-cause explanation (explain stage)
+
+When escalation occurs, the example SHALL invoke the existing `deep_causality` causal
+root-cause ranking (the BRCD/SURD path already used by `example_brcd_discovery`) over the anomalous
+data and SHALL produce a ranked list of candidate culprit metrics. The example SHALL reuse the
+existing causal-discovery machinery without modifying the causal-discovery algorithms.
+
+#### Scenario: Escalation produces a ranked culprit list
+
+- **WHEN** the causal stage runs on the anomalous window
+- **THEN** the example outputs a ranked list of candidate root-cause metrics (best first)
+
+### Requirement: Monadic bridge between the two stages
+
+The example SHALL sequence the detect and explain stages through a `PropagatingProcess` so that the
+Candle gate result determines whether the causal stage runs, the carried value advances to the
+root-cause verdict on escalation, and the escalation decision is recorded in the process
+`EffectLog`. A below-threshold (no-escalation) run SHALL short-circuit the chain without producing a
+root-cause verdict.
+
+#### Scenario: Escalation is recorded in the effect log
+
+- **WHEN** an anomalous window drives the chain to escalate
+- **THEN** the `EffectLog` of the resulting process records the escalation
+- **AND** the final carried value is the root-cause verdict
+
+#### Scenario: No-escalation short-circuits the chain
+
+- **WHEN** a normal window keeps the score below threshold
+- **THEN** the chain short-circuits without a root-cause verdict in the carried value
+
+### Requirement: Verdict compared against shipped ground truth
+
+The example SHALL compare the top-ranked culprit from the causal stage against the shipped ground
+truth (`expected.txt` / `notes.txt`) for the chosen case and SHALL print whether the top-ranked
+metric matches (or appears within the top-k of) the ground-truth ranking. The comparison output
+SHALL make the "ML detected, causality explained, ground truth confirmed" narrative explicit.
+
+#### Scenario: Verdict checked against ground truth
+
+- **WHEN** the causal stage yields its ranked culprit list
+- **THEN** the example reads the shipped ground-truth ranking for the case
+- **AND** reports whether the top-ranked culprit matches the ground-truth top cause (or is within the reported top-k)
+
+### Requirement: Runnable, documented example
+
+The example SHALL be runnable via
+`cargo run -p causal_discovery_examples --example example_ml_rca`, SHALL carry module-level (`//!`)
+documentation, and SHALL ship a `README.md` following the standard example template. The example
+SHALL be registered in the `causal_discovery_examples` `Cargo.toml`, the
+`causal_discovery_examples/README.md` table, and the top-level `examples/README.md` table.
+
+#### Scenario: Example runs end to end
+
+- **WHEN** `cargo run -p causal_discovery_examples --example example_ml_rca` is executed
+- **THEN** the example trains the classifier, gates, runs the causal stage on an anomalous window, and prints the ground-truth comparison without error
+
+#### Scenario: Example is discoverable in the docs
+
+- **WHEN** the example READMEs are inspected
+- **THEN** `example_ml_rca` appears in the `causal_discovery_examples` table and the top-level examples overview with its run command

--- a/openspec/changes/archive/2026-06-17-add-ml-rca-example/tasks.md
+++ b/openspec/changes/archive/2026-06-17-add-ml-rca-example/tasks.md
@@ -1,0 +1,45 @@
+## 1. Scaffolding & dependencies
+
+- [x] 1.1 Confirm the exact Candle version to pin (resolve the design Open Question), then add `candle-core` (and `candle-nn` only if the MLP path in D2 is chosen) with default features (CPU-only) to `examples/causal_discovery_examples/Cargo.toml` `[dependencies]`.
+- [x] 1.2 Add the `[[example]]` entry `name = "example_ml_rca"`, `path = "ml/ml_rca/main.rs"` to `examples/causal_discovery_examples/Cargo.toml`.
+- [x] 1.3 Create `examples/causal_discovery_examples/ml/ml_rca/main.rs` with the license header and module-level `//!` docs describing the "ML detects, causality explains" pattern.
+- [x] 1.4 Verify `cargo build -p causal_discovery_examples --example example_ml_rca` compiles (empty `main`), and confirm `candle-*` appears only under this example crate (`cargo tree` / manifest grep) — no `deep_causality_*` library crate gains an ML dependency.
+
+## 2. Dataset loading (detect-stage input)
+
+- [x] 2.1 Load `normal.csv` and `anomalous.csv` for the `carts_cpu_1` case relative to `CARGO_MANIFEST_DIR`; parse the 44 numeric feature columns and capture the header row for index→metric-name mapping.
+- [x] 2.2 Build a labeled feature matrix: every `normal.csv` row labeled `0`, every `anomalous.csv` row labeled `1`; error out with the missing path on an absent/unreadable file (no partial training).
+- [x] 2.3 Fit per-feature mean/standard-deviation on the training split and apply the standardizing transform; create a deterministic train/evaluation split (fixed seed).
+
+## 3. Candle anomaly classifier (detect stage)
+
+- [x] 3.1 Build the model in Candle (logistic regression: one linear layer + sigmoid; per D2), with fixed-seed weight initialization.
+- [x] 3.2 Implement the binary-cross-entropy training loop (forward → loss → optimizer step) over the standardized training matrix.
+- [x] 3.3 Implement `score(window) -> f64` returning an anomaly score in `[0, 1]`.
+- [x] 3.4 Verify on the held-back split that anomalous rows receive a higher mean score than normal rows, and that scores stay within `[0, 1]`.
+
+## 4. Causal explanation stage (reused BRCD pipeline)
+
+- [x] 4.1 Wrap the existing CDL BRCD pipeline (`CdlConfigBuilder::build_brcd_config(...).with_brcd_config(BrcdConfig::continuous(0)).with_cpdag_path(...).build()` → `CdlBuilder::build_brcd(&config).brcd_load_input().brcd_discover().brcd_analyze().finalize()`) behind a single `explain()` call that returns the ranked culprit list.
+- [x] 4.2 Confirm the wrapped pipeline reproduces the reference result (top cause `shipping_latency`, column 42) on `carts_cpu_1`.
+
+## 5. Monadic bridge (PropagatingProcess)
+
+- [x] 5.1 Define the `PropagatingProcess` chain: stage 1 carries the Candle anomaly score; the gate bind escalates at/above threshold and short-circuits to a "healthy" terminal value below it.
+- [x] 5.2 On escalation, bind to the explain stage so the carried value becomes the root-cause verdict, and append the escalation to the `EffectLog`.
+- [x] 5.3 Verify: an anomalous window escalates (verdict in carried value, escalation in `EffectLog`); a normal window short-circuits (no verdict).
+
+## 6. Ground-truth verdict & output
+
+- [x] 6.1 Map the BRCD top-ranked column index to a metric name via the CSV header; read the shipped `expected.txt` / `notes.txt` ground-truth ranking for the case.
+- [x] 6.2 Print the end-to-end narrative: anomaly score → gate decision → ranked culprit → whether the top culprit matches the ground-truth top cause (and whether it is within top-k).
+
+## 7. Docs & registration
+
+- [x] 7.1 Write `examples/causal_discovery_examples/ml/ml_rca/README.md` following the standard example template (overview, what it shows, run command, expected output).
+- [x] 7.2 Add an `example_ml_rca` row to `examples/causal_discovery_examples/README.md` and to the top-level `examples/README.md` causal-discovery table, including the run command.
+
+## 8. Verification
+
+- [x] 8.1 Run `cargo run -p causal_discovery_examples --example example_ml_rca` end to end and confirm it trains, gates, explains, and prints the ground-truth comparison without error.
+- [x] 8.2 Run `cargo fmt` and `cargo clippy -p causal_discovery_examples --all-targets` clean (no warnings); confirm no library crate manifest changed.

--- a/openspec/specs/ml-causal-rca-example/spec.md
+++ b/openspec/specs/ml-causal-rca-example/spec.md
@@ -1,0 +1,125 @@
+# ml-causal-rca-example Specification
+
+## Purpose
+TBD - created by archiving change add-ml-rca-example. Update Purpose after archive.
+## Requirements
+### Requirement: Labeled dataset loading
+
+The example SHALL load the shipped Sock Shop dataset from
+`examples/causal_discovery_examples/data/sock-shop-2/<case>/` and construct a labeled
+feature matrix in which every row of `normal.csv` is labeled `0` and every row of
+`anomalous.csv` is labeled `1`. The 44 numeric metric columns SHALL be used as features and the
+column order SHALL be preserved so that a feature index maps back to a named metric. The example
+MUST NOT add or ship any new data file.
+
+#### Scenario: Both label classes loaded from the shipped CSVs
+
+- **WHEN** the example loads the chosen Sock Shop case
+- **THEN** it reads `normal.csv` and `anomalous.csv` from the existing data directory
+- **AND** produces a feature matrix of 44 columns with a label vector containing both `0` (normal) and `1` (anomalous) rows
+
+#### Scenario: Missing data is reported, not panicked past silently
+
+- **WHEN** a required CSV file is absent or unreadable
+- **THEN** the example terminates with a clear error message naming the missing path
+- **AND** does not proceed to training on partial data
+
+### Requirement: Candle anomaly classifier (detect stage)
+
+The example SHALL train a Candle model (logistic regression or a one-hidden-layer MLP) on the
+labeled feature matrix and SHALL emit a scalar anomaly score in `[0, 1]` for an input window. The
+model, training loop, and inference SHALL use the Candle framework. Candle SHALL be a dependency of
+the `causal_discovery_examples` example crate only; no `deep_causality*` library crate may gain an
+ML dependency.
+
+#### Scenario: Trained classifier separates the two classes
+
+- **WHEN** the classifier is trained on the labeled matrix and then scored on held-back normal and anomalous rows
+- **THEN** anomalous rows receive a higher mean anomaly score than normal rows
+- **AND** the model produces scores within `[0, 1]`
+
+#### Scenario: ML dependency confined to the example
+
+- **WHEN** the workspace is inspected
+- **THEN** `candle-*` appears only under the `causal_discovery_examples` example crate's manifest
+- **AND** no `deep_causality_*` library crate declares a Candle dependency
+
+### Requirement: Anomaly gate
+
+The example SHALL apply a documented threshold to the Candle anomaly score to decide whether to
+escalate to the causal explanation stage. When the score is below the threshold the example SHALL
+report "healthy / no escalation" and SHALL NOT run the causal root-cause ranking; when the score is
+at or above the threshold the example SHALL escalate.
+
+#### Scenario: Anomalous window escalates
+
+- **WHEN** the anomaly score for an anomalous window is at or above the threshold
+- **THEN** the example escalates to the causal explanation stage
+
+#### Scenario: Normal window does not escalate
+
+- **WHEN** the anomaly score for a normal window is below the threshold
+- **THEN** the example reports a healthy verdict and skips the causal stage
+
+### Requirement: Causal root-cause explanation (explain stage)
+
+When escalation occurs, the example SHALL invoke the existing `deep_causality` causal
+root-cause ranking (the BRCD/SURD path already used by `example_brcd_discovery`) over the anomalous
+data and SHALL produce a ranked list of candidate culprit metrics. The example SHALL reuse the
+existing causal-discovery machinery without modifying the causal-discovery algorithms.
+
+#### Scenario: Escalation produces a ranked culprit list
+
+- **WHEN** the causal stage runs on the anomalous window
+- **THEN** the example outputs a ranked list of candidate root-cause metrics (best first)
+
+### Requirement: Monadic bridge between the two stages
+
+The example SHALL sequence the detect and explain stages through a `PropagatingProcess` so that the
+Candle gate result determines whether the causal stage runs, the carried value advances to the
+root-cause verdict on escalation, and the escalation decision is recorded in the process
+`EffectLog`. A below-threshold (no-escalation) run SHALL short-circuit the chain without producing a
+root-cause verdict.
+
+#### Scenario: Escalation is recorded in the effect log
+
+- **WHEN** an anomalous window drives the chain to escalate
+- **THEN** the `EffectLog` of the resulting process records the escalation
+- **AND** the final carried value is the root-cause verdict
+
+#### Scenario: No-escalation short-circuits the chain
+
+- **WHEN** a normal window keeps the score below threshold
+- **THEN** the chain short-circuits without a root-cause verdict in the carried value
+
+### Requirement: Verdict compared against shipped ground truth
+
+The example SHALL compare the top-ranked culprit from the causal stage against the shipped ground
+truth (`expected.txt` / `notes.txt`) for the chosen case and SHALL print whether the top-ranked
+metric matches (or appears within the top-k of) the ground-truth ranking. The comparison output
+SHALL make the "ML detected, causality explained, ground truth confirmed" narrative explicit.
+
+#### Scenario: Verdict checked against ground truth
+
+- **WHEN** the causal stage yields its ranked culprit list
+- **THEN** the example reads the shipped ground-truth ranking for the case
+- **AND** reports whether the top-ranked culprit matches the ground-truth top cause (or is within the reported top-k)
+
+### Requirement: Runnable, documented example
+
+The example SHALL be runnable via
+`cargo run -p causal_discovery_examples --example example_ml_rca`, SHALL carry module-level (`//!`)
+documentation, and SHALL ship a `README.md` following the standard example template. The example
+SHALL be registered in the `causal_discovery_examples` `Cargo.toml`, the
+`causal_discovery_examples/README.md` table, and the top-level `examples/README.md` table.
+
+#### Scenario: Example runs end to end
+
+- **WHEN** `cargo run -p causal_discovery_examples --example example_ml_rca` is executed
+- **THEN** the example trains the classifier, gates, runs the causal stage on an anomalous window, and prints the ground-truth comparison without error
+
+#### Scenario: Example is discoverable in the docs
+
+- **WHEN** the example READMEs are inspected
+- **THEN** `example_ml_rca` appears in the `causal_discovery_examples` table and the top-level examples overview with its run command
+


### PR DESCRIPTION

## Describe your changes

Add a runnable example to causal_discovery_examples showing the "ML detects, causality explains" pattern: a small Candle logistic- regression anomaly detector gates the existing BRCD causal root-cause pipeline through a PropagatingProcess monad, on the shipped, labeled Sock Shop dataset. The detector's score gates escalation; on escalate, BRCD ranks the culprit metric and the top result is checked against the shipped ground truth (expected.txt). A normal window short-circuits to Healthy; an anomalous window escalates and recovers shipping_latency.

## Issue ticket number and link

closes https://github.com/deepcausality-rs/deep_causality/issues/486

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable example that wires a `candle-core` logistic-regression detector to the BRCD root-cause explainer through a `PropagatingProcess` gate. It shows “ML detects, causality explains” on the Sock Shop dataset and checks the top culprit against ground truth.

- **New Features**
  - New example `example_ml_rca`: run with `cargo run -p causal_discovery_examples --example example_ml_rca`.
  - Detector: logistic regression on `candle-core` only (no `candle-nn`); standardizes 44 features, uses BCE with a hand-rolled GD step, deterministic split; outputs an anomaly score.
  - Gate: the score gates BRCD via `PropagatingProcess`; threshold auto-calibrated to the midpoint of held-out normal/anomalous mean scores; below threshold short-circuits to Healthy; at/above threshold escalates and logs decisions.
  - Explain and verify: BRCD ranks the culprit using the shipped CPDAG; the top result is compared to `expected.txt` (e.g., `shipping_latency`).

- **Dependencies**
  - Added `candle-core` (git `main`, CPU-only) to the examples crate only.
  - No `deep_causality_*` library crates depend on Candle.

<sup>Written for commit 1925dc2afcb32b375acda49695bda804a2aa8f11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

