### PR TITLE
test: raise test coverage across 8 crates.

### DIFF
--- a/deep_causality/tests/extensions/causable/causable_accessor_trait_tests.rs
+++ b/deep_causality/tests/extensions/causable/causable_accessor_trait_tests.rs
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Trait-qualified `CausableCollectionAccessor` coverage for the slice / `VecDeque` / `HashMap` /
+//! `BTreeMap` impls.
+//!
+//! The per-collection tests call `.len()` / `.is_empty()` / `.to_vec()` on the concrete type, which
+//! resolve to the *inherent* std methods rather than the trait impls in
+//! `extensions/causable/mod.rs`. These tests invoke the methods through
+//! `CausableCollectionAccessor` explicitly so the trait impls themselves are exercised.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use deep_causality::utils_test::test_utils::*;
+use deep_causality::*;
+
+type Item = BaseCausaloid<NumericalValue, bool>;
+
+fn items() -> Vec<Item> {
+    vec![
+        get_test_causaloid_deterministic(1),
+        get_test_causaloid_deterministic(2),
+        get_test_causaloid_deterministic(3),
+    ]
+}
+
+#[test]
+fn slice_accessor_trait_methods() {
+    let v = items();
+    let slice: &[Item] = &v;
+
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::len(slice),
+        3
+    );
+    assert!(!CausableCollectionAccessor::<NumericalValue, bool, _>::is_empty(slice));
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::to_vec(slice).len(),
+        3
+    );
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::get_all_items(slice).len(),
+        3
+    );
+    assert!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::get_item_by_id(slice, 2).is_some()
+    );
+
+    let empty: &[Item] = &[];
+    assert!(CausableCollectionAccessor::<NumericalValue, bool, _>::is_empty(empty));
+}
+
+#[test]
+fn vec_deque_accessor_trait_methods() {
+    let dq: VecDeque<Item> = VecDeque::from_iter(items());
+
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::len(&dq),
+        3
+    );
+    assert!(!CausableCollectionAccessor::<NumericalValue, bool, _>::is_empty(&dq));
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::to_vec(&dq).len(),
+        3
+    );
+}
+
+#[test]
+fn hash_map_accessor_trait_methods() {
+    let map: HashMap<i8, Item> =
+        HashMap::from_iter(items().into_iter().enumerate().map(|(i, c)| (i as i8, c)));
+
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::len(&map),
+        3
+    );
+    assert!(!CausableCollectionAccessor::<NumericalValue, bool, _>::is_empty(&map));
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::to_vec(&map).len(),
+        3
+    );
+}
+
+#[test]
+fn btree_map_accessor_trait_methods() {
+    let map: BTreeMap<i8, Item> =
+        BTreeMap::from_iter(items().into_iter().enumerate().map(|(i, c)| (i as i8, c)));
+
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::len(&map),
+        3
+    );
+    assert!(!CausableCollectionAccessor::<NumericalValue, bool, _>::is_empty(&map));
+    assert_eq!(
+        CausableCollectionAccessor::<NumericalValue, bool, _>::to_vec(&map).len(),
+        3
+    );
+}

--- a/deep_causality/tests/extensions/causable/mod.rs
+++ b/deep_causality/tests/extensions/causable/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 #[cfg(test)]
+mod causable_accessor_trait_tests;
+#[cfg(test)]
 mod causable_arr_tests;
 #[cfg(test)]
 mod causable_btree_map_tests;

--- a/deep_causality/tests/traits/causable_graph/graph_reasoning/stateful_tests.rs
+++ b/deep_causality/tests/traits/causable_graph/graph_reasoning/stateful_tests.rs
@@ -4,6 +4,11 @@
  */
 
 //! Tests for [`StatefulMonadicCausableGraphReasoning`] over `CausaloidGraph`.
+//!
+//! Coverage note: a few arms guard against a `get_causaloid` / `outbound_edges` failure *inside*
+//! the BFS / path walk, where the index originates from the graph's own frozen adjacency. On a
+//! frozen, validated graph those calls cannot fail, so the arms are defensive and left uncovered
+//! rather than forced through a corrupted graph.
 
 use deep_causality::*;
 use deep_causality_core::CausalityErrorEnum;
@@ -218,4 +223,164 @@ fn evaluate_shortest_path_between_causes_stateful_works() {
 
     assert!(out.error.is_none(), "got {:?}", out.error);
     assert_eq!(out.state.count, 3);
+}
+
+/// A `PropagatingProcess` that already carries an error (drives the short-circuit arms).
+fn build_errored() -> PropagatingProcess<u64, CounterState, ConfigCtx> {
+    PropagatingProcess {
+        value: EffectValue::None,
+        state: CounterState { count: 5 },
+        context: Some(ConfigCtx {}),
+        error: Some(CausalityError::new(CausalityErrorEnum::Custom(
+            "pre-existing".into(),
+        ))),
+        logs: EffectLog::new(),
+    }
+}
+
+/// A frozen graph with two unconnected nodes (no edge), so there is no path between them.
+fn build_two_unconnected() -> CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> {
+    let mut g: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let n0 = Causaloid::new_with_context(0, node_increment, ConfigCtx {}, "n0");
+    let n1 = Causaloid::new_with_context(1, node_increment, ConfigCtx {}, "n1");
+    g.add_root_causaloid(n0).expect("root");
+    g.add_causaloid(n1).expect("n1");
+    g.freeze();
+    g
+}
+
+// --- short-circuit on an incoming error (all three methods) ---
+
+#[test]
+fn stateful_methods_short_circuit_on_incoming_error() {
+    let g = build_three_node_path();
+    let errored = build_errored();
+
+    let single = g.evaluate_single_cause_stateful(0, &errored);
+    assert!(single.error.is_some());
+    assert_eq!(single.state.count, 5, "incoming state is preserved");
+
+    let subgraph = g.evaluate_subgraph_from_cause_stateful(0, &errored);
+    assert!(subgraph.error.is_some());
+
+    let path = g.evaluate_shortest_path_between_causes_stateful(0, 2, &errored);
+    assert!(path.error.is_some());
+}
+
+// --- not-frozen guard (all three methods) ---
+
+#[test]
+fn stateful_methods_require_a_frozen_graph() {
+    let mut g: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let n0 = Causaloid::new_with_context(0, node_increment, ConfigCtx {}, "n0");
+    g.add_root_causaloid(n0).expect("root");
+    // Deliberately NOT frozen.
+    let initial = build_initial();
+
+    for out in [
+        g.evaluate_single_cause_stateful(0, &initial),
+        g.evaluate_subgraph_from_cause_stateful(0, &initial),
+        g.evaluate_shortest_path_between_causes_stateful(0, 0, &initial),
+    ] {
+        let err = out.error.expect("must reject an unfrozen graph");
+        assert!(format!("{err:?}").contains("frozen"));
+    }
+}
+
+// --- index / containment guards ---
+
+#[test]
+fn evaluate_single_cause_stateful_rejects_a_missing_index() {
+    let g = build_three_node_path();
+    let initial = build_initial();
+    let out = g.evaluate_single_cause_stateful(99, &initial);
+    let err = out.error.expect("missing index errors");
+    assert!(format!("{err:?}").contains("not found"));
+}
+
+#[test]
+fn evaluate_subgraph_stateful_rejects_a_start_index_not_in_the_graph() {
+    let g = build_three_node_path();
+    let initial = build_initial();
+    let out = g.evaluate_subgraph_from_cause_stateful(99, &initial);
+    let err = out.error.expect("missing start errors");
+    assert!(format!("{err:?}").contains("does not contain"));
+}
+
+#[test]
+fn evaluate_subgraph_stateful_rejects_a_relay_to_a_missing_target() {
+    // A two-node graph whose root relays to index 2, which does not exist.
+    let mut g: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let n0 = Causaloid::new_with_context(0, node_relay_to_two, ConfigCtx {}, "relayer");
+    let n1 = Causaloid::new_with_context(1, node_increment, ConfigCtx {}, "n1");
+    let i0 = g.add_root_causaloid(n0).expect("root");
+    let i1 = g.add_causaloid(n1).expect("n1");
+    g.add_edge(i0, i1).expect("edge");
+    g.freeze();
+
+    let out = g.evaluate_subgraph_from_cause_stateful(0, &build_initial());
+    let err = out.error.expect("relay to a missing target errors");
+    assert!(format!("{err:?}").contains("RelayTo target"));
+}
+
+// --- shortest-path specific branches ---
+
+#[test]
+fn evaluate_shortest_path_stateful_start_equals_stop_runs_only_that_node() {
+    let g = build_three_node_path();
+    let out = g.evaluate_shortest_path_between_causes_stateful(1, 1, &build_initial());
+    assert!(out.error.is_none(), "got {:?}", out.error);
+    assert_eq!(out.state.count, 1, "exactly one node runs");
+}
+
+#[test]
+fn evaluate_shortest_path_stateful_errors_when_no_path_exists() {
+    let g = build_two_unconnected();
+    let out = g.evaluate_shortest_path_between_causes_stateful(0, 1, &build_initial());
+    assert!(out.error.is_some(), "no path between disconnected nodes");
+}
+
+#[test]
+fn evaluate_shortest_path_stateful_short_circuits_on_a_failing_node() {
+    let mut g: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let n0 = Causaloid::new_with_context(0, node_increment, ConfigCtx {}, "n0");
+    let n1 = Causaloid::new_with_context(1, node_failing, ConfigCtx {}, "n1");
+    let n2 = Causaloid::new_with_context(2, node_increment, ConfigCtx {}, "n2");
+    let i0 = g.add_root_causaloid(n0).expect("root");
+    let i1 = g.add_causaloid(n1).expect("n1");
+    let i2 = g.add_causaloid(n2).expect("n2");
+    g.add_edge(i0, i1).expect("edge");
+    g.add_edge(i1, i2).expect("edge");
+    g.freeze();
+
+    let out = g.evaluate_shortest_path_between_causes_stateful(0, 2, &build_initial());
+    assert!(out.error.is_some(), "a failing node aborts the path walk");
+    assert_eq!(out.state.count, 1, "only node 0 advanced state");
+}
+
+#[test]
+fn evaluate_shortest_path_stateful_returns_on_a_relay() {
+    // Path 0 -> 1 -> 2 where node 1 emits a RelayTo: the walk returns that process verbatim.
+    let mut g: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let n0 = Causaloid::new_with_context(0, node_increment, ConfigCtx {}, "n0");
+    let n1 = Causaloid::new_with_context(1, node_relay_to_two, ConfigCtx {}, "relayer");
+    let n2 = Causaloid::new_with_context(2, node_increment, ConfigCtx {}, "n2");
+    let i0 = g.add_root_causaloid(n0).expect("root");
+    let i1 = g.add_causaloid(n1).expect("n1");
+    let i2 = g.add_causaloid(n2).expect("n2");
+    g.add_edge(i0, i1).expect("edge");
+    g.add_edge(i1, i2).expect("edge");
+    g.freeze();
+
+    let out = g.evaluate_shortest_path_between_causes_stateful(0, 2, &build_initial());
+    assert!(out.error.is_none(), "got {:?}", out.error);
+    assert!(
+        matches!(out.value, EffectValue::RelayTo(2, _)),
+        "the walk returns the relaying node's process"
+    );
 }

