### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.13.10...deep_causality-v0.14.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-4)
+- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-3)
+- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-3)
+- *(deep_causality)* add opt-in freeze_dag() to enforce DAG structure
+- *(examples)* add example_ml_rca
+
+### Fixed
+
+- address code-review findings (graph-reasoning docs/test, stale doc example, clippy)
+- *(deep_causality)* principled graph sequencing + loud reconvergence; defer merge ∇
+- *(deep_causality_core)* make success-channel functor/applicative total across all witnesses
+- *(deep_causality)* error on command input to stateful singleton instead of silently dropping it
+- *(core)* make the value-level functor total over commands; address refactor review
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- *(deep_causality)* [**breaking**] reasoning engine as a Free::fold handler over CausalEffect
+- *(readme)* use absolute raw URLs for logo images
+- Code formatting and linting.
+- *(deep_causality)* adapt monad bench to intervene → alternate_value
+- *(formalization)* [**breaking**] close out enforce-w-invariant — proofs, witnesses, CI
+- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
+- Restructured the avionics example folder.
+- *(deep_causality)* close coverage gaps in core crate (tests only)
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+
 ## [0.13.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.13.9...deep_causality-v0.13.10) - 2026-06-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.13.10"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "deep_causality_ast",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -553,11 +553,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -589,14 +589,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -651,19 +651,19 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.3.3"
+version = "0.4.0"
 
 [[package]]
 name = "deep_causality_macros"
-version = "0.9.4"
+version = "0.9.5"
 
 [[package]]
 name = "deep_causality_metric"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "libm",
 ]
@@ -699,11 +699,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.1.16"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_sparse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_tensor"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.3.16"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2147,7 +2147,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.13.10"
+version = "0.14.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -42,7 +42,7 @@ os-random = ["deep_causality_uncertain/os-random"]
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_ast]
 path = "../deep_causality_ast"
@@ -50,7 +50,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.10"
+version = "0.11"
 default-features = true
 
 
@@ -60,7 +60,7 @@ version = "0.10"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.ultragraph]
 path = "../ultragraph"

--- a/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_algebra/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_algebra-v0.1.0) - 2026-07-08
+
+### Added
+
+- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)
+
+### Fixed
+
+- address code-review findings (graph-reasoning docs/test, stale doc example, clippy)
+
+### Other
+
+- Fixed dependencies version in various crate to fix CI auto release.
+- code formatting and linting.
+- rename the Lean layer Num → Algebra to mirror the new crate.
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual

--- a/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_algebra/Cargo.toml
@@ -21,7 +21,7 @@ no-std = ["deep_causality_num/no-std"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [lints]

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.3.0...deep_causality_algorithms-v0.4.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_algorithms)* opt-in O(du) MAP-config pruning for BRCD (near-linear path)
+- *(deep_causality_algorithms)* add dag_sampling uniform MEC DAG sampler
+- *(deep_causality_algorithms)* add dag_sampling — polynomial-time Clique-Picking AMO counter
+
+### Fixed
+
+- *(deep_causality_algorithms)* Fixed miri test config
+- *(deep_causality_algorithms)* Fixed miri test config
+- *(deep_causality_algorithms,deep_causality_discovery)* cache version tag, docs,
+- *(deep_causality_algorithms)* Removed dead code
+- *(deep_causality_algorithms)* remove latent panic in Clique-Picking AMO counter
+- *(brcd,discovery)* address QA findings (32-bit shift, DRY, Precision bound)
+- *(deep_causality_algorithms)* Resolved sorting order issues reported in https://github.com/deepcausality-rs/deep_causality/issues/641
+- *(deep_causality_algorithms)* correct verification data path after brcd-paper move
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- strengthen physics quantity assertions and fix review nits
+- *(deep_causality_algorithms)* close remaining coverage gaps with targeted branch tests
+- *(deep_causality_algorithms)* memoize invalid MapPrune orientations
+- *(deep_causality_algorithms)* updated
+- *(deep_causality_algorithms)* parallelize BRCD across candidates; add BRCD eval harnesses + companion papers
+- *(deep_causality_algorithms)* remove experimental BRCD thesis probes from verification
+- *(deep_causality_algorithms)* wire BRCD to the polynomial dag_sampling counter + sampler
+- Merge branch 'brcd-paper'
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.2.14...deep_causality_algorithms-v0.3.0) - 2026-06-09
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.3.0"
+version = "0.4.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -18,11 +18,11 @@ exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
@@ -30,11 +30,11 @@ version = "0.1"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"
-version = "0.6"
+version = "0.7"
 
 [dependencies.deep_causality_rand]
 path = "../deep_causality_rand"
-version = "0.1"
+version = "0.2"
 
 # Feature-conditional thread-safety marker (`MaybeParallel`): vacuous on serial
 # builds, `Send + Sync` when `parallel` is forwarded below. 

--- a/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.7...deep_causality_ast-v0.1.8) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.1.7](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.6...deep_causality_ast-v0.1.7) - 2026-06-09
 
 ### Other

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.1...deep_causality_calculus-v0.1.2) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+- Add the readme file to the calculus crate.
+
 ## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.0...deep_causality_calculus-v0.1.1) - 2026-06-09
 
 ### Other

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -33,12 +33,12 @@ alloc = ["deep_causality_haft/alloc"]
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -55,7 +55,7 @@ parallel = [
 
 [dependencies.deep_causality_physics]
 path = "../deep_causality_physics"
-version = "0.6"
+version = "0.7"
 default-features = false
 
 [dependencies.deep_causality_calculus]
@@ -64,7 +64,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.10"
+version = "0.11"
 
 [dependencies.deep_causality_file]
 path = "../deep_causality_file"
@@ -72,11 +72,11 @@ version = "0.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
@@ -92,18 +92,18 @@ version = "0.1"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 # Std-only: the uncertain-inflow zone consumes `MaybeUncertain<R>` and its global
 # sample cache. Gated behind `std` so the `alloc`-only build stays uncertain-free.
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"
-version = "0.3"
+version = "0.4"
 optional = true
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"
-version = "0.6"
+version = "0.7"
 
 [dependencies.deep_causality_par]
 path = "../deep_causality_par"

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.10.0...deep_causality_core-v0.11.0) - 2026-07-08
+
+### Added
+
+- *(file,cfd)* CFD file IO seams — typed tables, sensor traces, snapshot/resume
+- *(deep_causality_core)* file IO actions + CausalFlow read/write bridge
+
+### Fixed
+
+- *(deep_causality_core)* make success-channel functor/applicative total across all witnesses
+- *(core)* make the value-level functor total over commands; address refactor review
+- fixed sone doctest warnings
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(deep_causality_core)* assert command leaf value in fmap consistency test
+- code formatting and linting
+- *(Formalization)* Removed Kani run
+- *(core)* formalize deep_causality_core in Lean 4 (all 26 core.* ids proved + witnessed)
+- Code lintint and formatting.
+- *(core)* [**breaking**] replace EffectValue with the CausalEffect free monad; one Kleisli bind + state-threading arrow
+- *(core)* [**breaking**] thread state through the causal arrow (D2, one bind)
+- *(core)* [**breaking**] causal-arrow lawfulness + replace Intervenable with alternate_value
+- *(formalization)* [**breaking**] close out enforce-w-invariant — proofs, witnesses, CI
+- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
+- *(formalization)* scaffold Lean proof project + Rust witness bridge
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ### Changed
 
 - **[BREAKING]** *(deep_causality_core)* `CausalEffectPropagationProcess` now encodes value-XOR-error

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.10.0"
+version = "0.11.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -28,7 +28,7 @@ std = ["alloc", "deep_causality_haft/std"]
 alloc = []
 
 [dependencies]
