### PR TITLE
fix(deep_causality_physics): Fixing 10MB max upload limit on crates.io

### DIFF
--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -31,6 +31,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -13,8 +13,18 @@ repository = "https://github.com/deepcausality/deep_causality.rs"
 keywords = ["surd", "causal-graph", "causal-reasoning", "algorithms"]
 categories = ["algorithms", "science", "aerospace", "finance", "mathematics"]
 authors = ["Marvin Hansen <marvin.hansen@gmail.com>", ]
-exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore",".bazelrc", "tests/**/*"]
-
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -12,8 +12,18 @@ documentation = "https://docs.rs/deep_causality"
 categories = ["data-structures", "science"]
 keywords = ["data-structures", "ast"]
 # Exclude all bazel files as these conflict with Bazel workspace when vendored.
-exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore",".bazelrc", "tests/**/*"]
-
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [lints]
 workspace = true

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -26,6 +26,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 [package.metadata.docs.rs]

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 [features]

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -32,6 +32,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 [dependencies.deep_causality_haft]

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -12,7 +12,18 @@ documentation = "https://docs.rs/deep_causality_num_dual"
 categories = ["development-tools", "mathematics"]
 keywords = ["dual-number", "automatic-diff", "autodiff"]
 # Exclude all bazel files as these conflict with Bazel workspace when vendored.
-exclude = ["*.bazel", "*/*.bazel",  "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore",".bazelrc", "tests/**/*"]
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [features]
 default = ["std"]

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
 
 [features]

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -22,7 +22,9 @@ exclude = [
     ".bazelignore",
     ".bazelrc",
     "tests/**/*",
+    "papers/*",
 ]
+
 [dependencies.deep_causality_ast]
 path = "../deep_causality_ast"
 version = "0.1"

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -11,6 +11,18 @@ documentation = "https://docs.rs/deep_causality_topology"
 readme = "README.md"
 keywords = ["causality", "topology", "complex", "differential", "geometry"]
 categories = ["science", "mathematics"]
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [lib]
 name = "deep_causality_topology"

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -9,8 +9,18 @@ repository = "https://github.com/deepcausality/deep_causality.rs"
 authors = ["Marvin Hansen <marvin.hansen@gmail.com>", ]
 description = "A First-Order Type for Uncertain Programming for the DeepCausality project.'"
 documentation = "https://docs.rs/deep_causality"
-exclude = ["*.bazel", "*/*.bazel", "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore", ".bazelrc", "tests/**/*"]
-
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [features]
 # Enables random number generator from the host OS for secure random numbers.

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -15,8 +15,18 @@ documentation = "https://docs.rs/ultragraph"
 homepage = "https://github.com/deepcausality/deep_causality/tree/main/ultragraph"
 categories = ["data-structures"]
 keywords = ["data-structures"]
-exclude = ["*.bazel", "*/*.bazel", "*.bazel.*", "BUILD", "BUILD.bazel", "MODULE.bazel", ".bazelignore", ".bazelrc", "tests/**/*"]
-
+exclude = [
+    "*.bazel",
+    "*/*.bazel",
+    "*.bazel.*",
+    "BUILD",
+    "BUILD.bazel",
+    "MODULE.bazel",
+    ".bazelignore",
+    ".bazelrc",
+    "tests/**/*",
+    "papers/*",
+]
 
 [dev-dependencies]
 criterion = {  version = "0.8" }


### PR DESCRIPTION
## Describe your changes

fix(deep_causality_physics): Fixing 10MB max upload limit on crates.io

https://github.com/rust-lang/cargo/issues/16921

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `papers/*` from published crates to cut package size and fix 10MB upload failures on crates.io. No runtime changes.

- **Bug Fixes**
  - Added `papers/*` to `exclude` in Cargo.toml across workspace crates (`deep_causality_*`, `ultragraph`) to keep publish tarballs under 10MB.
  - Cleaned up and standardized existing `exclude` lists (Bazel files, tests) for consistent packaging.

<sup>Written for commit ddf9f631e12c8371c92ba237aea3aa97283d28d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