--- a/deep_causality/tests/types/causal_types/causaloid/causable_stateful_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid/causable_stateful_tests.rs
@@ -8,6 +8,7 @@
 use deep_causality::*;
 use deep_causality_core::CausalityErrorEnum;
 use deep_causality_haft::LogAddEntry;
+use std::sync::Arc;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 struct CounterState {
@@ -214,6 +215,148 @@ fn evaluate_stateful_passes_through_existing_error_unchanged() {
         !log_text.contains("Causaloid 29: Incoming"),
         "closure must not have run: {log_text}"
     );
+}
+
+/// A stateful closure whose output value is `None` but carries no error (drives the
+/// "causal_fn returned None output" arm).
+fn closure_none_output(
+    _obs: EffectValue<u64>,
+    state: CounterState,
+    ctx: Option<ConfigCtx>,
+) -> PropagatingProcess<u64, CounterState, ConfigCtx> {
+    PropagatingProcess {
+        value: EffectValue::None,
+        state,
+        context: ctx,
+        error: None,
+        logs: EffectLog::new(),
+    }
+}
+
+/// A stateful closure whose output is a structural `RelayTo` (drives the output pass-through arm).
+fn closure_relay_output(
+    _obs: EffectValue<u64>,
+    state: CounterState,
+    ctx: Option<ConfigCtx>,
+) -> PropagatingProcess<u64, CounterState, ConfigCtx> {
+    PropagatingProcess {
+        value: EffectValue::RelayTo(3, Box::new(PropagatingEffect::from_value(1u64))),
+        state,
+        context: ctx,
+        error: None,
+        logs: EffectLog::new(),
+    }
+}
+
+#[test]
+fn evaluate_stateful_errors_on_a_none_input_value() {
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::new_with_context(31, stateful_increment, ConfigCtx { multiplier: 1 }, "n");
+    let incoming = PropagatingProcess {
+        value: EffectValue::None,
+        state: CounterState { count: 3 },
+        context: Some(ConfigCtx { multiplier: 1 }),
+        error: None,
+        logs: EffectLog::new(),
+    };
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    let err = out.error.expect("a None input value errors");
+    assert!(format!("{err:?}").contains("input value is None"));
+    assert_eq!(out.state, CounterState { count: 3 }, "state preserved");
+}
+
+#[test]
+fn evaluate_stateful_passes_a_relay_input_through_unchanged() {
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::new_with_context(32, stateful_increment, ConfigCtx { multiplier: 1 }, "n");
+    let incoming = PropagatingProcess {
+        value: EffectValue::RelayTo(5, Box::new(PropagatingEffect::from_value(1u64))),
+        state: CounterState { count: 4 },
+        context: Some(ConfigCtx { multiplier: 1 }),
+        error: None,
+        logs: EffectLog::new(),
+    };
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    assert!(out.error.is_none(), "structural input flows through");
+    // `cast_effect_value` collapses structural input variants to `None` on the output channel.
+    assert_eq!(out.value, EffectValue::None);
+    assert_eq!(out.state, CounterState { count: 4 }, "state untouched");
+}
+
+#[test]
+fn evaluate_stateful_errors_when_the_closure_returns_a_none_output() {
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::new_with_context(33, closure_none_output, ConfigCtx { multiplier: 1 }, "n");
+    let incoming = build_incoming(
+        CounterState { count: 0 },
+        Some(ConfigCtx { multiplier: 1 }),
+        5,
+    );
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    let err = out.error.expect("a None output errors");
+    assert!(format!("{err:?}").contains("returned None output"));
+}
+
+#[test]
+fn evaluate_stateful_passes_a_relay_output_through_unchanged() {
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::new_with_context(34, closure_relay_output, ConfigCtx { multiplier: 1 }, "n");
+    let incoming = build_incoming(
+        CounterState { count: 0 },
+        Some(ConfigCtx { multiplier: 1 }),
+        5,
+    );
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    assert!(out.error.is_none());
+    assert!(
+        matches!(out.value, EffectValue::RelayTo(3, _)),
+        "a structural output is passed through without output logging"
+    );
+}
+
+#[test]
+fn evaluate_stateful_rejects_a_collection_causaloid() {
+    let child: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::new(40, stateless_passthrough, "child");
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> = Causaloid::from_causal_collection(
+        41,
+        Arc::new(vec![child]),
+        "collection",
+        AggregateLogic::All,
+        0.0,
+    );
+    let incoming = build_incoming(
+        CounterState { count: 0 },
+        Some(ConfigCtx { multiplier: 1 }),
+        5,
+    );
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    let err = out
+        .error
+        .expect("collection stateful eval is unsupported here");
+    assert!(format!("{err:?}").contains("collection"));
+}
+
+#[test]
+fn evaluate_stateful_rejects_a_graph_causaloid() {
+    let inner: CausaloidGraph<Causaloid<u64, u64, CounterState, ConfigCtx>> =
+        CausaloidGraph::new(0u64);
+    let causaloid: Causaloid<u64, u64, CounterState, ConfigCtx> =
+        Causaloid::from_causal_graph(42, "graph", Arc::new(inner));
+    let incoming = build_incoming(
+        CounterState { count: 0 },
+        Some(ConfigCtx { multiplier: 1 }),
+        5,
+    );
+
+    let out = causaloid.evaluate_stateful(&incoming);
+    let err = out.error.expect("graph stateful eval is unsupported here");
+    assert!(format!("{err:?}").contains("graph"));
 }
 
 #[test]

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_shortest_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_shortest_tests.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use deep_causality::utils_test::test_utils_graph;
+use deep_causality::utils_test::{test_utils, test_utils_graph};
 use deep_causality::*;
 
 #[test]