-deep_causality_haft = { path = "../deep_causality_haft", version = "0.3" }
+deep_causality_haft = { path = "../deep_causality_haft", version = "0.4" }
 
 [lints]
 workspace = true

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.15](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.14...deep_causality_data_structures-v0.10.15) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.10.14](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.13...deep_causality_data_structures-v0.10.14) - 2026-06-09
 
 ### Other

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.14"
+version = "0.10.15"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.4.1...deep_causality_discovery-v0.5.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_discovery)* learn-once, rank-many CPDAG cache for BRCD
+
+### Fixed
+
+- *(deep_causality_discovery)* version-tag CPDAG cache key; correct Precision doc
+- *(brcd,discovery)* address QA findings (32-bit shift, DRY, Precision bound)
+- fixed sone doctest warnings
+- *(deep_causality_discovery)* fixed bazel test config.
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- *(deep_causality_algorithms)* parallelize BRCD across candidates; add BRCD eval harnesses + companion papers
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- Merge branch 'deepcausality-rs:main' into main
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.4.0...deep_causality_discovery-v0.4.1) - 2026-06-12
 
 ### Other

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -19,11 +19,11 @@ exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE
 
 [dependencies.deep_causality_algorithms]
 path = "../deep_causality_algorithms"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
@@ -31,17 +31,17 @@ version = "0.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"
-version = "0.6"
+version = "0.7"
 
 
 # External dependencies
@@ -52,7 +52,7 @@ parquet = {version = "59", default-features = false}
 
 [dev-dependencies]
 tempfile = {version = "3", default-features = false}
-deep_causality_rand = { path = "../deep_causality_rand", version = "0.1" }
+deep_causality_rand = { path = "../deep_causality_rand", version = "0.2" }
 
 
 # Comparison: cold (BOSS learns) vs warm (CPDAG cache) end-to-end runs.

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.7...deep_causality_ethos-v0.2.8) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- *(readme)* use absolute raw URLs for logo images
+- Restructured the avionics example folder.
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.2.7](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.6...deep_causality_ethos-v0.2.7) - 2026-06-09
 
 ### Other

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.7"
+version = "0.2.8"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -37,7 +37,7 @@ exclude = [
 
 [dependencies.deep_causality]
 path = "../deep_causality"
-version = "0.13"
+version = "0.14"
 
 [dependencies.ultragraph]
 path = "../ultragraph"

--- a/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_fft/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.0...deep_causality_fft-v0.1.1) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- Generated new SBOM for all crates.

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -39,7 +39,7 @@ parallel = ["dep:rayon", "deep_causality_par/parallel"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dependencies.deep_causality_algebra]

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -28,11 +28,11 @@ publish = false
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"

--- a/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.3.3...deep_causality_haft-v0.4.0) - 2026-07-08
+
+### Added
+
+- *(haft)* add the free monad on a functor (algebraic-effects base)
+- *(formalization)* formalize deep_causality_haft in Lean + mirrored Rust witnesses
+- *(deep_causality_haft)* formatting
+- *(deep_causality_haft)* add lazy IoAction effect (the Arrow twin)
+- *(deep_causality_haft)* To reorganize source code structure
+
+### Fixed
+
+- *(haft)* [**breaking**] align law docs with proved theory; make effect-system reference impl lawful
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- Code formatting and linting.
+- Fixed multiple issues in the HAFT formalization.
+- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
+- chorde(deep_causality_haft); reorganized source code
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.3.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.3.1...deep_causality_haft-v0.3.2) - 2026-05-26
 
 ### Fixed

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.3.3"
+version = "0.4.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_macros/CHANGELOG.md
+++ b/deep_causality_macros/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_macros-v0.9.4...deep_causality_macros-v0.9.5) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+
 ## [0.9.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_macros-v0.9.3...deep_causality_macros-v0.9.4) - 2026-06-09
 
 ### Other

--- a/deep_causality_macros/Cargo.toml
+++ b/deep_causality_macros/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_macros"
-version = "0.9.4"
+version = "0.9.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_metric/CHANGELOG.md
+++ b/deep_causality_metric/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.2...deep_causality_metric-v0.2.3) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.1...deep_causality_metric-v0.2.2) - 2026-06-09
 
 ### Other

--- a/deep_causality_metric/Cargo.toml
+++ b/deep_causality_metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_metric"
-version = "0.2.2"
+version = "0.2.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.2...deep_causality_multivector-v0.5.3) - 2026-07-08
+
+### Added
+
+- *(examples)* add example_ml_rca
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.1...deep_causality_multivector-v0.5.2) - 2026-06-09
 
 ### Added

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.5.2"
+version = "0.5.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -26,12 +26,12 @@ exclude = [
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
@@ -44,7 +44,7 @@ version = "0.1"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"

--- a/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.3.3...deep_causality_num-v0.4.0) - 2026-07-08
+
+### Added
+
+- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)
+- *(deep_causality_num)* generic monoid tower + verdict carrier (num-generic-monoid-tower)
+- *(deep_causality_num)* Added default to dual type.
+- *(deep_causality_num,deep_causality_tensor)* complex-capable SVD/QR kernels via ConjugateScalar
+- *(deep_causality_tensor)* tensor-network Stage 1 — CausalTensorTrain (MPS) state
+- *(deep_causality_num)* double-double erf/erfc for Float106
+
+### Fixed
+
+- *(formalization)* repair Lean Core build + review follow-ups
+- *(deep_causality_num)* Fixed miri test config
+- *(deep_causality_num)* Fixed miri test config
+- *(deep_causality_num)* Fixed miri test config
+- *(deep_causality_num)* Fixed miri test config
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- *(formalization)* scaffold Lean proof project + Rust witness bridge
+- *(deep_causality_num)* [**breaking**] remove unused EuclideanDomain trait
+- *(deep_causality_tensor)* tensor-network — document Stage-4 scalar generality
+- *(deep_causality_num)* restructured internal code modules.
+- Generated new SBOM for all crates.
+- *(deep_causality_num)* skip cos_val under Miri
+- Updated README file across multiple crates to meet project standard.
+- *(deep_causality_num)* Add table-based fast path for Float106::sin_cos
+
 ## [0.3.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.3.1...deep_causality_num-v0.3.2) - 2026-05-26
 
 ### Added

--- a/deep_causality_num/Cargo.toml
+++ b/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.3.3"
+version = "0.4.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_num_complex/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_num_complex-v0.1.0) - 2026-07-08
+
+### Added
+
+- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)
+
+### Other
+
+- Fixed dependencies version in various crate to fix CI auto release.
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual

--- a/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_num_complex/Cargo.toml
@@ -21,7 +21,7 @@ no-std = ["deep_causality_num/no-std", "deep_causality_algebra/no-std"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dependencies.deep_causality_algebra]

--- a/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_num_dual/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_num_dual-v0.1.0) - 2026-07-08
+
+### Added
+
+- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)
+
+### Other
+
+- Fixed dependencies version in various crate to fix CI auto release.
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -21,7 +21,7 @@ no-std = ["deep_causality_num/no-std", "deep_causality_algebra/no-std"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dependencies.deep_causality_algebra]

