### PR TITLE
Fixed miri tests

### DIFF
--- a/deep_causality_num/tests/algebra/field_real_f64_tests.rs
+++ b/deep_causality_num/tests/algebra/field_real_f64_tests.rs
@@ -88,10 +88,6 @@ fn test_log10() {
 }
 
 #[test]
-// Disabled under Miri: software-emulated floats produce different last-bit
-// results for transcendental ops, so exact equality cannot hold. The test
-// itself is correct and runs under normal CI.
-#[cfg_attr(miri, ignore)]
 fn test_powf() {
     let x = 2.0_f64;
     let n = 3.0_f64;

--- a/deep_causality_num/tests/algebra/mod.rs
+++ b/deep_causality_num/tests/algebra/mod.rs
@@ -9,13 +9,13 @@ mod domain_euclidean_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
-#[cfg_attr(miri, ignore)]
+#[cfg(not(miri))]
 #[cfg(test)]
 mod field_real_f32_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
-#[cfg_attr(miri, ignore)]
+#[cfg(not(miri))]
 #[cfg(test)]
 mod field_real_f64_tests;
 #[cfg(test)]

--- a/deep_causality_num/tests/algebra/mod.rs
+++ b/deep_causality_num/tests/algebra/mod.rs
@@ -2,7 +2,12 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
 #[cfg(test)]
+#[cfg(not(miri))]
 mod algebra_tests;
 #[cfg(test)]
 mod domain_euclidean_tests;

--- a/deep_causality_num/tests/algebra/mod.rs
+++ b/deep_causality_num/tests/algebra/mod.rs
@@ -6,8 +6,16 @@
 mod algebra_tests;
 #[cfg(test)]
 mod domain_euclidean_tests;
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 #[cfg(test)]
 mod field_real_f32_tests;
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 #[cfg(test)]
 mod field_real_f64_tests;
 #[cfg(test)]

--- a/deep_causality_num/tests/algebra/mod.rs
+++ b/deep_causality_num/tests/algebra/mod.rs
@@ -9,14 +9,18 @@ mod domain_euclidean_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
-#[cfg(not(miri))]
 #[cfg(test)]
+#[cfg(not(miri))]
 mod field_real_f32_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
+#[cfg(test)]
 #[cfg(not(miri))]
+pub(crate) mod field_real_f64_tests;
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
 #[cfg(test)]
-mod field_real_f64_tests;
-#[cfg(test)]
+#[cfg(not(miri))]
 mod real_tests;

--- a/deep_causality_num/tests/float/mod.rs
+++ b/deep_causality_num/tests/float/mod.rs
@@ -2,12 +2,16 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
 #[cfg(test)]
+#[cfg(not(miri))]
 mod float_32_tests;
-// Skipped wholesale under Miri: this module exercises f64 floating-point
-// behavior, much of it via exact `assert_eq!` on transcendental results
-// (sin/cos/cbrt/atan2/...). Miri's soft-float emulation differs from hardware
-// in the last bit, so these comparisons spuriously fail one by one. The tests
-// are correct and pass under normal CI.
-#[cfg(all(test, not(miri)))]
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg(test)]
+#[cfg(not(miri))]
 mod float_64_tests;

--- a/deep_causality_num/tests/float_double/mod.rs
+++ b/deep_causality_num/tests/float_double/mod.rs
@@ -14,6 +14,10 @@ mod double_attributes_tests;
 mod double_comparison_tests;
 #[cfg(test)]
 mod double_display_tests;
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 #[cfg(test)]
 mod double_erf_tests;
 #[cfg(test)]
@@ -26,5 +30,9 @@ mod double_num_traits_tests;
 mod double_ops_tests;
 #[cfg(test)]
 mod double_traits_tests;
+// Disabled under Miri: software-emulated floats produce different last-bit
+// results for transcendental ops, so exact equality cannot hold. The test
+// itself is correct and runs under normal CI.
+#[cfg_attr(miri, ignore)]
 #[cfg(test)]
 mod double_transcendental_tests;

--- a/deep_causality_num/tests/float_double/mod.rs
+++ b/deep_causality_num/tests/float_double/mod.rs
@@ -17,8 +17,8 @@ mod double_display_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
-#[cfg_attr(miri, ignore)]
 #[cfg(test)]
+#[cfg(not(miri))]
 mod double_erf_tests;
 #[cfg(test)]
 mod double_float_tests;
@@ -33,6 +33,6 @@ mod double_traits_tests;
 // Disabled under Miri: software-emulated floats produce different last-bit
 // results for transcendental ops, so exact equality cannot hold. The test
 // itself is correct and runs under normal CI.
-#[cfg_attr(miri, ignore)]
 #[cfg(test)]
+#[cfg(not(miri))]
 mod double_transcendental_tests;

--- a/deep_causality_physics/tests/BUILD.bazel
+++ b/deep_causality_physics/tests/BUILD.bazel
@@ -371,8 +371,6 @@ rust_test_suite(
     ],
 )
 