@@ -32,6 +32,57 @@ fn test_shortest_path_on_single_node() {
     assert!(res.is_ok());
 
     assert_eq!(res.value, EffectValue::Value(1.0));
+}
+
+#[test]
+fn test_shortest_path_short_circuits_on_a_failing_node() {
+    // 0 -> 1(error) -> 2: walking the path aborts at the failing node.
+    let mut g = CausaloidGraph::new(0);
+    let i0 = g
+        .add_root_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("root");
+    let i1 = g
+        .add_causaloid(test_utils::get_test_error_causaloid())
+        .expect("err");
+    let i2 = g
+        .add_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("n2");
+    g.add_edge(i0, i1).expect("edge");
+    g.add_edge(i1, i2).expect("edge");
+    g.freeze();
+
+    let res = g.evaluate_shortest_path_between_causes(i0, i2, &PropagatingEffect::from_value(true));
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("Test error"));
+}
+
+fn relay_to_9(_obs: bool) -> PropagatingEffect<bool> {
+    PropagatingEffect::from_effect_value(EffectValue::RelayTo(
+        9,
+        Box::new(PropagatingEffect::from_value(true)),
+    ))
+}
+
+#[test]
+fn test_shortest_path_returns_on_a_relay() {
+    // 0 -> 1(relay) -> 2: the walk returns the relaying node's effect verbatim.
+    let mut g = CausaloidGraph::new(0);
+    let i0 = g
+        .add_root_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("root");
+    let i1 = g
+        .add_causaloid(Causaloid::new(1, relay_to_9, "relayer"))
+        .expect("relay");
+    let i2 = g
+        .add_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("n2");
+    g.add_edge(i0, i1).expect("edge");
+    g.add_edge(i1, i2).expect("edge");
+    g.freeze();
+
+    let res = g.evaluate_shortest_path_between_causes(i0, i2, &PropagatingEffect::from_value(true));
+    assert!(res.is_ok(), "got {:?}", res.error);
+    assert!(matches!(res.value, EffectValue::RelayTo(9, _)));
 }
 
 #[test]

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_single_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_single_tests.rs
@@ -47,6 +47,19 @@ fn test_evaluate_single_causaloid_not_found_error() {
 }
 
 #[test]