--- a/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_par/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.0...deep_causality_par-v0.1.1) - 2026-07-08
+
+### Added
+
+- *(cfd,physics,examples)* finite-rate ionization network, two-stage counterfactual sweep, review fixes, MDAO positioning
+- *(deep_causality_par)* scoped fork-join + parallel counterfactual fan-out
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.6.3...deep_causality_physics-v0.7.0) - 2026-07-08
+
+### Added
+
+- *(cfd,physics,file,examples)* study DSL (sweep, Gates, run_owned, duct_march) + three gated examples
+- *(cfd,physics,examples)* finite-rate ionization network, two-stage counterfactual sweep, review fixes, MDAO positioning
+- *(physics,cfd,avionics_examples)* uncalibrated finite-rate ionization network (lever 3)
+- *(cfd)* navigation engine (Stage 2) — ESKF + regime switch, in the CFD crate
+- *(physics)* synthetic sensors + closed-loop nav gate (Stage 2.2)
+- *(physics)* cohesive ReentryNavEngine — KS + ESKF + two-clock (Stage 2.1c)
+- *(physics)* 17-state ESKF covariance + measurement update (Stage 2.1b)
+- *(physics)* strapdown-INS error state + drift laws — nav-engine core (Stage 2.1a)
+- *(cfd)* BodyFittedCoordinate3d — spherical-shell fitted 3-D metric (Stage 1.1b)
+- *(physics,cfd)* Stage 0 — KS conformal core, constraint projection, blackout coupling seam
+- *(physics)* Gap-3 trajectory-axis spec-readiness + 3 feasibility studies + promoted clock/Kepler kernels
+- *(deep_causality_physics)* make nuclear kernels generic over RealField
+- *(deep_causality_physics)* make condensed-matter kernels generic over RealField
+- *(deep_causality_physics)* add Park-2T hypersonic reacting/ionization kernels
+- *(deep_causality_physics)* removed unused deps
+- *(deep_causality_physics)* opt-in Quasi-Monte-Carlo collapse for the uncertain inflow
+- *(cfd)* scaffold deep_causality_cfd and migrate the fluid stack + tests
+- *(deep_causality_physics)* staircase-vs-aperture-resolved no-slip toggle + cylinder validation harness
+- *(deep_causality_physics)* wire aperture-resolved immersed no-slip into the DEC solver
+- *(deep_causality_physics)* one-sided wall-normal friction diagnostic (Kirkpatrick true Δh)
+- *(deep_causality_physics)* free outflow tangential edges (zero-gradient outflow)
+- *(deep_causality_physics)* pressure surface-force diagnostic on cut bodies
+- *(deep_causality_physics)* free-slip / far-field boundary zone
+- *(deep_causality_physics)* inflow/outflow boundary zones + open-projection wiring
+- *(deep_causality_physics)* inflow/outflow boundary zones + open-projection wiring
+- *(deep_causality_physics)* composable boundary-zone abstraction (static dispatch)
+- *(deep_causality_physics)* CFD Stage-4 Group C — the uncertain-inflow zone
+- *(cfd)* Small-cut-cell stabilization — CFD Stage 4 B1–B3 (cell-merging; inherent stability finding)
+- *(cfd)* Cut-cell cylinder wake harness — CFD Stage 4 Group D
+- feat(deep_causality_physics):
+- feat(deep_causality_physics):
+- *(deep_causality_physics)* Add the wall-bounded DEC Navier-Stokes
+- *(deep_causality_fft)* Add FFT crate, deep_causality_par, and the spectral Poisson solve (closes add-fft)
+- *(deep_causality_physics)* Update  readme with parallel flag.
+- *(deep_causality_physics)* Add the periodic DEC-native incompressible
+- *(deep_causality_physics)* Add typed fluid-dynamics form units incl. the
+
+### Fixed
+
+- *(haft)* [**breaking**] align law docs with proved theory; make effect-system reference impl lawful
+- *(deep_causality_rand)* Format and linting
+- *(deep_causality_physics)* Fixed bazel test config
+- *(deep_causality_topology)* Diagnosis (2026-06-12, task 1.3 — budget probe on the 32³ Re-1600 trajectory): hypothesis (1) confirmed. The convective power ⟨u, −i_u(du)⟩_M is exactly zero on the smooth single-mode initial state (−9e-16), turns positive as the spectrum fills (+0.59 at t* 3.1, +28 at 7.9), and overwhelms the viscous sink (always properly negative) at t* ≈ 8.5 — energy growth follows.
+- fixed sone doctest warnings
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(deep_causality_physics)* fixed miri test failures.
+- *(physics,tensor,file)* skip Miri-incompatible tests
+- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
+- strengthen physics quantity assertions and fix review nits
+- *(deep_causality_physics)* split quantity tests into per-quantity leaves
+- *(deep_causality_physics)* close reachable coverage gaps; document the rest
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- Merge remote-tracking branch 'origin/main'
+- *(deep_causality_physics)* updated README
+- *(deep_causality_physics)* [**breaking**] remove the fluid-dynamics theories (consolidated into deep_causality_cfd)
+- *(dec-solver)* warm-start the λ (cut-face multiplier) block in the weighted projection
+- *(dec-solver)* projection CG warm-start + cycle-mean cylinder drag
+- *(deep_causality_physics)* cross-domain UncertainBoundarySource
+- *(deep_causality_physics)* Improved testing.
+- *(deep_causality_physics)* Verify the convective-instability fix —
+- added new specs to fix a bug
+- *(deep_causality_topology)* Add compiled DEC stencil tables and the
+- *(deep_causality_num)* Add table-based fast path for Float106::sin_cos
+- *(deep_causality_topology)* Add DEC solver benchmark, eliminate
+- *(deep_causality_topology)* Memoize boundary matrices and preserve
+- *(deep_causality_physics)* Consolidate quantity tests into tests/quantities/
+- *(deep_causality_physics)* Consolidate quantities to 13 coherent files (19 → 13)
+- *(deep_causality_physics)* Consolidate all quantities into src/quantities/
+
 ## [0.6.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.6.2...deep_causality_physics-v0.6.3) - 2026-06-12
 
 ### Other

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.6.3"
+version = "0.7.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -52,11 +52,11 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"
@@ -68,7 +68,7 @@ version = "0.5"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
@@ -84,7 +84,7 @@ version = "0.1"
 
 [dependencies.deep_causality_rand]
 path = "../deep_causality_rand"
-version = "0.1"
+version = "0.2"
 optional = true
 
 [dependencies.deep_causality_sparse]
@@ -93,11 +93,11 @@ version = "0.2"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"
-version = "0.6"
+version = "0.7"
 
 [dependencies.deep_causality_par]
 path = "../deep_causality_par"

--- a/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.1.16...deep_causality_rand-v0.2.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_rand)* Sobol sequence + inverse-CDF transforms for QMC
+- *(deep_causality_rand)* Generalize the distribution surface from Float to Real
+- *(deep_causality_num)* removed chacha20 csprng to remove unsafe code.
+
+### Fixed
+
+- *(deep_causality_rand)* Format and linting
+- *(deep_causality_rand)* Fixed miri test config
+- *(deep_causality_rand)* Fixed miri test config
+- *(deep_causality_rand)* Fixed miri test config
+
+### Other
+
+- Fixed dependencies version in various crate to fix CI auto release.
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.1.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.1.15...deep_causality_rand-v0.1.16) - 2026-06-09
 
 ### Added

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.1.16"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -26,7 +26,7 @@ exclude = [
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"

--- a/deep_causality_sparse/CHANGELOG.md
+++ b/deep_causality_sparse/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.0...deep_causality_sparse-v0.2.1) - 2026-07-08
+
+### Added
+
+- *(deep_causality_topology)* Add wall substrate - DCT transforms,
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(cfd)* finalize deep_causality_cfd + Flow DSL design and spec
+- *(dec-solver)* projection CG warm-start + cycle-mean cylinder drag
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.1.8...deep_causality_sparse-v0.2.0) - 2026-06-09
 
 ### Added

