### PR TITLE
fix(deep_causality_algorithms): Fixed miri test config

### DIFF
--- a/deep_causality_algorithms/tests/causal_discovery/brcd/mod.rs
+++ b/deep_causality_algorithms/tests/causal_discovery/brcd/mod.rs
@@ -31,6 +31,7 @@ mod error_tests;
 #[cfg(test)]
 mod family_tests;
 #[cfg(test)]
+#[cfg(not(miri))]
 mod gate_tests;
 #[cfg(test)]
 mod gaussian_tests;


### PR DESCRIPTION


## Describe your changes

 Fixed miri test config

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `gate_tests` when running under Miri by adding `#[cfg(not(miri))]`. This fixes Miri test failures while leaving normal test runs unchanged.

<sup>Written for commit 1dfbe46d276b37fa6c957ff92592d58ed815fe26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