+fn test_evaluate_single_cause_requires_a_frozen_graph() {
+    let mut g = CausaloidGraph::new(0);
+    let causaloid = test_utils::get_test_causaloid_deterministic_input_output();
+    let index = g.add_causaloid(causaloid).expect("Failed to add causaloid");
+    // Deliberately not frozen.
+
+    let effect = PropagatingEffect::from_value(true);
+    let res = g.evaluate_single_cause(index, &effect);
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("not frozen"));
+}
+
+#[test]
 fn test_evaluate_single_eval_error() {
     // Case 2: The causaloid itself returns an error during evaluation.
     let mut g = CausaloidGraph::new(0);

--- a/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_sub_tests.rs
+++ b/deep_causality/tests/types/causal_types/causaloid_graph/causality_graph_reasoning_sub_tests.rs
@@ -3,8 +3,101 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+//! Coverage note: the `MonadicCausableGraphReasoning` BFS / path walks carry defensive arms that
+//! re-fetch a causaloid by an index taken from the graph's own frozen adjacency, or handle an
+//! `outbound_edges` failure. On a frozen, validated graph those cannot fail, so they are left
+//! uncovered rather than forced through a corrupted graph (the same rationale as the stateful trait).
+
 use deep_causality::utils_test::test_utils;
 use deep_causality::*;
+
+fn relay_to_2(_obs: bool) -> PropagatingEffect<bool> {
+    PropagatingEffect::from_effect_value(EffectValue::RelayTo(
+        2,
+        Box::new(PropagatingEffect::from_value(true)),
+    ))
+}
+
+fn relay_to_5(_obs: bool) -> PropagatingEffect<bool> {
+    PropagatingEffect::from_effect_value(EffectValue::RelayTo(
+        5,
+        Box::new(PropagatingEffect::from_value(true)),
+    ))
+}
+
+#[test]
+fn test_evaluate_subgraph_requires_a_frozen_graph() {
+    let mut g = CausaloidGraph::new(0);
+    let c = test_utils::get_test_causaloid_deterministic_input_output();
+    let idx = g.add_root_causaloid(c).expect("root");
+    // Not frozen.
+    let res = g.evaluate_subgraph_from_cause(idx, &PropagatingEffect::from_value(true));
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("not frozen"));
+}
+
+#[test]
+fn test_evaluate_subgraph_rejects_a_missing_start_index() {
+    let mut g: BaseCausalGraph = CausaloidGraph::new(0);
+    g.freeze();
+    let res = g.evaluate_subgraph_from_cause(99, &PropagatingEffect::from_value(true));
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("does not contain"));
+}
+
+#[test]
+fn test_evaluate_subgraph_short_circuits_on_a_node_error() {
+    let mut g = CausaloidGraph::new(0);
+    let root = test_utils::get_test_causaloid_deterministic_input_output();
+    let i0 = g.add_root_causaloid(root).expect("root");
+    let err_node = test_utils::get_test_error_causaloid();
+    let i1 = g.add_causaloid(err_node).expect("err");
+    g.add_edge(i0, i1).expect("edge");
+    g.freeze();
+
+    let res = g.evaluate_subgraph_from_cause(i0, &PropagatingEffect::from_value(true));
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("Test error"));
+}
+
+#[test]
+fn test_evaluate_subgraph_follows_a_relay_to_a_valid_target() {
+    // 0 (relays to 2) -> 1 ; 2 stands alone. The relay jumps straight to node 2.
+    let mut g = CausaloidGraph::new(0);
+    let i0 = g
+        .add_root_causaloid(Causaloid::new(0, relay_to_2, "relayer"))
+        .expect("root");
+    let i1 = g
+        .add_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("n1");
+    let i2 = g
+        .add_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("n2");
+    g.add_edge(i0, i1).expect("edge");
+    g.freeze();
+
+    let res = g.evaluate_subgraph_from_cause(i0, &PropagatingEffect::from_value(true));
+    assert!(res.is_ok(), "got {:?}", res.error);
+    let _ = i2;
+}
+
+#[test]
+fn test_evaluate_subgraph_rejects_a_relay_to_a_missing_target() {
+    // The root relays to index 5, which the graph does not contain.
+    let mut g = CausaloidGraph::new(0);
+    let i0 = g
+        .add_root_causaloid(Causaloid::new(0, relay_to_5, "relayer"))
+        .expect("root");
+    let i1 = g
+        .add_causaloid(test_utils::get_test_causaloid_deterministic_input_output())
+        .expect("n1");
+    g.add_edge(i0, i1).expect("edge");
+    g.freeze();
+
+    let res = g.evaluate_subgraph_from_cause(i0, &PropagatingEffect::from_value(true));
+    assert!(res.is_err());
+    assert!(res.error.unwrap().to_string().contains("RelayTo target"));
+}
 
 #[test]
 fn test_evaluate_subgraph_from_cause() {

--- a/deep_causality/tests/types/context_node_types/space_time/lorentzian/adjustable_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space_time/lorentzian/adjustable_tests.rs
@@ -24,6 +24,48 @@ fn test_update_success() {
 }
 
 #[test]
+fn test_update_and_adjust_over_1d_2d_4d_grids() {
+    // The 3D arm is covered above; exercise the remaining 1D / 2D / 4D index arms of both
+    // `update` and `adjust`.
+
+    // 1D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array1D);
+    grid.set(PointIndex::new1d(0), 10.0);
+    grid.set(PointIndex::new1d(1), 20.0);
+    grid.set(PointIndex::new1d(2), 30.0);
+    grid.set(PointIndex::new1d(3), 40.0);
+    let mut s = LorentzianSpacetime::new(1, 1.0, 2.0, 3.0, 4.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.x(), 10.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.x(), 20.0);
+
+    // 2D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array2D);
+    grid.set(PointIndex::new2d(0, 0), 1.0);
+    grid.set(PointIndex::new2d(1, 0), 2.0);
+    grid.set(PointIndex::new2d(2, 0), 3.0);
+    grid.set(PointIndex::new2d(3, 0), 4.0);
+    let mut s = LorentzianSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.y(), 2.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.y(), 4.0);
+
+    // 4D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array4D);
+    grid.set(PointIndex::new4d(0, 0, 0, 0), 5.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 1), 6.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 2), 7.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 3), 8.0);
+    let mut s = LorentzianSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.z(), 7.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.z(), 14.0);
+}
+
+#[test]
 fn test_update_nan_should_fail() {
     let mut s = LorentzianSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
 

--- a/deep_causality/tests/types/context_node_types/space_time/minkowski/adjustable_tests.rs
+++ b/deep_causality/tests/types/context_node_types/space_time/minkowski/adjustable_tests.rs
@@ -25,6 +25,48 @@ fn test_update_success() {
 }
 
 #[test]
+fn test_update_and_adjust_over_1d_2d_4d_grids() {
+    // The 3D arm is covered above; exercise the remaining 1D / 2D / 4D index arms of both
+    // `update` and `adjust`.
+
+    // 1D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array1D);
+    grid.set(PointIndex::new1d(0), 10.0);
+    grid.set(PointIndex::new1d(1), 20.0);
+    grid.set(PointIndex::new1d(2), 30.0);
+    grid.set(PointIndex::new1d(3), 40.0);
+    let mut s = MinkowskiSpacetime::new(1, 1.0, 2.0, 3.0, 4.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.x(), 10.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.x(), 20.0);
+
+    // 2D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array2D);
+    grid.set(PointIndex::new2d(0, 0), 1.0);
+    grid.set(PointIndex::new2d(1, 0), 2.0);
+    grid.set(PointIndex::new2d(2, 0), 3.0);
+    grid.set(PointIndex::new2d(3, 0), 4.0);
+    let mut s = MinkowskiSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.y(), 2.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.y(), 4.0);
+
+    // 4D
+    let grid: ArrayGrid<f64, 4, 4, 4, 4> = ArrayGrid::new(ArrayType::Array4D);
+    grid.set(PointIndex::new4d(0, 0, 0, 0), 5.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 1), 6.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 2), 7.0);
+    grid.set(PointIndex::new4d(0, 0, 0, 3), 8.0);
+    let mut s = MinkowskiSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
+    assert!(s.update(&grid).is_ok());
+    assert_eq!(s.z(), 7.0);
+    assert!(s.adjust(&grid).is_ok());
+    assert_eq!(s.z(), 14.0);
+}
+
+#[test]
 fn test_update_with_nan_should_fail() {
     let mut s = MinkowskiSpacetime::new(1, 0.0, 0.0, 0.0, 0.0, TimeScale::Second);
 

--- a/deep_causality_cfd/tests/solvers/dec/uncertain_inflow_tests.rs
+++ b/deep_causality_cfd/tests/solvers/dec/uncertain_inflow_tests.rs
@@ -297,6 +297,35 @@ fn inflow_step_rejects_an_invalid_wall_reconfiguration() {
 }
 
 #[test]
+fn inflow_step_on_a_consumed_solver_short_circuits() {
+    // A failed wall reconfiguration consumes the solver, leaving the returned state with
+    // `solver: None`. Re-binding that state must short-circuit on the "solver consumed by a prior
+    // failure" guard rather than panic.
+    let m = periodic_manifold();
+    let state = InflowMarchState::new(base_solver(&m), rest_seed(&m), U_IN);
+    let zone = UncertainInflowZone::new(0, true, 1, U_IN) // wall axis 0 is periodic → reconfig fails
+        .with_presence_gate(0.5, 0.9, 0.1, 64)
+        .with_collapse_samples(8);
+    let context = InflowContext::new(zone, vec![MaybeUncertain::<f64>::from_value(U_IN); 2]);
+    let failed = inflow_march_step(EffectValue::Value(U_IN), state, Some(context.clone()));
+    assert!(
+        failed.error().is_some(),
+        "the reconfiguration must fail first"
+    );
+
+    // Re-bind the errored state (its solver was consumed).
+    let again = inflow_march_step(EffectValue::Value(U_IN), failed.state, Some(context));
+    let err = again
+        .error()
+        .clone()
+        .expect("the consumed-solver guard must fire");
+    assert!(
+        format!("{err:?}").contains("consumed"),
+        "expected the consumed-solver guard: {err:?}"
+    );
+}
+
+#[test]
 fn memory_cost_is_confined_to_the_tagged_patch() {
     let m = wall_manifold();
     let n0 = m.complex().num_cells(0);

--- a/deep_causality_discovery/tests/types/cdl/surd_data_tests.rs
+++ b/deep_causality_discovery/tests/types/cdl/surd_data_tests.rs
@@ -4,11 +4,26 @@
  */
 
 use deep_causality_discovery::{
-    BinningStrategy, CdlBuilder, CdlConfigBuilder, CdlError, ColumnSelector, DataDiscretizer,
-    MaxOrder, OptionNoneDataCleaner, PreprocessConfig, SurdAnalyzeConfig,
+    BinningStrategy, CDL, CdlBuilder, CdlConfigBuilder, CdlError, ColumnSelector, DataCleaner,
+    DataCleaningError, DataDiscretizer, MaxOrder, OptionNoneDataCleaner, PreprocessConfig,
+    SurdAnalyzeConfig, SurdData,
 };
+use deep_causality_tensor::{CausalTensor, CausalTensorError};
 use std::io::Write;
 use tempfile::NamedTempFile;
+
+/// A `DataCleaner` that always fails, to drive the `clean_data` error branch.
+struct FailingCleaner;
+impl DataCleaner<f64> for FailingCleaner {
+    fn process(
+        &self,
+        _tensor: CausalTensor<f64>,
+    ) -> Result<CausalTensor<Option<f64>>, DataCleaningError> {
+        Err(DataCleaningError::TensorError(
+            CausalTensorError::DimensionMismatch,
+        ))
+    }
+}
 
 fn write_csv(content: &str) -> NamedTempFile {
     let mut f = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
@@ -83,4 +98,49 @@ fn test_preprocess_invalid_column_errors() {
         .surd_load_input()
         .preprocess(DataDiscretizer, &pp);
     assert!(matches!(effect.inner, Err(CdlError::PreprocessError(_))));
+}
+
+#[test]
+fn test_clean_data_surfaces_a_cleaner_error() {
+    let file = write_csv(DATA);
+    let cfg = config(file.path().to_str().unwrap());
+    let effect = CdlBuilder::build_surd(&cfg)
+        .surd_load_input()
+        .clean_data(FailingCleaner);
+    assert!(
+        effect.inner.is_err(),
+        "a failing cleaner must surface its error"
+    );
+}
+
+#[test]
+fn test_filter_cohort_rejects_a_non_2d_tensor() {
+    // `filter_cohort` is only defined for a 2-D matrix; a rank-1 tensor must error rather than
+    // panic on the `shape[1]` index.
+    let file = write_csv(DATA);
+    let cfg = config(file.path().to_str().unwrap());
+    let tensor = CausalTensor::new(vec![1.0_f64, 2.0, 3.0], vec![3]).unwrap(); // rank 1
+    let cdl = CDL {
+        state: SurdData {
+            tensor,
+            records_count: 3,
+            config: cfg,
+        },
+    };
+    let effect = cdl.filter_cohort(|_row| true);
+    assert!(matches!(
+        effect.inner,
+        Err(CdlError::CausalDiscoveryError(_))
+    ));
+}
+
+#[test]
+fn test_filter_cohort_keeping_no_rows_yields_an_empty_dataset() {
+    let file = write_csv(DATA);
+    let cfg = config(file.path().to_str().unwrap());
+    let effect = CdlBuilder::build_surd(&cfg)
+        .surd_load_input()
+        .filter_cohort(|_row| false); // keep nothing
+    assert!(effect.inner.is_ok());
+    assert_eq!(effect.inner.unwrap().state.records_count, 0);
 }

--- a/deep_causality_multivector/tests/extensions/hkt_multifield/hkt_multifield_tests.rs
+++ b/deep_causality_multivector/tests/extensions/hkt_multifield/hkt_multifield_tests.rs
@@ -132,13 +132,20 @@ fn test_monad_bind() {
 
 #[test]
 fn test_monad_bind_empty() {
-    // How to create an empty field? CausalMultiField typically isn't empty in current constructors.
-    // Maybe with CausalTensor::new(vec![], shape)?
-    // But constructors usually enforce valid shapes.
-    // If we assume standard usage, we always have elements.
-    // The bind implementation handles empty case `if let Some(&first_val) = data_vec.first()`.
-    // Validating "empty" path might be hard if we can't construct an empty one.
-    // I'll stick to valid non-empty functionality.
+    // A zero-extent spatial shape yields a field with no coefficients, driving the empty-field
+    // branch of `bind` (which returns a freshly-built zero field rather than applying `f`).
+    let metric = Metric::from_signature(2, 0, 0);
+    let dx = [0.1f32, 0.1, 0.1];
+    let empty = CausalMultiField::<f32>::zeros([0, 1, 1], metric, dx);
+    assert!(empty.data().as_slice().is_empty(), "fixture must be empty");
+
+    let result = CausalMultiFieldWitness::<f32>::bind(empty, |x| {
+        CausalMultiFieldWitness::<f32>::pure(x * 3.0)
+    });
+
+    // The empty branch reconstructs a zero field preserving the source shape; `f` never runs.
+    assert_eq!(result.shape(), &[0, 1, 1]);
+    assert!(result.data().as_slice().is_empty());
 }
 
 #[test]

--- a/deep_causality_physics/tests/kernels/em/fields_tests.rs
+++ b/deep_causality_physics/tests/kernels/em/fields_tests.rs
@@ -398,6 +398,67 @@ fn test_lagrangian_density_kernel_nan_b_error() {
     assert!(lagrangian_density_kernel(&e, &b).is_err());
 }
 
+// =============================================================================
+// Overflow guards: finite inputs whose intermediate products overflow to ±inf,
+// exercising the post-computation non-finite checks.
+// =============================================================================
+
+#[test]
+fn test_poynting_vector_kernel_overflow_result_is_rejected() {
+    // Finite but huge spatial components: the cross product overflows to ±inf, tripping the
+    // non-finite-result guard (distinct from the non-finite-input guard).
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, f64::MAX, f64::MAX, f64::MAX, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, f64::MAX, f64::MAX, f64::MAX, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(poynting_vector_kernel(&e, &b).is_err());
+}
+
+#[test]
+fn test_proca_equation_kernel_m_squared_overflow_is_rejected() {
+    // `mass` is finite, but `mass * mass` overflows to inf, tripping the m^2 guard.
+    let field_manifold = create_simple_manifold();
+    let potential_manifold = create_simple_manifold();
+    let result = proca_equation_kernel(&field_manifold, &potential_manifold, f64::MAX);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_energy_density_kernel_overflow_squared_magnitude_is_rejected() {
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, f64::MAX, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(energy_density_kernel(&e, &b).is_err());
+}
+
+#[test]
+fn test_lagrangian_density_kernel_overflow_squared_magnitude_is_rejected() {
+    let e = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, f64::MAX, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    let b = CausalMultiVector::<f64>::new(
+        vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        Metric::Euclidean(3),
+    )
+    .unwrap();
+    assert!(lagrangian_density_kernel(&e, &b).is_err());
+}
+
 #[test]
 fn test_lagrangian_density_kernel_dimension_mismatch() {
     let e = CausalMultiVector::<f64>::new(

--- a/deep_causality_sparse/tests/solver/cg_tests.rs
+++ b/deep_causality_sparse/tests/solver/cg_tests.rs
@@ -292,3 +292,114 @@ fn warm_started_cg_surfaces_budget_exhaustion() {
     let err = cg_solve_preconditioned_from(&apply, &diag, &b, &x0, 1e-15, 1).unwrap_err();
     assert_eq!(err.iterations, 1);
 }
+
+// =============================================================================
+// Operator-failure and algebraic-breakdown guards across the three CG variants.
+// =============================================================================
+
+use std::cell::Cell;
+
+#[test]
+fn cg_solve_rejects_a_wrong_length_operator() {
+    // The operator returns a vector of the wrong length: caught on the first application.
+    let b = vec![1.0_f64, 2.0];
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0; 5] };
+    let err = cg_solve(apply, &b, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0);
+}
+
+#[test]
+fn cg_solve_breaks_down_on_a_singular_operator() {
+    // A·p = 0 for a non-zero search direction makes pᵀAp = 0 — the algebraic-breakdown guard.
+    let b = vec![1.0_f64, 1.0];
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0, 0.0] };
+    let err = cg_solve(apply, &b, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0, "breakdown fires on the first iteration");
+}
+
+#[test]
+fn preconditioned_cg_returns_zero_for_zero_rhs() {
+    use deep_causality_sparse::cg_solve_preconditioned;
+    // b = 0 takes the `b_norm == 0` absolute-tolerance branch and converges immediately.
+    let apply = |v: &[f64]| v.to_vec();
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![0.0_f64, 0.0];
+    let x = cg_solve_preconditioned(apply, &diag, &b, 1e-12, 50).unwrap();
+    assert_eq!(x, vec![0.0, 0.0]);
+}
+
+#[test]
+fn preconditioned_cg_rejects_a_wrong_length_operator() {
+    use deep_causality_sparse::cg_solve_preconditioned;
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![1.0_f64, 2.0];
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0; 7] };
+    let err = cg_solve_preconditioned(apply, &diag, &b, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0);
+}
+
+#[test]
+fn preconditioned_cg_breaks_down_on_a_singular_operator() {
+    use deep_causality_sparse::cg_solve_preconditioned;
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![1.0_f64, 1.0];
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0, 0.0] };
+    let err = cg_solve_preconditioned(apply, &diag, &b, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0);
+}
+
+#[test]
+fn warm_started_cg_returns_zero_for_zero_rhs() {
+    use deep_causality_sparse::cg_solve_preconditioned_from;
+    // b = 0, x0 = 0: r₀ = 0 converges immediately through the `b_norm == 0` branch.
+    let apply = |v: &[f64]| v.to_vec();
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![0.0_f64, 0.0];
+    let x0 = vec![0.0_f64, 0.0];
+    let x = cg_solve_preconditioned_from(apply, &diag, &b, &x0, 1e-12, 50).unwrap();
+    assert_eq!(x, vec![0.0, 0.0]);
+}
+
+#[test]
+fn warm_started_cg_rejects_a_wrong_length_operator_on_the_initial_residual() {
+    use deep_causality_sparse::cg_solve_preconditioned_from;
+    // The very first application (A·x₀) returns the wrong length.
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![1.0_f64, 2.0];
+    let x0 = vec![0.0_f64, 0.0];
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0; 9] };
+    let err = cg_solve_preconditioned_from(apply, &diag, &b, &x0, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0);
+}
+
+#[test]
+fn warm_started_cg_rejects_a_wrong_length_operator_inside_the_loop() {
+    use deep_causality_sparse::cg_solve_preconditioned_from;
+    // Correct length for the initial residual (A·x₀), wrong length once the loop applies A·p.
+    let calls = Cell::new(0usize);
+    let apply = |v: &[f64]| -> Vec<f64> {
+        let n = calls.get();
+        calls.set(n + 1);
+        if n == 0 { v.to_vec() } else { vec![0.0; 9] }
+    };
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![1.0_f64, 2.0];
+    let x0 = vec![0.0_f64, 0.0];
+    let err = cg_solve_preconditioned_from(apply, &diag, &b, &x0, 1e-12, 50).unwrap_err();
+    assert_eq!(
+        err.iterations, 0,
+        "the loop's operator application is rejected"
+    );
+}
+
+#[test]
+fn warm_started_cg_breaks_down_on_a_singular_operator() {
+    use deep_causality_sparse::cg_solve_preconditioned_from;
+    // A·x₀ = 0 (x₀ = 0) gives a non-zero residual, then A·p = 0 trips the breakdown guard.
+    let apply = |_v: &[f64]| -> Vec<f64> { vec![0.0, 0.0] };
+    let diag = vec![1.0_f64, 1.0];
+    let b = vec![1.0_f64, 1.0];
+    let x0 = vec![0.0_f64, 0.0];
+    let err = cg_solve_preconditioned_from(apply, &diag, &b, &x0, 1e-12, 50).unwrap_err();
+    assert_eq!(err.iterations, 0);
+}