--- a/deep_causality_sparse/Cargo.toml
+++ b/deep_causality_sparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_sparse"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -35,7 +35,7 @@ tensor-iso = ["dep:deep_causality_tensor"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dependencies.deep_causality_algebra]
@@ -45,11 +45,11 @@ default-features = false
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 default-features = false
 optional = true
 

--- a/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.4.4...deep_causality_tensor-v0.5.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_tensor)* complete the tensor-train operator algebra
+- *(deep_causality_tensor)* randomize-then-orthogonalize TT round + precision-generic RNG
+- *(deep_causality_tensor)* adaptive randomized TT-rounding
+- *(deep_causality_tensor)* tensor-network benchmarks (group 7) + spec sync
+- *(deep_causality_tensor)* complex Hermitian eigensolver — solve::eigen at Complex
+- *(deep_causality_tensor)* complex TT solvers — AMEn linear, ALS fit, TDVP
+- *(deep_causality_tensor)* complex TT-cross (ConjugateScalar)
+- *(deep_causality_tensor)* complex matrix-product operators (ConjugateScalar)
+- *(deep_causality_tensor)* complex tensor-train state layer (ConjugateScalar)
+- *(deep_causality_num,deep_causality_tensor)* complex-capable SVD/QR kernels via ConjugateScalar
+- *(deep_causality_tensor)* tensor-network Stage 3 — two-site TDVP2 time step
+- *(deep_causality_tensor)* tensor-network Stage 3 — DMRG3S eigensolver
+- *(deep_causality_tensor)* tensor-network Stage 2c — ALS solve engine + integrate
+- *(deep_causality_tensor)* tensor-network Stage 2b — TT-cross + apply_nonlinear
+- *(deep_causality_tensor)* tensor-network Stage 2a — CausalTensorTrainOperator (MPO)
+- *(deep_causality_tensor)* tensor-network Stage 1 — CausalTensorTrain (MPS) state
+- *(deep_causality_tensor)* tensor-network Stage 0 — truncated SVD, QR, Truncation
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(physics,tensor,file)* skip Miri-incompatible tests
+- *(deep_causality_tensor)* fused Hadamard-round, inner buffer reuse, crossover study
+- *(deep_causality_tensor)* Updated README.md
+- *(deep_causality_tensor)* tensor-network — document Stage-4 scalar generality
+- *(deep_causality_tensor)* tensor-network Stage 4 — Dual<f64> forward-mode AD
+- *(deep_causality_tensor)* tensor-network — AMEn linear solve + algorithm citations
+- *(openspec)* Added specs for tensor network.
+- *(deep_causality_tensor)* Improve test coverage
+- Generated new SBOM for all crates.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.4.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.4.3...deep_causality_tensor-v0.4.4) - 2026-06-09
 
 ### Added

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_tensor"
-version = "0.4.4"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -29,11 +29,11 @@ version = "0.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"

--- a/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.6.1...deep_causality_topology-v0.7.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_topology)* opt-in deterministic cut-cell iteration order
+- *(deep_causality_physics)* wire aperture-resolved immersed no-slip into the DEC solver
+- *(deep_causality_physics)* one-sided wall-normal friction diagnostic (Kirkpatrick true Δh)
+- *(deep_causality_topology)* aperture-resolved cut-face no-slip — geometry + weighted KKT projector
+- *(deep_causality_topology)* net-flux open-boundary Leray projection
+- *(cfd)* Small-cut-cell stabilization — CFD Stage 4 B1–B3 (cell-merging; inherent stability finding)
+- *(cfd)* Cut-cell cylinder wake harness — CFD Stage 4 Group D
+- feat(deep_causality_topology):
+- *(cfd)* Cut cells flow through the DEC NS solver via a registry-aware Hodge star — Stage 4 B5
+- *(deep_causality_topology)* Cut-aware Hodge star — CFD Stage 4 Group B foundation
+- *(deep_causality_topology)* Cut-cell geometry substrate — CFD Stage 4 Group A (add-cut-cells-and-immersed-boundaries)
+- *(deep_causality_topology)* Add graded (variable-spacing) metric constructors — CFD R1
+- *(deep_causality_physics)* Add the wall-bounded DEC Navier-Stokes
+- *(deep_causality_topology)* Add wall substrate - DCT transforms,
+- *(deep_causality_fft)* Add FFT crate, deep_causality_par, and the spectral Poisson solve (closes add-fft)
+- *(deep_causality_topology)* Add DEC exterior algebra, de Rham transfer,
+
+### Fixed
+
+- *(haft)* [**breaking**] align law docs with proved theory; make effect-system reference impl lawful
+- *(deep_causality_topology)* Fixed bazel test config
+- *(deep_causality_topology)* Diagnosis (2026-06-12, task 1.3 — budget probe on the 32³ Re-1600 trajectory): hypothesis (1) confirmed. The convective power ⟨u, −i_u(du)⟩_M is exactly zero on the smooth single-mode initial state (−9e-16), turns positive as the spectrum fills (+0.59 at t* 3.1, +28 at 7.9), and overwhelms the viscous sink (always properly negative) at t* ≈ 8.5 — energy growth follows.
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- *(deep_causality_topology)* close reachable coverage gaps; document defensive remainder
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(dec-solver)* warm-start the λ (cut-face multiplier) block in the weighted projection
+- *(dec-solver)* projection CG warm-start + cycle-mean cylinder drag
+- *(openspec)* Drop fix-graded-convective-consistency — premise superseded by findings
+- *(deep_causality_topology)* Verify operator convergence on graded metrics — CFD R1 (B1)
+- *(deep_causality_topology)* Memoize the diagonal Hodge star to take
+- *(deep_causality_topology)* Add compiled DEC stencil tables and the
+- *(deep_causality_num)* Add table-based fast path for Float106::sin_cos
+- *(deep_causality_topology)* Add DEC solver benchmark, eliminate
+- *(deep_causality_topology)* Memoize boundary matrices and preserve
+
 ## [0.6.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.6.0...deep_causality_topology-v0.6.1) - 2026-06-09
 
 ### Added

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.6.1"
+version = "0.7.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -40,7 +40,7 @@ optional = true
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dependencies.deep_causality_num_complex]
@@ -64,7 +64,7 @@ default-features = false
 
 [dependencies.deep_causality_rand]
 path = "../deep_causality_rand"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_sparse]
 path = "../deep_causality_sparse"
@@ -73,11 +73,11 @@ default-features = false
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.4"
+version = "0.5"
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"

--- a/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.3.16...deep_causality_uncertain-v0.4.0) - 2026-07-08
+
+### Added
+
+- *(deep_causality_uncertain)* QmcSampler as an alternative Sampler
+- *(deep_causality_uncertain)* deterministic sampler seeding (seed_sampler / clear_sampler_seed)
+- *(deep_causality_uncertain)* Generalize the uncertain engine over RealField (Float106)
+
+### Fixed
+
+- *(deep_causality_uncertain)* Fixed miri test config
+- *(deep_causality_uncertain)* Fixed miri test config
+- *(deep_causality_uncertain)* Fixed miri test config
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
+- raise test coverage across 8 crates.
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- *(deep_causality_uncertain)* QmcSampler::new takes &Uncertain<T>; root_node() is crate-internal
+- *(deep_causality_uncertain)* Generalize the lift, sampling, and statistics surface over the value type
+- *(deep_causality_uncertain)* Make lift_to_uncertain generic over ProbabilisticType
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.3.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.3.15...deep_causality_uncertain-v0.3.16) - 2026-06-09
 
 ### Other

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.3.16"
+version = "0.4.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -21,7 +21,7 @@ os-random = ["deep_causality_rand/os-random"]
 
 [dependencies.deep_causality_rand]
 path = "../deep_causality_rand"
