### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_dual"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",

--- a/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.1...deep_causality_file-v0.1.2) - 2026-07-08
+
+### Other
+
+- release
+
 ## [0.1.1](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_file-v0.1.1) - 2026-07-08
 
 ### Added

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.2...deep_causality_num_complex-v0.1.3) - 2026-07-08
+
+### Other
+
+- release
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.1...deep_causality_num_complex-v0.1.2) - 2026-07-08
 
 ### Other

--- a/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.2...deep_causality_num_dual-v0.1.3) - 2026-07-08
+
+### Other
+
+- release
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.0...deep_causality_num_dual-v0.1.2) - 2026-07-08
 
 ### Other

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_dual"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num_complex`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_num_dual`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_file`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_physics`: 0.6.3 -> 0.7.0
* `deep_causality_discovery`: 0.4.1 -> 0.5.0
* `deep_causality_ethos`: 0.2.7 -> 0.2.8
* `deep_causality_macros`: 0.9.4 -> 0.9.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num_complex`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.2...deep_causality_num_complex-v0.1.3) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.2...deep_causality_num_dual-v0.1.3) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.1...deep_causality_file-v0.1.2) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.6.3...deep_causality_physics-v0.7.0) - 2026-07-08

### Added

- *(cfd,physics,file,examples)* study DSL (sweep, Gates, run_owned, duct_march) + three gated examples
- *(cfd,physics,examples)* finite-rate ionization network, two-stage counterfactual sweep, review fixes, MDAO positioning
- *(physics,cfd,avionics_examples)* uncalibrated finite-rate ionization network (lever 3)
- *(cfd)* navigation engine (Stage 2) — ESKF + regime switch, in the CFD crate
- *(physics)* synthetic sensors + closed-loop nav gate (Stage 2.2)
- *(physics)* cohesive ReentryNavEngine — KS + ESKF + two-clock (Stage 2.1c)
- *(physics)* 17-state ESKF covariance + measurement update (Stage 2.1b)
- *(physics)* strapdown-INS error state + drift laws — nav-engine core (Stage 2.1a)
- *(cfd)* BodyFittedCoordinate3d — spherical-shell fitted 3-D metric (Stage 1.1b)
- *(physics,cfd)* Stage 0 — KS conformal core, constraint projection, blackout coupling seam
- *(physics)* Gap-3 trajectory-axis spec-readiness + 3 feasibility studies + promoted clock/Kepler kernels
- *(deep_causality_physics)* make nuclear kernels generic over RealField
- *(deep_causality_physics)* make condensed-matter kernels generic over RealField
- *(deep_causality_physics)* add Park-2T hypersonic reacting/ionization kernels
- *(deep_causality_physics)* removed unused deps
- *(deep_causality_physics)* opt-in Quasi-Monte-Carlo collapse for the uncertain inflow
- *(cfd)* scaffold deep_causality_cfd and migrate the fluid stack + tests
- *(deep_causality_physics)* staircase-vs-aperture-resolved no-slip toggle + cylinder validation harness
- *(deep_causality_physics)* wire aperture-resolved immersed no-slip into the DEC solver
- *(deep_causality_physics)* one-sided wall-normal friction diagnostic (Kirkpatrick true Δh)
- *(deep_causality_physics)* free outflow tangential edges (zero-gradient outflow)
- *(deep_causality_physics)* pressure surface-force diagnostic on cut bodies
- *(deep_causality_physics)* free-slip / far-field boundary zone
- *(deep_causality_physics)* inflow/outflow boundary zones + open-projection wiring
- *(deep_causality_physics)* inflow/outflow boundary zones + open-projection wiring
- *(deep_causality_physics)* composable boundary-zone abstraction (static dispatch)
- *(deep_causality_physics)* CFD Stage-4 Group C — the uncertain-inflow zone
- *(cfd)* Small-cut-cell stabilization — CFD Stage 4 B1–B3 (cell-merging; inherent stability finding)
- *(cfd)* Cut-cell cylinder wake harness — CFD Stage 4 Group D
- feat(deep_causality_physics):
- feat(deep_causality_physics):
- *(deep_causality_physics)* Add the wall-bounded DEC Navier-Stokes
- *(deep_causality_fft)* Add FFT crate, deep_causality_par, and the spectral Poisson solve (closes add-fft)
- *(deep_causality_physics)* Update  readme with parallel flag.
- *(deep_causality_physics)* Add the periodic DEC-native incompressible
- *(deep_causality_physics)* Add typed fluid-dynamics form units incl. the

### Fixed

- *(haft)* [**breaking**] align law docs with proved theory; make effect-system reference impl lawful
- *(deep_causality_rand)* Format and linting
- *(deep_causality_physics)* Fixed bazel test config
- *(deep_causality_topology)* Diagnosis (2026-06-12, task 1.3 — budget probe on the 32³ Re-1600 trajectory): hypothesis (1) confirmed. The convective power ⟨u, −i_u(du)⟩_M is exactly zero on the smooth single-mode initial state (−9e-16), turns positive as the spectrum fills (+0.59 at t* 3.1, +28 at 7.9), and overwhelms the viscous sink (always properly negative) at t* ≈ 8.5 — energy growth follows.
- fixed sone doctest warnings

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(deep_causality_physics)* fixed miri test failures.
- *(physics,tensor,file)* skip Miri-incompatible tests
- *(core)* [**breaking**] enforce the W-invariant — value-XOR-error as one channel
- strengthen physics quantity assertions and fix review nits
- *(deep_causality_physics)* split quantity tests into per-quantity leaves
- *(deep_causality_physics)* close reachable coverage gaps; document the rest
- raise test coverage across 8 crates.
- Generated new SBOM for all crates.
- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
- Merge remote-tracking branch 'origin/main'
- *(deep_causality_physics)* updated README
- *(deep_causality_physics)* [**breaking**] remove the fluid-dynamics theories (consolidated into deep_causality_cfd)
- *(dec-solver)* warm-start the λ (cut-face multiplier) block in the weighted projection
- *(dec-solver)* projection CG warm-start + cycle-mean cylinder drag
- *(deep_causality_physics)* cross-domain UncertainBoundarySource
- *(deep_causality_physics)* Improved testing.
- *(deep_causality_physics)* Verify the convective-instability fix —
- added new specs to fix a bug
- *(deep_causality_topology)* Add compiled DEC stencil tables and the
- *(deep_causality_num)* Add table-based fast path for Float106::sin_cos
- *(deep_causality_topology)* Add DEC solver benchmark, eliminate
- *(deep_causality_topology)* Memoize boundary matrices and preserve
- *(deep_causality_physics)* Consolidate quantity tests into tests/quantities/
- *(deep_causality_physics)* Consolidate quantities to 13 coherent files (19 → 13)
- *(deep_causality_physics)* Consolidate all quantities into src/quantities/
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.4.1...deep_causality_discovery-v0.5.0) - 2026-07-08

### Added

- *(deep_causality_discovery)* learn-once, rank-many CPDAG cache for BRCD

### Fixed

- *(deep_causality_discovery)* version-tag CPDAG cache key; correct Precision doc
- *(brcd,discovery)* address QA findings (32-bit shift, DRY, Precision bound)
- fixed sone doctest warnings
- *(deep_causality_discovery)* fixed bazel test config.

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- *(deep_causality_algorithms)* parallelize BRCD across candidates; add BRCD eval harnesses + companion papers
- raise test coverage across 8 crates.
- Generated new SBOM for all crates.
- Merge branch 'deepcausality-rs:main' into main
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.7...deep_causality_ethos-v0.2.8) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- *(readme)* use absolute raw URLs for logo images
- Restructured the avionics example folder.
- Generated new SBOM for all crates.
- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_macros`

<blockquote>

## [0.9.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_macros-v0.9.4...deep_causality_macros-v0.9.5) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- Generated new SBOM for all crates.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare patch releases for `deep_causality_num_complex`, `deep_causality_num_dual`, and `deep_causality_file`. No breaking changes; version bumps and CHANGELOG updates only.

- **Dependencies**
  - Bumped `deep_causality_num_complex` to 0.1.3 and `deep_causality_num_dual` to 0.1.3.
  - Bumped `deep_causality_file` to 0.1.2.
  - Updated CHANGELOGs and synced `Cargo.lock`.

<sup>Written for commit 1ae74dae275d91df49f94251e43ccc5f55fc97e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