--- a/deep_causality_topology/tests/types/manifold/leray_weighted_tests.rs
+++ b/deep_causality_topology/tests/types/manifold/leray_weighted_tests.rs
@@ -18,7 +18,7 @@ use deep_causality_tensor::CausalTensor;
 use deep_causality_topology::{
     ChainComplex, CubicalReggeGeometry, CutCell, CutCellRegistry, CutConstraintKind,
     CutFaceConstraint, CutFaceFragment, HodgeDecomposeOptions, LatticeCell, LatticeComplex,
-    Manifold, SourceGeometry,
+    Manifold, SourceGeometry, TopologyErrorEnum,
 };
 
 fn manifold_2d(
@@ -403,4 +403,128 @@ fn tangential_only_ablation_still_enforces_tangential_no_slip() {
         div < 1e-9,
         "interior divergence {div:e} above solve exactness"
     );
+}
+
+// -- open-weighted validation guards -------------------------------------------------------------
+//
+// Coverage note: the deeper interior branches of `leray_project_open_weighted` (the constrained-gauge
+// RHS path with no reference, the every-edge-constrained abort, and the dual-residual diagnostics)
+// are exercised by the broader CFD verification suite that drives full cut-cell solves; the cheap,
+// deterministic input-validation guards are pinned directly here.
+
+/// One non-empty weighted row over a single cut cell at `base`, plus the manifold and edge count.
+fn open_weighted_fixture() -> (
+    Manifold<LatticeComplex<2, f64>, f64>,
+    Vec<CutFaceConstraint<f64>>,
+    usize,
+) {
+    let m = manifold_2d([8, 8], [false, false], CubicalReggeGeometry::unit());
+    let n1 = m.complex().num_cells(1);
+    let reg = single_cut_cell(m.complex(), [4, 4]);
+    let rows = reg.cut_face_constraints(m.complex());
+    assert!(
+        !rows.is_empty(),
+        "fixture must produce at least one weighted row"
+    );
+    (m, rows, n1)
+}
+
+#[test]
+fn open_weighted_rejects_a_field_of_the_wrong_length() {
+    let (m, rows, n1) = open_weighted_fixture();
+    let field = random_field(n1 - 1, 5); // one short
+    let err = m
+        .leray_project_open_weighted_opts(
+            &field,
+            &[],
+            &[],
+            &[0usize],
+            &rows,
+            &HodgeDecomposeOptions::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err.0, TopologyErrorEnum::DimensionMismatch(_)));
+}
+
+#[test]
+fn open_weighted_requires_a_metric() {
+    // A metric-less manifold cannot build the Hodge star the weighted operator needs.
+    let lattice = LatticeComplex::<2, f64>::new([8, 8], [false, false]);
+    let n1 = lattice.num_cells(1);
+    let total: usize = (0..=2).map(|k| lattice.num_cells(k)).sum();
+    let data = CausalTensor::new(vec![0.0; total], vec![total]).unwrap();
+    let m_metric = manifold_2d([8, 8], [false, false], CubicalReggeGeometry::unit());
+    let rows = single_cut_cell(m_metric.complex(), [4, 4]).cut_face_constraints(m_metric.complex());
+    let m: Manifold<LatticeComplex<2, f64>, f64> = Manifold::from_cubical(lattice, data, 0);
+
+    let field = random_field(n1, 5);
+    let err = m
+        .leray_project_open_weighted_opts(
+            &field,
+            &[],
+            &[],
+            &[0usize],
+            &rows,
+            &HodgeDecomposeOptions::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err.0, TopologyErrorEnum::InvalidInput(_)));
+}
+
+#[test]
+fn open_weighted_requires_a_reference_for_a_prescribed_inflow() {
+    let (m, rows, n1) = open_weighted_fixture();
+    let field = random_field(n1, 5);
+    // A prescribed (inflow) edge with no reference (outflow) face to balance the net flux.
+    let err = m
+        .leray_project_open_weighted_opts(
+            &field,
+            &[],
+            &[0usize],
+            &[],
+            &rows,
+            &HodgeDecomposeOptions::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err.0, TopologyErrorEnum::InvalidInput(_)));
+}
+
+#[test]
+fn open_weighted_rejects_a_fixed_edge_index_out_of_range() {
+    let (m, rows, n1) = open_weighted_fixture();
+    let field = random_field(n1, 5);
+    let err = m
+        .leray_project_open_weighted_opts(
+            &field,
+            &[n1 + 7], // zeroed edge out of range
+            &[],
+            &[0usize],
+            &rows,
+            &HodgeDecomposeOptions::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err.0, TopologyErrorEnum::InvalidInput(_)));
+}
+
+#[test]
+fn open_weighted_rejects_a_reference_vertex_out_of_range() {
+    let (m, rows, n1) = open_weighted_fixture();
+    let n0 = m.complex().num_cells(0);
+    let field = random_field(n1, 5);
+    let err = m
+        .leray_project_open_weighted_opts(
+            &field,
+            &[],
+            &[],
+            &[n0 + 3], // reference vertex out of range
+            &rows,
+            &HodgeDecomposeOptions::default(),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(err.0, TopologyErrorEnum::InvalidInput(_)));
 }