-version = "0.1"
+version = "0.2"
 
 
 [package.metadata.docs.rs]
@@ -33,7 +33,7 @@ version = "0.1"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.3"
+version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.1...ultragraph-v0.9.2) - 2026-07-08
+
+### Other
+
+- *(num)* split deep_causality_num into num-core + algebra + complex + dual
+- Generated new SBOM for all crates.
+- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
+- Updated README file across multiple crates to meet project standard.
+
 ## [0.9.1](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.0...ultragraph-v0.9.1) - 2026-06-09
 
 ### Other

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.1"
+version = "0.9.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_ast`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `deep_causality_haft`: 0.3.3 -> 0.4.0 (⚠ API breaking changes)
* `deep_causality_core`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `deep_causality_data_structures`: 0.10.14 -> 0.10.15 (✓ API compatible changes)
* `deep_causality_num`: 0.3.3 -> 0.4.0 (⚠ API breaking changes)
* `deep_causality_algebra`: 0.1.0
* `deep_causality_rand`: 0.1.16 -> 0.2.0 (⚠ API breaking changes)
* `deep_causality_uncertain`: 0.3.16 -> 0.4.0 (⚠ API breaking changes)
* `ultragraph`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `deep_causality`: 0.13.10 -> 0.14.0 (⚠ API breaking changes)
* `deep_causality_par`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.0
* `deep_causality_num_dual`: 0.1.0
* `deep_causality_tensor`: 0.4.4 -> 0.5.0 (⚠ API breaking changes)
* `deep_causality_fft`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `deep_causality_metric`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `deep_causality_multivector`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `deep_causality_sparse`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `deep_causality_topology`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `deep_causality_calculus`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_physics`: 0.6.3 -> 0.7.0 (⚠ API breaking changes)
* `deep_causality_discovery`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `deep_causality_ethos`: 0.2.7 -> 0.2.8 (✓ API compatible changes)
* `deep_causality_macros`: 0.9.4 -> 0.9.5 (✓ API compatible changes)

### ⚠ `deep_causality_haft` breaking changes

```text
--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait deep_causality_haft::Promonad, previously in file /tmp/.tmpXhd66L/deep_causality_haft/src/promonad/mod.rs:22
```

### ⚠ `deep_causality_core` breaking changes

```text
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field CausalEffectPropagationProcess.outcome in /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:57

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum deep_causality_core::EffectValue, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/effect_value/mod.rs:28

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant CausalityErrorEnum:IoError in /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/errors/causality_error.rs:53

--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_const_removed.ron

Failed in:
  CausalEffectPropagationProcess::value in /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/getters.rs:23
  CausalEffectPropagationProcess::error in /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/getters.rs:62

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  CausalEffectPropagationProcess::from_effect_value, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:214
  CausalEffectPropagationProcess::from_effect_value_with_log, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:236
  CausalFlow::intervene, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_flow/intervene.rs:19
  CausalFlow::intervene_if, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_flow/intervene.rs:32

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field value of struct CausalEffectPropagationProcess, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:43
  field state of struct CausalEffectPropagationProcess, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:45
  field context of struct CausalEffectPropagationProcess, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:47
  field error of struct CausalEffectPropagationProcess, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:49
  field logs of struct CausalEffectPropagationProcess, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:51

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field CausalEffectPropagationProcess.state in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:55
  field CausalEffectPropagationProcess.context in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:55
  field CausalEffectPropagationProcess.logs in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_core/src/types/causal_effect_propagation_process/mod.rs:55

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait deep_causality_core::Intervenable, previously in file /tmp/.tmpXhd66L/deep_causality_core/src/traits/intervenable/mod.rs:27
```

### ⚠ `deep_causality_num` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function deep_causality_num::iso::test_support::assert_iso_from_round_trip, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:50
  function deep_causality_num::iso::witness::test_support::assert_witness_division_algebra_iso_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:162
  function deep_causality_num::iso::test_support::assert_algebra_iso_from_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:149
  function deep_causality_num::iso::test_support::assert_ring_iso_from_laws, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:95
  function deep_causality_num::utils_tests::utils_complex_tests::assert_approx_eq, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_complex_tests.rs:8
  function deep_causality_num::iso::witness::test_support::assert_witness_ring_iso_laws, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:93
  function deep_causality_num::iso::test_support::assert_field_iso_from_laws, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:130
  function deep_causality_num::utils_tests::utils_octonion_tests::assert_approx_eq, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_octonion_tests.rs:8
  function deep_causality_num::iso::witness::test_support::assert_witness_iso_round_trip, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:52
  function deep_causality_num::iso::test_support::assert_group_iso_from_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:77
  function deep_causality_num::iso::witness::test_support::assert_witness_field_iso_laws, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:127
  function deep_causality_num::iso::witness::test_support::assert_witness_group_iso_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:77
  function deep_causality_num::iso::test_support::assert_division_algebra_iso_from_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:174
  function deep_causality_num::utils_tests::utils_complex_tests::assert_complex_approx_eq, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_complex_tests.rs:18
  function deep_causality_num::utils_tests::utils_octonion_tests::assert_octonion_approx_eq, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_octonion_tests.rs:18
  function deep_causality_num::iso::witness::test_support::assert_witness_algebra_iso_law, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:144

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod deep_causality_num::iso::group_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/group_iso.rs:6
  mod deep_causality_num::iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/mod.rs:6
  mod deep_causality_num::iso::witness::test_support, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/test_support.rs:6
  mod deep_causality_num::iso::witness::iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/iso.rs:6
  mod deep_causality_num::iso::division_algebra_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/division_algebra_iso.rs:6
  mod deep_causality_num::utils_tests::utils_complex_tests, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_complex_tests.rs:5
  mod deep_causality_num::iso::witness::ring_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/ring_iso.rs:6
  mod deep_causality_num::iso::test_support, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/test_support.rs:6
  mod deep_causality_num::utils_tests::utils_octonion_tests, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/utils_octonion_tests.rs:5
  mod deep_causality_num::iso::witness::division_algebra_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/division_algebra_iso.rs:6
  mod deep_causality_num::iso::witness::standard, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/standard.rs:6
  mod deep_causality_num::iso::witness, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/mod.rs:6
  mod deep_causality_num::iso::witness::field_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/field_iso.rs:6
  mod deep_causality_num::iso::algebra_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/algebra_iso.rs:6
  mod deep_causality_num::utils_tests, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/utils_tests/mod.rs:5
  mod deep_causality_num::iso::witness::group_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/group_iso.rs:6
  mod deep_causality_num::iso::ring_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/ring_iso.rs:6
  mod deep_causality_num::iso::witness::algebra_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/algebra_iso.rs:6
  mod deep_causality_num::iso::field_iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/field_iso.rs:6

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct deep_causality_num::iso::witness::standard::StandardIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/standard.rs:59
  struct deep_causality_num::iso::witness::StandardIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/standard.rs:59
  struct deep_causality_num::Quaternion, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/complex/quaternion_number/mod.rs:21
  struct deep_causality_num::Octonion, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/complex/octonion_number/mod.rs:83
  struct deep_causality_num::Complex, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/complex/complex_number/mod.rs:43
  struct deep_causality_num::Dual, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/dual/dual_number/mod.rs:44

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait deep_causality_num::AssociativeAlgebra, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/algebra_assoc.rs:29
  trait deep_causality_num::Rotation, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/rotation.rs:11
  trait deep_causality_num::iso::algebra_iso::AlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/algebra_iso.rs:46
  trait deep_causality_num::iso::AlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/algebra_iso.rs:46
  trait deep_causality_num::AlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/algebra_iso.rs:46
  trait deep_causality_num::AddMagma, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/magma.rs:16
  trait deep_causality_num::AssociativeRing, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/ring_associative.rs:27
  trait deep_causality_num::Group, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/group.rs:33
  trait deep_causality_num::AddMonoid, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/monoid.rs:24
  trait deep_causality_num::ComplexField, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/field_complex.rs:33
  trait deep_causality_num::iso::group_iso::GroupIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/group_iso.rs:50
  trait deep_causality_num::iso::GroupIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/group_iso.rs:50
  trait deep_causality_num::GroupIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/group_iso.rs:50
  trait deep_causality_num::AssociativeDivisionAlgebra, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/algebra_assoc_div.rs:27
  trait deep_causality_num::iso::witness::ring_iso::RingIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/ring_iso.rs:23
  trait deep_causality_num::iso::witness::RingIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/ring_iso.rs:23
  trait deep_causality_num::Associative, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/associative.rs:20
  trait deep_causality_num::iso::witness::algebra_iso::AlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/algebra_iso.rs:38
  trait deep_causality_num::iso::witness::AlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/algebra_iso.rs:38
  trait deep_causality_num::Ring, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/ring.rs:35
  trait deep_causality_num::Module, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/module.rs:33
  trait deep_causality_num::Normed, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/normed.rs:16
  trait deep_causality_num::RealField, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/field_real.rs:20
  trait deep_causality_num::DivGroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/group_div.rs:17
  trait deep_causality_num::AddGroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/group_add.rs:23
  trait deep_causality_num::MulSemigroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/semigroup.rs:47
  trait deep_causality_num::MulMagma, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/magma.rs:23
  trait deep_causality_num::iso::witness::division_algebra_iso::DivisionAlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/division_algebra_iso.rs:41
  trait deep_causality_num::iso::witness::DivisionAlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/division_algebra_iso.rs:41
  trait deep_causality_num::Real, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/real.rs:28
  trait deep_causality_num::iso::ring_iso::RingIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/ring_iso.rs:31
  trait deep_causality_num::iso::RingIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/ring_iso.rs:31
  trait deep_causality_num::RingIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/ring_iso.rs:31
  trait deep_causality_num::Field, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/field.rs:38
  trait deep_causality_num::AbelianGroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/group_abelian.rs:27
  trait deep_causality_num::iso::witness::field_iso::FieldIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/field_iso.rs:31
  trait deep_causality_num::iso::witness::FieldIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/field_iso.rs:31
  trait deep_causality_num::InvMonoid, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/monoid.rs:67
  trait deep_causality_num::Commutative, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/commutative.rs:20
  trait deep_causality_num::Scalar, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/scalar.rs:29
  trait deep_causality_num::iso::division_algebra_iso::DivisionAlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/division_algebra_iso.rs:37
  trait deep_causality_num::iso::DivisionAlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/division_algebra_iso.rs:37
  trait deep_causality_num::DivisionAlgebraIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/division_algebra_iso.rs:37
  trait deep_causality_num::CommutativeRing, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/ring_commutative.rs:30
  trait deep_causality_num::iso::witness::iso::Iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/iso.rs:67
  trait deep_causality_num::iso::witness::Iso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/iso.rs:67
  trait deep_causality_num::Algebra, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/algebra_base.rs:48
  trait deep_causality_num::EuclideanDomain, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/domain_euclidean.rs:35
  trait deep_causality_num::AddSemigroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/semigroup.rs:23
  trait deep_causality_num::MulGroup, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/group_mul.rs:24
  trait deep_causality_num::iso::witness::group_iso::GroupIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/group_iso.rs:34
  trait deep_causality_num::iso::witness::GroupIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/witness/group_iso.rs:34
  trait deep_causality_num::Distributive, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/distributive.rs:8
  trait deep_causality_num::iso::field_iso::FieldIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/field_iso.rs:33
  trait deep_causality_num::iso::FieldIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/field_iso.rs:33
  trait deep_causality_num::FieldIso, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/iso/field_iso.rs:33
  trait deep_causality_num::MulMonoid, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/monoid.rs:45
  trait deep_causality_num::DivisionAlgebra, previously in file /tmp/.tmpXhd66L/deep_causality_num/src/algebra/algebra_div.rs:23

--- failure trait_removed_supertrait: supertrait removed or renamed ---

Description:
A supertrait was removed from a trait. Users of the trait can no longer assume it can also be used like its supertrait.
        ref: https://doc.rust-lang.org/reference/items/traits.html#supertraits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_removed_supertrait.ron

Failed in:
  supertrait deep_causality_num::Ring of trait Integer in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_num/src/integer/mod.rs:38
```