-
-
 rust_test_suite(
     name = "theories",
     srcs = glob([

--- a/deep_causality_rand/tests/types/dist/normal/standard_normal_tests.rs
+++ b/deep_causality_rand/tests/types/dist/normal/standard_normal_tests.rs
@@ -8,6 +8,7 @@ use deep_causality_rand::types::distr::normal::standard_normal::StandardNormal;
 macro_rules! standard_normal_tests {
     ($float_type:ty, $tolerance:expr) => {
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn test_mean_and_std_dev() {
             let mut rng = rng();
             let distr = StandardNormal;
@@ -91,6 +92,7 @@ mod f106_tests {
     use deep_causality_rand::rng;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_mean_and_std_dev() {
         let mut rng = rng();
         let distr = StandardNormal;

--- a/deep_causality_rand/tests/types/dist/uniform/mod.rs
+++ b/deep_causality_rand/tests/types/dist/uniform/mod.rs
@@ -5,7 +5,6 @@
 
 #[cfg(test)]
 #[cfg(not(miri))]
-
 mod standard_uniform_tests;
 #[cfg(test)]
 #[cfg(not(miri))]

--- a/deep_causality_rand/tests/types/dist/uniform/mod.rs
+++ b/deep_causality_rand/tests/types/dist/uniform/mod.rs
@@ -4,6 +4,9 @@
  */
 
 #[cfg(test)]
+#[cfg(not(miri))]
+
 mod standard_uniform_tests;
 #[cfg(test)]
+#[cfg(not(miri))]
 mod uniform_tests;

--- a/deep_causality_rand/tests/utils/mod.rs
+++ b/deep_causality_rand/tests/utils/mod.rs
@@ -4,9 +4,9 @@
  */
 #[cfg(test)]
 // Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
-#[cfg(all(test, not(miri)))]
+#[cfg(not(miri))]
 mod inverse_cdf_tests;
 #[cfg(test)]
 // Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
-#[cfg(all(test, not(miri)))]
+#[cfg(not(miri))]
 mod sobol_tests;

--- a/deep_causality_rand/tests/utils/mod.rs
+++ b/deep_causality_rand/tests/utils/mod.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 #[cfg(test)]
+// Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
+#[cfg(all(test, not(miri)))]
 mod inverse_cdf_tests;
 #[cfg(test)]
+// Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
+#[cfg(all(test, not(miri)))]
 mod sobol_tests;

--- a/deep_causality_uncertain/tests/types/sampler/mod.rs
+++ b/deep_causality_uncertain/tests/types/sampler/mod.rs
@@ -4,11 +4,11 @@
  */
 #[cfg(test)]
 // Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
-#[cfg(all(test, not(miri)))]
+#[cfg(not(miri))]
 mod qmc_sampler_tests;
 #[cfg(test)]
 mod sampler_seed_tests;
 #[cfg(test)]
 // Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
-#[cfg(all(test, not(miri)))]
+#[cfg(not(miri))]
 mod sequential_sampler_tests;

--- a/deep_causality_uncertain/tests/types/sampler/mod.rs
+++ b/deep_causality_uncertain/tests/types/sampler/mod.rs
@@ -3,8 +3,12 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 #[cfg(test)]
+// Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
+#[cfg(all(test, not(miri)))]
 mod qmc_sampler_tests;
 #[cfg(test)]
 mod sampler_seed_tests;
 #[cfg(test)]
+// Disabled under Miri: Miri's soft-float emulation drifts by ~1 ULP (got 0.9999999996 vs 1)
+#[cfg(all(test, not(miri)))]
 mod sequential_sampler_tests;

--- a/deep_causality_uncertain/tests/types/sampler/sequential_sampler_tests.rs
+++ b/deep_causality_uncertain/tests/types/sampler/sequential_sampler_tests.rs
@@ -363,10 +363,6 @@ fn test_logical_op_errors() {
 }
 
 #[test]
-// Disabled under Miri: the sampler evaluates `x.powi(2)` on f64, which under
-// Miri's soft-float emulation drifts by ~1 ULP (got 99.99999999999996 vs
-// 100.0). Test is correct under normal CI.
-#[cfg_attr(miri, ignore)]
 fn test_function_op_f64() {
     let sampler = SequentialSampler;
     let operand = create_node(UncertainNodeContent::Value(SampledValue::Float(10.0f64)));

--- a/deep_causality_uncertain/tests/types/uncertain/mod.rs
+++ b/deep_causality_uncertain/tests/types/uncertain/mod.rs
@@ -6,17 +6,24 @@
 // a subprocess via `posix_spawn`, and Miri does not implement the
 // `posix_spawn*` libc shims, so the tests abort. They are correct and run
 // under normal CI.
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_arithmetic_tests;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_comparison_tests;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_default;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_logic_tests;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_sampling_tests;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_statistics_tests;
 #[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_tests;

--- a/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
+++ b/deep_causality_uncertain/tests/types/uncertain_maybe/mod.rs
@@ -7,12 +7,16 @@
 // not implement the `posix_spawn*` libc shims, so the tests abort. They are
 // correct and run under normal CI.
 #[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_maybe_bool_tests;
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_maybe_f64_tests;
 
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_maybe_f64_arithmetic_tests;
 
-#[cfg(all(test, not(miri)))]
+#[cfg(test)]
+#[cfg(not(miri))]
 mod uncertain_maybe_f106_tests;


### PR DESCRIPTION

## Describe your changes

Fixed miri tests

## Issue ticket number and link

https://github.com/deepcausality-rs/deep_causality/issues/643

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Miri test failures by gating ULP‑sensitive float and stochastic tests under `miri` and adding ignores for unstable cases. Normal CI still runs the full suite. Addresses #643.

- **Bug Fixes**
  - `deep_causality_num`: gate algebra `f32`/`f64`, `float_32/64`, and `double_erf`/`double_transcendental` with `#[cfg(not(miri))]`; remove redundant per‑test ignores.
  - `deep_causality_rand`: gate inverse CDF, Sobol, and uniform tests; add `#[cfg_attr(miri, ignore)]` to StandardNormal mean/std; minor formatting/linting.
  - `deep_causality_uncertain`: gate QMC and sequential sampler, plus `uncertain_*` and `uncertain_maybe_*` modules; drop per‑test ignores.

<sup>Written for commit aee75a8e123488f0c7a833b2fcf99048576724ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