--- a/deep_causality_uncertain/tests/BUILD.bazel
+++ b/deep_causality_uncertain/tests/BUILD.bazel
@@ -138,6 +138,8 @@ rust_test_suite(
         # Crate to test
         "//deep_causality_uncertain",
         "//deep_causality_ast",
+        # Internal dependencies
+        "//deep_causality_num",
         # External dependencies
         "//thirdparty/crates:rusty-fork",
     ],
@@ -172,6 +174,8 @@ rust_test_suite(
     deps = [
         # Crate to test
         "//deep_causality_uncertain",
+        # Internal dependencies
+        "//deep_causality_num",
         # External dependencies
         "//thirdparty/crates:rusty-fork",
     ],

--- a/deep_causality_uncertain/tests/types/sampler/qmc_sampler_tests.rs
+++ b/deep_causality_uncertain/tests/types/sampler/qmc_sampler_tests.rs
@@ -4,9 +4,27 @@
  */
 
 //! Tests for the Quasi-Monte-Carlo sampler and its opt-in batch estimators.
+//!
+//! Coverage note: `evaluate_node` carries defensive arms that no public `Uncertain` builder can
+//! reach, so they are intentionally left uncovered rather than tested through contrived inputs:
+//!   * the `PureOp` / `FmapOp` / `ApplyOp` / `BindOp` node variants — no `Uncertain` constructor
+//!     produces them (only `from_root_node` could, and `BindOp` rejection is unit-tested in-crate);
+//!   * the `UnsupportedTypeError` arms of every op (arithmetic / comparison / logical / function /
+//!     negation / conditional) — the typed builders guarantee matching `SampledValue` variants, so
+//!     a mismatch is unconstructible;
+//!   * the `DoubleFloat` arms of `f64`-only ops (`ComparisonOp`, `FunctionOpF64`, `FunctionOpBool`)
+//!     — `greater_than` / `map` / `map_to_bool` exist only on `Uncertain<f64>`, so their operand is
+//!     never `Float106`;
+//!   * the `NOR` and wrong-arity `LogicalOp` arms — the `&` / `|` / `!` / `^` operators emit only
+//!     `And` / `Or` / `Not` / `XOR` at the correct arity.
 
+use deep_causality_num::Float106;
 use deep_causality_uncertain::{QmcSampler, Uncertain, UncertainError, seed_sampler};
 use rusty_fork::rusty_fork_test;
+
+fn f106(x: f64) -> Float106 {
+    Float106::from_f64(x)
+}
 
 // =============================================================================
 // Dimension assignment and static-structure validation (no global state)
@@ -59,6 +77,68 @@ fn test_accept_conditional_sharing_leaves() {
     // Both branches reference the same leaf node → identical distribution sets → accepted.
     let cond = Uncertain::<bool>::bernoulli(0.5);
     let shared = Uncertain::normal(0.0, 1.0);
+    let u = Uncertain::conditional(cond, shared.clone(), shared);
+    assert!(QmcSampler::new(&u, None).is_ok());
+}
+
+#[test]
+fn test_over_dimension_tree_is_rejected() {
+    // MAX_SOBOL_DIM is 16; a sum of 17 independent normals needs 17 stochastic dimensions.
+    let mut u = Uncertain::normal(0.0, 1.0);
+    for _ in 0..16 {
+        u = u + Uncertain::normal(0.0, 1.0);
+    }
+    let err = QmcSampler::new(&u, None).unwrap_err();
+    assert!(matches!(err, UncertainError::SamplingError(_)));
+}
+
+#[test]
+fn test_dimension_assignment_walks_every_static_node_kind() {
+    // One graph touching the arithmetic, negation, comparison, logical, function, and conditional
+    // arms of `assign_dimensions` / `collect_stochastic_leaves`. Both conditional branches share
+    // the exact same leaves, so the branch-divergence guard accepts it.
+    let n = Uncertain::normal(0.0, 1.0);
+    let uni = Uncertain::uniform(0.0, 1.0);
+    // A rich numeric branch: negation, arithmetic, an f64 `map` (FunctionOpF64).
+    let branch = ((-n.clone()) + uni.clone()).map(|x| x + 1.0);
+    // A boolean condition mixing a comparison and a logical `&` over the same leaves.
+    let cond = n.clone().greater_than(0.0) & uni.clone().less_than(0.5);
+    let u = Uncertain::conditional(cond, branch.clone(), branch);
+
+    let sampler = QmcSampler::new(&u, None).expect("static structure with shared leaves is valid");
+    // Two distinct stochastic leaves (the normal and the uniform).
+    assert_eq!(sampler.dimension(), 2);
+}
+
+#[test]
+fn test_f106_dimension_assignment() {
+    let u = Uncertain::<Float106>::normal(f106(0.0), f106(1.0))
+        + Uncertain::<Float106>::uniform(f106(0.0), f106(1.0));
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    assert_eq!(sampler.dimension(), 2);
+}
+
+#[test]
+fn test_branch_leaf_collection_walks_nested_conditional_and_bool_logical() {
+    // A numeric branch containing a *nested* conditional whose boolean condition mixes a
+    // comparison and a logical `&` over a Bernoulli leaf. `collect_stochastic_leaves` recurses
+    // through the conditional / comparison / logical / bool-leaf arms while validating the outer
+    // conditional's branches. Both outer branches share the identical subtree, so it is accepted.
+    let b = Uncertain::<bool>::bernoulli(0.5);
+    let n = Uncertain::normal(0.0, 1.0);
+    let inner_cond = n.clone().greater_than(0.0) & b;
+    let inner = Uncertain::conditional(inner_cond, n.clone(), n);
+    let outer_cond = Uncertain::<bool>::bernoulli(0.5);
+    let u = Uncertain::conditional(outer_cond, inner.clone(), inner);
+
+    assert!(QmcSampler::new(&u, None).is_ok());
+}
+
+#[test]
+fn test_f106_branch_leaf_collection() {
+    // The `Float106` arm of `collect_stochastic_leaves`, reached by validating an f106 conditional.
+    let cond = Uncertain::<bool>::bernoulli(0.5);
+    let shared = Uncertain::<Float106>::normal(f106(0.0), f106(1.0));
     let u = Uncertain::conditional(cond, shared.clone(), shared);
     assert!(QmcSampler::new(&u, None).is_ok());
 }
@@ -138,6 +218,124 @@ fn test_qmc_batch_rejects_dynamic_tree() {
     let cond = Uncertain::<bool>::bernoulli(0.5);
     let u = Uncertain::conditional(cond, Uncertain::normal(0.0, 1.0), Uncertain::normal(9.0, 1.0));
     assert!(u.expected_value_qmc(64, 1).is_err());
+}
+
+// --- evaluate_node arm coverage (each draws through the QMC sampler) ---
+
+#[test]
+fn test_qmc_samples_f64_uniform_leaf() {
+    let u = Uncertain::uniform(2.0, 4.0);
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    let v = u.sample_with_index_qmc(0, &sampler).unwrap();
+    assert!((2.0..4.0).contains(&v), "uniform draw {v} out of [2,4)");
+}
+
+#[test]
+fn test_qmc_samples_bool_bernoulli_leaf() {
+    let u = Uncertain::<bool>::bernoulli(1.0); // certainly true
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    assert!(u.sample_with_index_qmc(0, &sampler).unwrap());
+}
+
+#[test]
+fn test_qmc_samples_f64_negation_and_map_and_function_bool() {
+    let base = Uncertain::normal(5.0, 0.0); // a degenerate normal: always its mean
+    let neg = -base.clone();
+    let neg_sampler = QmcSampler::new(&neg, None).unwrap();
+    let nv = neg.sample_with_index_qmc(0, &neg_sampler).unwrap();
+    assert!((nv + 5.0).abs() < 1e-9, "negation gave {nv}");
+
+    let mapped = base.clone().map(|x| x * 2.0);
+    let mapped_sampler = QmcSampler::new(&mapped, None).unwrap();
+    let mv = mapped.sample_with_index_qmc(0, &mapped_sampler).unwrap();
+    assert!((mv - 10.0).abs() < 1e-9, "map gave {mv}");
+
+    let to_bool = base.map_to_bool(|x| x > 0.0);
+    let tb_sampler = QmcSampler::new(&to_bool, None).unwrap();
+    assert!(to_bool.sample_with_index_qmc(0, &tb_sampler).unwrap());
+}
+
+#[test]
+fn test_qmc_samples_comparison_and_logical_ops() {
+    let n = Uncertain::normal(1.0, 0.0); // always 1.0
+    let gt = n.greater_than(0.0);
+    let s = QmcSampler::new(&gt, None).unwrap();
+    assert!(gt.sample_with_index_qmc(0, &s).unwrap());
+
+    let a = Uncertain::<bool>::bernoulli(1.0);
+    let b = Uncertain::<bool>::bernoulli(0.0);
+    let and = a.clone() & b.clone();
+    let or = a.clone() | b.clone();
+    let xor = a.clone() ^ b.clone();
+    let not = !a;
+    for (u, want) in [(and, false), (or, true), (xor, true), (not, false)] {
+        let s = QmcSampler::new(&u, None).unwrap();
+        assert_eq!(u.sample_with_index_qmc(0, &s).unwrap(), want);
+    }
+}
+
+#[test]
+fn test_qmc_samples_conditional_both_branches() {
+    // Shared leaves so the static-structure guard accepts the conditional; sampling across many
+    // indices drives the condition both ways, exercising both branch arms of `evaluate_node`.
+    let cond = Uncertain::<bool>::bernoulli(0.5);
+    let shared = Uncertain::normal(0.0, 1.0);
+    let u = Uncertain::conditional(cond, shared.clone(), shared);
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    for i in 0..64 {
+        assert!(u.sample_with_index_qmc(i, &sampler).unwrap().is_finite());
+    }
+}
+
+#[test]
+fn test_qmc_samples_f106_distributions_arithmetic_and_negation() {
+    let normal = Uncertain::<Float106>::normal(f106(3.0), f106(0.0)); // always 3.0
+    let uniform = Uncertain::<Float106>::uniform(f106(0.0), f106(2.0));
+
+    let sum = normal.clone() + uniform.clone();
+    let s = QmcSampler::new(&sum, None).unwrap();
+    let v = sum.sample_with_index_qmc(0, &s).unwrap();
+    assert!(v.to_f64().is_finite() && v.to_f64() >= 3.0 && v.to_f64() < 5.0);
+
+    let neg = -normal;
+    let s2 = QmcSampler::new(&neg, None).unwrap();
+    let nv = neg.sample_with_index_qmc(0, &s2).unwrap();
+    assert!((nv.to_f64() + 3.0).abs() < 1e-9, "f106 negation gave {}", nv.to_f64());
+
+    let s3 = QmcSampler::new(&uniform, None).unwrap();
+    let uv = uniform.sample_with_index_qmc(0, &s3).unwrap();
+    assert!((0.0..2.0).contains(&uv.to_f64()));
+}
+
+#[test]
+fn test_qmc_memoizes_a_shared_leaf() {
+    // `n` feeds both operands of the sum, so the second visit to its node id hits the per-sample
+    // memoization cache (one draw per shared leaf, matching SequentialSampler semantics).
+    let n = Uncertain::normal(2.0, 0.0); // degenerate: always 2.0
+    let u = n.clone() + n;
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    let v = u.sample_with_index_qmc(0, &sampler).unwrap();
+    assert!((v - 4.0).abs() < 1e-9, "shared leaf summed to {v}, expected 4.0");
+}
+
+#[test]
+fn test_qmc_samples_point_leaf_inside_a_tree() {
+    // A `point` leaf combined with a stochastic leaf exercises the Point distribution arm.
+    let u = Uncertain::<f64>::point(10.0) + Uncertain::normal(0.0, 0.0);
+    let sampler = QmcSampler::new(&u, None).unwrap();
+    let v = u.sample_with_index_qmc(0, &sampler).unwrap();
+    assert!((v - 10.0).abs() < 1e-9);
+}
+
+#[test]
+fn test_qmc_coordinate_errors_on_a_foreign_leaf() {
+    // A sampler built for tree A has no dimension for tree B's distinct stochastic leaf, so
+    // sampling B with A's sampler hits the `coordinate` "no assigned dimension" guard.
+    let a = Uncertain::normal(0.0, 1.0);
+    let b = Uncertain::normal(0.0, 1.0); // a different node id, not in A's dims
+    let sampler_a = QmcSampler::new(&a, None).unwrap();
+    let err = b.sample_with_index_qmc(0, &sampler_a).unwrap_err();
+    assert!(matches!(err, UncertainError::SamplingError(_)));
 }
 
 } // rusty_fork_test!