### ⚠ `deep_causality_rand` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant RngError:UnsupportedDimension in /tmp/.tmpVbtK9r/deep_causality/deep_causality_rand/src/errors/rng_error.rs:13

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature aead-random in the package's Cargo.toml
  feature chacha20poly1305 in the package's Cargo.toml
  feature zeroize in the package's Cargo.toml

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod deep_causality_rand::types::misc::map, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/misc/map.rs:6
  mod deep_causality_rand::types::misc::iter, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/misc/iter.rs:6
  mod deep_causality_rand::types::distr::uniform::uniform_u32, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/distr/uniform/uniform_u32.rs:6
  mod deep_causality_rand::types::misc, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/misc/mod.rs:5

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct deep_causality_rand::types::misc::iter::Iter, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/misc/iter.rs:9
  struct deep_causality_rand::types::ChaCha20Rng, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/rand/chacha_rng.rs:17
  struct deep_causality_rand::types::distr::uniform::uniform_u32::UniformU32, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/distr/uniform/uniform_u32.rs:11
  struct deep_causality_rand::types::misc::map::Map, previously in file /tmp/.tmpXhd66L/deep_causality_rand/src/types/misc/map.rs:9
```

### ⚠ `deep_causality_uncertain` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant UncertainNodeContent:DistributionF106 in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/computation/uncertain_node_content/mod.rs:47
  variant SampledValue:DoubleFloat in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/cache/sampled_value.rs:23

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  deep_causality_uncertain::ComparisonOperator::apply takes 1 generic types instead of 0, in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/computation/operator/comparison_operator.rs:20
  deep_causality_uncertain::ArithmeticOperator::apply takes 1 generic types instead of 0, in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/computation/operator/arithmetic_operator.rs:21

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  Sampler::sample now takes 2 instead of 1 parameters, in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/traits/sampler/mod.rs:15

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait UniformDistributionParams (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/distribution_parameters/uniform_distribution_params.rs:11
  trait NormalDistributionParams (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/distribution_parameters/normal_distribution_params.rs:12

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct UniformDistributionParams (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/distribution_parameters/uniform_distribution_params.rs:11
  Struct NormalDistributionParams (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_uncertain/src/types/distribution_parameters/normal_distribution_params.rs:12
```

### ⚠ `deep_causality` breaking changes

```text
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ActionParameterValue::ContextualLink, previously in file /tmp/.tmpXhd66L/deep_causality/src/types/csm_types/csm_parameter/action_parameter_value/mod.rs:19
```

