### PR TITLE
fix(deep_causality_file): Fixed dependencies versioning issue 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "deep_causality_haft",

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -24,10 +24,17 @@ exclude = [
     "tests/**/*",
 ]
 
+[dependencies.deep_causality_haft]
+path = "../deep_causality_haft"
+version = "0.3"
+
+[dependencies.deep_causality_num]
+path = "../deep_causality_num"
+version = "0.3"
+
 [dependencies]
+# External dependencies
 chrono = { version = "0.4" }
-deep_causality_num = { path = "../deep_causality_num" }
-deep_causality_haft = { path = "../deep_causality_haft" }
 
 [dev-dependencies]
 tempfile = { version = "3", default-features = false }


### PR DESCRIPTION
## Describe your changes

fix(deep_causality_file): Fixed dependencies versioning issue  that prevented auto-release via CI.

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dependency versioning in `deep_causality_file` to unblock CI auto-release. Bumps crate to 0.1.1 and pins internal deps to 0.3.

- **Dependencies**
  - Pinned `deep_causality_haft` and `deep_causality_num` to `0.3` via explicit `[dependencies.*]` tables with local paths.
  - Updated `Cargo.toml` and `Cargo.lock` to `0.1.1` for `deep_causality_file`.

<sup>Written for commit 6726201fdb9b9db875db0d2855fbb81d822755de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