--- a/deep_causality_uncertain/tests/types/sampler/sequential_sampler_tests.rs
+++ b/deep_causality_uncertain/tests/types/sampler/sequential_sampler_tests.rs
@@ -4,6 +4,7 @@
  */
 
 use deep_causality_ast::ConstTree;
+use deep_causality_num::Float106;
 use deep_causality_uncertain::{
     ArithmeticOperator, BernoulliParams, ComparisonOperator, DistributionEnum, LogicalOperator,
     NormalDistributionParams, SampledValue, Sampler, SequentialSampler, UncertainError,
@@ -474,6 +475,142 @@ fn test_conditional_op() {
     });
     assert!(matches!(
         Sampler::<f64>::sample(&sampler, &node, 0),
+        Err(UncertainError::UnsupportedTypeError(_))
+    ));
+}
+
+// =============================================================================
+// Float106 (double-double) precision paths
+// =============================================================================
+
+fn f106(x: f64) -> Float106 {
+    Float106::from_f64(x)
+}
+
+fn dfloat(x: f64) -> UncertainNode {
+    create_node(UncertainNodeContent::Value(SampledValue::DoubleFloat(
+        f106(x),
+    )))
+}
+
+#[test]
+fn test_distribution_f106_point_normal_uniform() {
+    let sampler = SequentialSampler;
+
+    let node = create_root(UncertainNodeContent::DistributionF106(
+        DistributionEnum::Point(f106(42.0)),
+    ));
+    assert_eq!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(f106(42.0))
+    );
+
+    let node = create_root(UncertainNodeContent::DistributionF106(
+        DistributionEnum::Normal(NormalDistributionParams::new(f106(0.0), f106(1.0))),
+    ));
+    assert!(matches!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(_)
+    ));
+
+    let node = create_root(UncertainNodeContent::DistributionF106(
+        DistributionEnum::Uniform(UniformDistributionParams::new(f106(0.0), f106(1.0))),
+    ));
+    assert!(matches!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(_)
+    ));
+}
+
+#[test]
+fn test_double_float_arithmetic_and_negation() {
+    let sampler = SequentialSampler;
+
+    let node = create_root(UncertainNodeContent::ArithmeticOp {
+        op: ArithmeticOperator::Add,
+        lhs: dfloat(10.0),
+        rhs: dfloat(5.0),
+    });
+    assert_eq!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(f106(15.0))
+    );
+
+    let node = create_root(UncertainNodeContent::NegationOp {
+        operand: dfloat(7.0),
+    });
+    assert_eq!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(f106(-7.0))
+    );
+}
+
+#[test]
+fn test_double_float_comparison_and_function_ops() {
+    let sampler = SequentialSampler;
+
+    // ComparisonOp over a DoubleFloat operand.
+    let node = create_root(UncertainNodeContent::ComparisonOp {
+        op: ComparisonOperator::GreaterThan,
+        threshold: 5.0,
+        operand: dfloat(10.0),
+    });
+    assert_eq!(
+        Sampler::<bool>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::Bool(true)
+    );
+
+    // FunctionOpF64 over a DoubleFloat operand (the func runs on the widened f64).
+    let func = Arc::new(|x: f64| x + 1.0);
+    let node = create_root(UncertainNodeContent::FunctionOpF64 {
+        func,
+        operand: dfloat(10.0),
+    });
+    assert_eq!(
+        Sampler::<Float106>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::DoubleFloat(f106(11.0))
+    );
+
+    // FunctionOpBool over a DoubleFloat operand.
+    let func = Arc::new(|x: f64| x > 0.0);
+    let node = create_root(UncertainNodeContent::FunctionOpBool {
+        func,
+        operand: dfloat(10.0),
+    });
+    assert_eq!(
+        Sampler::<bool>::sample(&sampler, &node, 0).unwrap(),
+        SampledValue::Bool(true)
+    );
+}
+
+#[test]
+fn test_distribution_variant_mismatch_errors() {
+    // Each distribution channel rejects a variant that does not belong to it. `Bernoulli` carries
+    // no `T`, so it slots into the f64 / f106 channels as a deliberate mismatch; a `Normal<bool>`
+    // is the analogous mismatch for the bool channel.
+    let sampler = SequentialSampler;
+
+    let node = create_root(UncertainNodeContent::DistributionF64(
+        DistributionEnum::Bernoulli(BernoulliParams::new(0.5)),
+    ));
+    assert!(matches!(
+        Sampler::<f64>::sample(&sampler, &node, 0),
+        Err(UncertainError::UnsupportedTypeError(_))
+    ));
+
+    let node = create_root(UncertainNodeContent::DistributionF106(
+        DistributionEnum::Bernoulli(BernoulliParams::new(0.5)),
+    ));
+    assert!(matches!(
+        Sampler::<Float106>::sample(&sampler, &node, 0),
+        Err(UncertainError::UnsupportedTypeError(_))
+    ));
+
+    let node = create_root(UncertainNodeContent::DistributionBool(
+        DistributionEnum::Normal(NormalDistributionParams::new(true, false)),
+    ));
+    assert!(matches!(
+        Sampler::<bool>::sample(&sampler, &node, 0),
         Err(UncertainError::UnsupportedTypeError(_))
     ));
 }