### ⚠ `deep_causality_tensor` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant CausalTensorError:BondDimensionMismatch in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:22
  variant CausalTensorError:NotCanonical in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:24
  variant CausalTensorError:RankExceeded in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:26
  variant CausalTensorError:CrossSampleFailure in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:28
  variant CausalTensorError:SweepDidNotConverge in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:30

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  CausalTensorError::EinSumError moved from position 11 to 16, in /tmp/.tmpVbtK9r/deep_causality/deep_causality_tensor/src/errors/causal_tensor_error.rs:32
```

### ⚠ `deep_causality_algorithms` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BrcdConfig.config_strategy in /tmp/.tmpVbtK9r/deep_causality/deep_causality_algorithms/src/causal_discovery/brcd/brcd_config.rs:68
  field BrcdConfig.config_strategy in /tmp/.tmpVbtK9r/deep_causality/deep_causality_algorithms/src/causal_discovery/brcd/brcd_config.rs:68
  field BrcdConfig.config_strategy in /tmp/.tmpVbtK9r/deep_causality/deep_causality_algorithms/src/causal_discovery/brcd/brcd_config.rs:68
  field BrcdConfig.config_strategy in /tmp/.tmpVbtK9r/deep_causality/deep_causality_algorithms/src/causal_discovery/brcd/brcd_config.rs:68
```

