### PR TITLE
Update Cargo.toml

### DIFF
--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Marvin Hansen <marvin.hansen@gmail.com>", ]
 description = "Dual number type (forward-mode automatic differentiation) for deep_causality."
 documentation = "https://docs.rs/deep_causality_num_dual"
 categories = ["development-tools", "mathematics"]
-keywords = ["dual-number", "automatic-differentiation", "autodiff"]
+keywords = ["dual-number", "automatic-diff", "autodiff"]
 # Exclude all bazel files as these conflict with Bazel workspace when vendored.
 exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore",".bazelrc", "tests/**/*"]
 


### PR DESCRIPTION
Fixed "too long keyword"

## Describe your changes

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened a crate keyword in `deep_causality_num_dual/Cargo.toml` to meet crates.io limits and unblock publishing. Replaced "automatic-differentiation" with "automatic-diff".

<sup>Written for commit c800e35e365dd00f3ccd44672afe4fcd99089c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