--- a/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
+++ b/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
@@ -13,3 +13,6 @@ mod uncertain_maybe_f64_tests;
 
 #[cfg(all(test, not(miri)))]
 mod uncertain_maybe_f64_arithmetic_tests;
+
+#[cfg(all(test, not(miri)))]
+mod uncertain_maybe_f106_tests;

--- a/deep_causality_uncertain/tests/types/uncertain_maybe/uncertain_maybe_f106_tests.rs
+++ b/deep_causality_uncertain/tests/types/uncertain_maybe/uncertain_maybe_f106_tests.rs
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+ */
+
+//! Tests for `MaybeUncertain<Float106>` — the precision-carrying mirror of the `f64` surface:
+//! the four constructors, `sample`, `is_some` / `is_none`, and the SPRT-gated `lift_to_uncertain`
+//! (success, presence-failure, always-none, always-some).
+
+use deep_causality_num::Float106;
+use deep_causality_uncertain::{MaybeUncertain, Uncertain, UncertainError};
+use rusty_fork::rusty_fork_test;
+
+rusty_fork_test! {
+    #[test]
+    fn test_from_value_constructor() {
+        let mu = MaybeUncertain::<Float106>::from_value(Float106::from_f64(42.0));
+        assert_eq!(mu.sample().unwrap(), Some(Float106::from_f64(42.0)));
+    }
+
+    #[test]
+    fn test_from_uncertain_constructor() {
+        let u = Uncertain::<Float106>::point(Float106::from_f64(42.0));
+        let mu = MaybeUncertain::<Float106>::from_uncertain(u);
+        assert_eq!(mu.sample().unwrap(), Some(Float106::from_f64(42.0)));
+    }
+
+    #[test]
+    fn test_always_none_constructor() {
+        let mu = MaybeUncertain::<Float106>::always_none();
+        assert_eq!(mu.sample().unwrap(), None);
+    }
+
+    #[test]
+    fn test_from_bernoulli_and_uncertain_constructor() {
+        let u = Uncertain::<Float106>::point(Float106::from_f64(42.0));
+        let mu = MaybeUncertain::<Float106>::from_bernoulli_and_uncertain(1.0, u);
+        assert_eq!(mu.sample().unwrap(), Some(Float106::from_f64(42.0)));
+
+        let u2 = Uncertain::<Float106>::point(Float106::from_f64(42.0));
+        let mu2 = MaybeUncertain::<Float106>::from_bernoulli_and_uncertain(0.0, u2);
+        assert_eq!(mu2.sample().unwrap(), None);
+    }
+
+    #[test]
+    fn test_is_some() {
+        let mu = MaybeUncertain::<Float106>::from_value(Float106::from_f64(42.0));
+        assert!(mu.is_some().sample().unwrap());
+    }
+
+    #[test]
+    fn test_is_none() {
+        let mu = MaybeUncertain::<Float106>::always_none();
+        assert!(mu.is_none().sample().unwrap());
+    }
+
+    #[test]
+    fn test_sample() {
+        let mu = MaybeUncertain::<Float106>::from_value(Float106::from_f64(123.0));
+        assert_eq!(mu.sample().unwrap(), Some(Float106::from_f64(123.0)));
+    }
+
+    #[test]
+    fn test_lift_to_uncertain_success() {
+        let u = Uncertain::<Float106>::point(Float106::from_f64(42.0));
+        let mu = MaybeUncertain::<Float106>::from_bernoulli_and_uncertain(0.9, u);
+        let result = mu.lift_to_uncertain(0.8, 0.95, 0.05, 100).unwrap();
+        assert_eq!(result.sample().unwrap(), Float106::from_f64(42.0));
+    }
+
+    #[test]
+    fn test_lift_to_uncertain_failure() {
+        let u = Uncertain::<Float106>::point(Float106::from_f64(42.0));
+        let mu = MaybeUncertain::<Float106>::from_bernoulli_and_uncertain(0.7, u);
+        let result = mu.lift_to_uncertain(0.8, 0.95, 0.05, 100);
+        assert!(matches!(result, Err(UncertainError::PresenceError(_))));
+    }
+
+    #[test]
+    fn test_lift_to_uncertain_always_none() {
+        let mu = MaybeUncertain::<Float106>::always_none();
+        let result = mu.lift_to_uncertain(0.1, 0.95, 0.05, 100);
+        assert!(matches!(result, Err(UncertainError::PresenceError(_))));
+    }
+
+    #[test]
+    fn test_lift_to_uncertain_always_some() {
+        let mu = MaybeUncertain::<Float106>::from_value(Float106::from_f64(42.0));
+        let result = mu.lift_to_uncertain(0.9, 0.95, 0.05, 100).unwrap();
+        assert_eq!(result.sample().unwrap(), Float106::from_f64(42.0));
+    }
+}


### PR DESCRIPTION


## Describe your changes

Add targeted tests for the files flagged in the coverage dashboard:
- uncertain: full f106 MaybeUncertain mirror; QMC/sequential sampler f106 + DoubleFloat arms, structure/validation guards
- deep_causality: stateful & stateless graph-reasoning error paths, causable collection trait-accessor calls, spacetime adjustable 1D/2D/4D grid arms, causaloid stateful singleton/collection/graph arms
- topology: open-weighted Leray projection validation guards
- physics: EM-kernel overflow guards
- cfd: consumed-solver inflow-march guard
- sparse: CG operator-failure / algebraic-breakdown guards (3 variants)
- discovery: SURD clean/filter error branches
- multivector: empty-field monadic bind

## Issue ticket number and link

https://github.com/deepcausality-rs/deep_causality/issues/638

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise test coverage across 8 crates by adding targeted tests for error paths, validation guards, and precision-specific code paths to harden behavior and improve reliability.

- **Coverage**
  - `deep_causality_uncertain`: Added `Float106` `MaybeUncertain` suite; extended `SequentialSampler`/`QmcSampler` to cover `DoubleFloat` ops, negation/comparison/logical/function/conditional paths, shared-leaf memoization, dimension assignment and over-dimension rejection, and coordinate errors; point/bernoulli leaves inside trees.
  - `deep_causality`: Added stateful/stateless graph-reasoning guards (unfrozen graph, missing indices, no-path, failing node short-circuit, relay behavior, start=stop); causaloid stateful eval guards (None input, relay pass-through, closure returning None, reject collection/graph causaloids); trait-qualified collection accessors; spacetime adjustable 1D/2D/4D grid arms.
  - `deep_causality_topology`: Open-weighted Leray projection input validation (field length, missing metric, inflow needs reference, out-of-range edge/vertex).
  - `deep_causality_physics`: EM-kernel overflow-result guards (Poynting, Proca m², energy/lagrangian densities).
  - `deep_causality_cfd`: Consumed-solver short-circuit after failed inflow wall reconfiguration.
  - `deep_causality_sparse`: CG guards for wrong-length operator, algebraic breakdown, zero-RHS early exit, and loop-time failures across plain/preconditioned/warm-start variants.
  - `deep_causality_discovery`: SURD cleaner error surfaced; `filter_cohort` rejects non-2D and handles empty cohort.
  - `deep_causality_multivector`: Empty-field `bind` returns a zero field without invoking the function.

- **Dependencies**
  - Tests now depend on `//deep_causality_num` to exercise `Float106` paths.

<sup>Written for commit af6532a87007f12fb6211cd510238a9af64df512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