### ⚠ `deep_causality_physics` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function deep_causality_physics::theories::fluid_dynamics::incompressible_ns_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/incompressible_ns.rs:45
  function deep_causality_physics::fluid_dynamics::incompressible_ns_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/incompressible_ns.rs:45
  function deep_causality_physics::theories::incompressible_ns_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/incompressible_ns.rs:45
  function deep_causality_physics::incompressible_ns_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/incompressible_ns.rs:45
  function deep_causality_physics::euler_momentum_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1042
  function deep_causality_physics::theories::fluid_dynamics::compressible_ns_continuity_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:43
  function deep_causality_physics::fluid_dynamics::compressible_ns_continuity_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:43
  function deep_causality_physics::theories::compressible_ns_continuity_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:43
  function deep_causality_physics::compressible_ns_continuity_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:43
  function deep_causality_physics::compressible_ns_momentum_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1099
  function deep_causality_physics::theories::fluid_dynamics::euler_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/euler.rs:36
  function deep_causality_physics::fluid_dynamics::euler_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/euler.rs:36
  function deep_causality_physics::theories::euler_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/euler.rs:36
  function deep_causality_physics::euler_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/euler.rs:36
  function deep_causality_physics::stokes_momentum_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1063
  function deep_causality_physics::theories::fluid_dynamics::compressible_ns_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:63
  function deep_causality_physics::fluid_dynamics::compressible_ns_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:63
  function deep_causality_physics::theories::compressible_ns_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:63
  function deep_causality_physics::compressible_ns_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:63
  function deep_causality_physics::compressible_ns_energy_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1124
  function deep_causality_physics::incompressible_ns_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1011
  function deep_causality_physics::theories::fluid_dynamics::stokes_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/stokes.rs:33
  function deep_causality_physics::fluid_dynamics::stokes_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/stokes.rs:33
  function deep_causality_physics::theories::stokes_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/stokes.rs:33
  function deep_causality_physics::stokes_momentum_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/stokes.rs:33
  function deep_causality_physics::compressible_ns_continuity_rhs, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/fluids/wrappers.rs:1084
  function deep_causality_physics::theories::fluid_dynamics::compressible_ns_energy_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:97
  function deep_causality_physics::fluid_dynamics::compressible_ns_energy_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:97
  function deep_causality_physics::theories::compressible_ns_energy_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:97
  function deep_causality_physics::compressible_ns_energy_rhs_kernel, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/compressible_ns.rs:97

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types (e.g. via turbofish syntax) will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function wilson_loop_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:263
  function cahn_hilliard_flux_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/phase.rs:126
  function cahn_hilliard_flux_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/phase.rs:126
  function effective_band_drude_weight (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:80
  function foppl_von_karman_strain (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:149
  function gell_mann_matrices (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:37
  function effective_band_drude_weight_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:179
  function effective_band_drude_weight_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:179
  function covariant_derivative_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:168
  function running_coupling_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:375
  function quasi_qgt (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:55
  function quantum_geometric_tensor_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:45
  function quantum_geometric_tensor_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:45
  function foppl_von_karman_strain_simple (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:130
  function quasi_qgt_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:135
  function quasi_qgt_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/qgt.rs:135
  function cahn_hilliard_flux (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:197
  function foppl_von_karman_strain_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:277
  function foppl_von_karman_strain_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:277
  function all_structure_constants (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:135
  function ginzburg_landau_free_energy_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/phase.rs:44
  function ginzburg_landau_free_energy_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/phase.rs:44
  function confinement_potential_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:327
  function bistritzer_macdonald_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:55
  function bistritzer_macdonald_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:55
  function quantum_geometric_tensor (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:30
  function bistritzer_macdonald (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:107
  function foppl_von_karman_strain_simple_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:206
  function foppl_von_karman_strain_simple_kernel (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/moire.rs:206
  function ginzburg_landau_free_energy (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/condensed/wrappers.rs:174
  function structure_constant (0 -> 1 generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/kernels/nuclear/qcd.rs:95

--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_const_removed.ron

Failed in:
  LundParameters::kappa in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:467
  LundParameters::lund_a in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:472
  LundParameters::lund_b in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:477
  LundParameters::sigma_pt in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:482
  LundParameters::strange_suppression in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:487
  LundParameters::diquark_suppression in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:492
  LundParameters::vector_meson_fraction in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:497
  LundParameters::min_invariant_mass in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:502

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod deep_causality_physics::theories::fluid_dynamics, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/mod.rs:6
  mod deep_causality_physics::fluid_dynamics, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/theories/fluid_dynamics/mod.rs:6
  mod deep_causality_physics::chronometric_quantities, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/chronometric/chronometric_quantities.rs:5

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct deep_causality_physics::chronometric_quantities::SpaceTimeCoordinate, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/chronometric/chronometric_quantities.rs:58
  struct deep_causality_physics::chronometric_quantities::CentralBody, previously in file /tmp/.tmpXhd66L/deep_causality_physics/src/kernels/chronometric/chronometric_quantities.rs:18

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait ChemicalPotentialGradient (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:368
  trait QuantumEigenvector (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:271
  trait OrderParameter (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:247
  trait VectorPotential (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:383
  trait LundParameters (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:400
  trait Displacement (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:324
  trait Concentration (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:340
  trait Momentum (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:303
  trait QuantumVelocity (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:288

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct ChemicalPotentialGradient (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:368
  Struct QuantumEigenvector (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:271
  Struct OrderParameter (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:247
  Struct VectorPotential (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:383
  Struct LundParameters (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/nuclear/mod.rs:400
  Struct Displacement (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:324
  Struct Concentration (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:340
  Struct Momentum (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:303
  Struct QuantumVelocity (0 -> 1 required generic types) in /tmp/.tmpVbtK9r/deep_causality/deep_causality_physics/src/quantities/condensed/mod.rs:288
```

### ⚠ `deep_causality_discovery` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant BrcdLoadError:Learning in /tmp/.tmpVbtK9r/deep_causality/deep_causality_discovery/src/errors/brcd_load_error.rs:25

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait deep_causality_discovery::Precision gained ToPrimitive in file /tmp/.tmpVbtK9r/deep_causality/deep_causality_discovery/src/traits/precision.rs:23
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_ast`

<blockquote>

## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.7...deep_causality_ast-v0.1.8) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- Generated new SBOM for all crates.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.3.3...deep_causality_haft-v0.4.0) - 2026-07-08

### Added

- *(haft)* add the free monad on a functor (algebraic-effects base)
- *(formalization)* formalize deep_causality_haft in Lean + mirrored Rust witnesses
- *(deep_causality_haft)* formatting
- *(deep_causality_haft)* add lazy IoAction effect (the Arrow twin)
- *(deep_causality_haft)* To reorganize source code structure

### Fixed

- *(haft)* [**breaking**] align law docs with proved theory; make effect-system reference impl lawful

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- Code formatting and linting.
- Fixed multiple issues in the HAFT formalization.
- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
- chorde(deep_causality_haft); reorganized source code
- Generated new SBOM for all crates.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.11.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.10.0...deep_causality_core-v0.11.0) - 2026-07-08

### Added

- *(file,cfd)* CFD file IO seams — typed tables, sensor traces, snapshot/resume
- *(deep_causality_core)* file IO actions + CausalFlow read/write bridge

### Fixed

- *(deep_causality_core)* make success-channel functor/applicative total across all witnesses
- *(core)* make the value-level functor total over commands; address refactor review
- fixed sone doctest warnings

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(deep_causality_core)* assert command leaf value in fmap consistency test
- code formatting and linting
- *(Formalization)* Removed Kani run
- *(core)* formalize deep_causality_core in Lean 4 (all 26 core.* ids proved + witnessed)
- Code lintint and formatting.
- *(core)* [**breaking**] replace EffectValue with the CausalEffect free monad; one Kleisli bind + state-threading arrow
- *(core)* [**breaking**] thread state through the causal arrow (D2, one bind)
- *(core)* [**breaking**] causal-arrow lawfulness + replace Intervenable with alternate_value
- *(formalization)* [**breaking**] close out enforce-w-invariant — proofs, witnesses, CI
- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
- *(formalization)* scaffold Lean proof project + Rust witness bridge
- Generated new SBOM for all crates.
- Updated README file across multiple crates to meet project standard.

### Changed

- **[BREAKING]** *(deep_causality_core)* `CausalEffectPropagationProcess` now encodes value-XOR-error
  as a single **private** channel `outcome: Result<EffectValue<Value>, Error>` instead of the two
  public fields `value: EffectValue<Value>` and `error: Option<Error>`. This enforces the W-invariant
  (`error present ⇒ no value`) structurally — the "value AND error" state is no longer representable —
  so the monad's **right-identity law now holds unconditionally** (it previously discarded data on
  errored carriers). Machine-checked in `lean/DeepCausalityFormal/Core/CausalMonad.lean` + Kani.
  All fields (`outcome`, `state`, `context`, `logs`) are private. Migration:
  - **Construct** via `CausalEffectPropagationProcess::new(outcome, state, context, logs)` (or the
    `PropagatingEffect` / `PropagatingProcess` aliases), or the named constructors (`pure`,
    `from_value`, `from_effect_value`, `from_error`, `none`, `with_state`, …) — struct literals no
    longer compile. `outcome` is `Ok(EffectValue::…)` or `Err(err)`.
  - **Decompose** by value via `into_parts() -> (Result<EffectValue<Value>, Error>, State, Option<Context>, Log)`.
  - **Read** via getters: `value() -> Option<&Value>` (the carried scalar — `Some` only for
    `EffectValue::Value`), `value_cloned()` / `into_value()` (owned scalar, borrowing / consuming),
    `effect() -> Option<&EffectValue<Value>>` (the full wrapper, for `RelayTo` / `None` /
    `ContextualLink` / `Map` discrimination), `error() -> Option<&Error>`, `outcome()`, `state()`,
    `context()`, `logs()`. (`is_ok()` / `is_err()` are unchanged and generalized to all `State` /
    `Context`.)
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.15](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.14...deep_causality_data_structures-v0.10.15) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- Generated new SBOM for all crates.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_num`

<blockquote>

## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.3.3...deep_causality_num-v0.4.0) - 2026-07-08

### Added

- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)
- *(deep_causality_num)* generic monoid tower + verdict carrier (num-generic-monoid-tower)
- *(deep_causality_num)* Added default to dual type.
- *(deep_causality_num,deep_causality_tensor)* complex-capable SVD/QR kernels via ConjugateScalar
- *(deep_causality_tensor)* tensor-network Stage 1 — CausalTensorTrain (MPS) state
- *(deep_causality_num)* double-double erf/erfc for Float106

### Fixed

- *(formalization)* repair Lean Core build + review follow-ups
- *(deep_causality_num)* Fixed miri test config
- *(deep_causality_num)* Fixed miri test config
- *(deep_causality_num)* Fixed miri test config
- *(deep_causality_num)* Fixed miri test config

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- *(formalization)* scaffold Lean proof project + Rust witness bridge
- *(deep_causality_num)* [**breaking**] remove unused EuclideanDomain trait
- *(deep_causality_tensor)* tensor-network — document Stage-4 scalar generality
- *(deep_causality_num)* restructured internal code modules.
- Generated new SBOM for all crates.
- *(deep_causality_num)* skip cos_val under Miri
- Updated README file across multiple crates to meet project standard.
- *(deep_causality_num)* Add table-based fast path for Float106::sin_cos
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_algebra-v0.1.0) - 2026-07-08

### Added

- *(lean)* formalize the extracted num/algebra/complex/dual crates (L1)

### Fixed

- address code-review findings (graph-reasoning docs/test, stale doc example, clippy)

### Other

- Fixed dependencies version in various crate to fix CI auto release.
- code formatting and linting.
- rename the Lean layer Num → Algebra to mirror the new crate.
- *(num)* split deep_causality_num into num-core + algebra + complex + dual
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.1.16...deep_causality_rand-v0.2.0) - 2026-07-08

### Added

- *(deep_causality_rand)* Sobol sequence + inverse-CDF transforms for QMC
- *(deep_causality_rand)* Generalize the distribution surface from Float to Real
- *(deep_causality_num)* removed chacha20 csprng to remove unsafe code.

### Fixed

- *(deep_causality_rand)* Format and linting
- *(deep_causality_rand)* Fixed miri test config
- *(deep_causality_rand)* Fixed miri test config
- *(deep_causality_rand)* Fixed miri test config

### Other

- Fixed dependencies version in various crate to fix CI auto release.
- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- Generated new SBOM for all crates.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.3.16...deep_causality_uncertain-v0.4.0) - 2026-07-08

### Added

- *(deep_causality_uncertain)* QmcSampler as an alternative Sampler
- *(deep_causality_uncertain)* deterministic sampler seeding (seed_sampler / clear_sampler_seed)
- *(deep_causality_uncertain)* Generalize the uncertain engine over RealField (Float106)

### Fixed

- *(deep_causality_uncertain)* Fixed miri test config
- *(deep_causality_uncertain)* Fixed miri test config
- *(deep_causality_uncertain)* Fixed miri test config

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- raise test coverage across 8 crates.
- Generated new SBOM for all crates.
- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
- *(deep_causality_uncertain)* QmcSampler::new takes &Uncertain<T>; root_node() is crate-internal
- *(deep_causality_uncertain)* Generalize the lift, sampling, and statistics surface over the value type
- *(deep_causality_uncertain)* Make lift_to_uncertain generic over ProbabilisticType
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.2](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.1...ultragraph-v0.9.2) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- Generated new SBOM for all crates.
- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality`

<blockquote>

## [0.14.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.13.10...deep_causality-v0.14.0) - 2026-07-08

### Added

- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-4)
- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-3)
- *(deep_causality)* labeled fan-in wire-slot engine + join API (comonoid-graph-join 1-3)
- *(deep_causality)* add opt-in freeze_dag() to enforce DAG structure
- *(examples)* add example_ml_rca

### Fixed

- address code-review findings (graph-reasoning docs/test, stale doc example, clippy)
- *(deep_causality)* principled graph sequen