### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.14.0...deep_causality-v0.14.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.14.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.13.10...deep_causality-v0.14.0) - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "criterion",
  "deep_causality_ast",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "deep_causality_calculus"
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "deep_causality_haft",
 ]
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "deep_causality_macros"
@@ -663,7 +663,7 @@ version = "0.2.3"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -703,7 +703,7 @@ version = "0.1.1"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_tensor"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2147,7 +2147,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.14.0"
+version = "0.14.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.0...deep_causality_algorithms-v0.4.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.3.0...deep_causality_algorithms-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.7...deep_causality_ast-v0.1.8) - 2026-07-08
 
 ### Other

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.11.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.10.0...deep_causality_core-v0.11.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.3.3...deep_causality_haft-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.2...deep_causality_multivector-v0.5.3) - 2026-07-08
 
 ### Added

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.5.3"
+version = "0.5.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.7.0...deep_causality_physics-v0.7.1) - 2026-07-08
+
+### Other
+
+- updated the following local packages: deep_causality_core
+
 ## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.6.3...deep_causality_physics-v0.7.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.7.0"
+version = "0.7.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -53,7 +53,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"

--- a/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.4.4...deep_causality_tensor-v0.5.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_tensor"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.6.1...deep_causality_topology-v0.7.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.7.0"
+version = "0.7.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.4.1) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.3.16...deep_causality_uncertain-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-08
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.9.2](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.1...ultragraph-v0.9.2) - 2026-07-08
 
 ### Other

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.2"
+version = "0.9.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_ast`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `deep_causality_haft`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `deep_causality_core`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `deep_causality_uncertain`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `ultragraph`: 0.9.2 -> 0.9.3 (✓ API compatible changes)
* `deep_causality`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.2 -> 0.1.3
* `deep_causality_num_dual`: 0.1.2 -> 0.1.3
* `deep_causality_tensor`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `deep_causality_multivector`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `deep_causality_topology`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `deep_causality_file`: 0.1.1 -> 0.1.2
* `deep_causality_discovery`: 0.4.1 -> 0.5.0
* `deep_causality_ethos`: 0.2.7 -> 0.2.8
* `deep_causality_macros`: 0.9.4 -> 0.9.5
* `deep_causality_physics`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_ast`

<blockquote>

## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.4.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality`

<blockquote>

## [0.14.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.14.0...deep_causality-v0.14.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.2...deep_causality_num_complex-v0.1.3) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.2...deep_causality_num_dual-v0.1.3) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.0...deep_causality_algorithms-v0.4.1) - 2026-07-08

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.1...deep_causality_file-v0.1.2) - 2026-07-08

### Other

- release
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.4.1...deep_causality_discovery-v0.5.0) - 2026-07-08

### Added

- *(deep_causality_discovery)* learn-once, rank-many CPDAG cache for BRCD

### Fixed

- *(deep_causality_discovery)* version-tag CPDAG cache key; correct Precision doc
- *(brcd,discovery)* address QA findings (32-bit shift, DRY, Precision bound)
- fixed sone doctest warnings
- *(deep_causality_discovery)* fixed bazel test config.

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- *(deep_causality_algorithms)* parallelize BRCD across candidates; add BRCD eval harnesses + companion papers
- raise test coverage across 8 crates.
- Generated new SBOM for all crates.
- Merge branch 'deepcausality-rs:main' into main
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.7...deep_causality_ethos-v0.2.8) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- *(bazel)* register all missing test suites; add Dual Default; move iso test utils to src/utils_tests
- *(readme)* use absolute raw URLs for logo images
- Restructured the avionics example folder.
- Generated new SBOM for all crates.
- *(papers)* Reorganized publication by moving each paper into the crate where it is actually implemented.
- Updated README file across multiple crates to meet project standard.
</blockquote>

## `deep_causality_macros`

<blockquote>

## [0.9.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_macros-v0.9.4...deep_causality_macros-v0.9.5) - 2026-07-08

### Other

- *(num)* split deep_causality_num into num-core + algebra + complex + dual
- Generated new SBOM for all crates.
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.7.0...deep_causality_physics-v0.7.1) - 2026-07-08

### Other

- updated the following local packages: deep_causality_core
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).