### PR TITLE
ci(MIRI): Fixed slow running crates

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) "2023" . The DeepCausality Authors. All Rights Reserved.
+
+# CI-only profile for the Miri workflow (.github/workflows/rust_miri.yml).
+# Local `cargo nextest run` uses the default profile and is unaffected; this
+# profile only activates when invoked with `--profile ci`.
+[profile.ci]
+# Under Miri tests run 100-1000x slower, so `period` is generous. A test that
+# stays slow for `terminate-after` consecutive periods is KILLED and NAMED --
+# turning a multi-hour binary hang into "test X terminated after 6 minutes".
+# Tune `period` up if a legitimately slow Miri test is falsely terminated.
+slow-timeout = { period = "180s", terminate-after = 2 }
+# Miri shadow-memory is heavy; cap parallel test processes so a crate like
+# deep_causality_multivector cannot exhaust runner RAM.
+test-threads = 2
+# A hung-then-killed test is a real failure, not a flake: do not retry it.
+retries = 0

--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -85,6 +85,7 @@ jobs:
             extra_flags: -Zmiri-disable-isolation       # DSL opens files
           - crate: deep_causality_uncertain
             extra_flags: -Zmiri-disable-isolation       # open() in tests/mod.rs binary
+            runner: cargo-test                          # rusty-fork (rusty_fork_test!) is incompatible with nextest
     steps:
       - uses: actions/checkout@v7
 
@@ -93,6 +94,12 @@ jobs:
           rustup toolchain install nightly --component miri --profile minimal
           rustup override set nightly
           cargo miri setup
+
+      # nextest runs each test in its own process, so a single hanging test can
+      # be terminated and NAMED via the `ci` profile's slow-timeout
+      # (.config/nextest.toml) instead of wedging the whole test binary.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -109,5 +116,17 @@ jobs:
         # binaries don't reliably honor the `cfg(miri)` flag cargo-miri sets,
         # so doctest-level skip shims (e.g. `# if cfg!(miri) { return; }`) do
         # not fire. Doctests verify documentation correctness, not UB —
-        # normal CI runs them, so coverage is preserved.
-        run: cargo miri test -p ${{ matrix.crate }} --lib --tests
+        # normal CI runs them, so coverage is preserved. (nextest never runs
+        # doctests, so `--lib --tests` is a no-op there but kept for parity.)
+        #
+        # Default runner is `cargo miri nextest run --profile ci`: one process
+        # per test, so a hang is terminated and named by the slow-timeout in
+        # .config/nextest.toml. deep_causality_uncertain opts out (runner:
+        # cargo-test) because rusty-fork's `rusty_fork_test!` re-execs the test
+        # binary and collides with nextest's process-per-test protocol.
+        run: |
+          if [ "${{ matrix.runner }}" = "cargo-test" ]; then
+            cargo miri test -p ${{ matrix.crate }} --lib --tests
+          else
+            cargo miri nextest run --profile ci -p ${{ matrix.crate }} --lib --tests
+          fi

--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -19,6 +19,12 @@ jobs:
   miri:
     name: cargo miri test
     runs-on: ubuntu-latest
+    # Cap runaway jobs. Miri is nondeterministic across runs (thread scheduling,
+    # ASLR/HashMap seeding, shadow-memory pressure); an unlucky run can wedge a
+    # single crate for hours. Clean crates finish in seconds, so 20 minutes is a
+    # generous ceiling. `fail-fast: false` + the crate matrix already isolate the
+    # blast radius to one job, so a timeout here never affects the other crates.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +67,16 @@ jobs:
         # real time / files.
         include:
           - crate: deep_causality
-            extra_flags: -Zmiri-disable-isolation       # clock_gettime in test setup
+            # -Zmiri-disable-isolation: clock_gettime in test setup.
+            # The weak-memory + preemption flags tame the one genuine concurrency
+            # test (test_evolve_error_on_poisoned_context_lock spawns a thread that
+            # panics under a write lock, then joins). Under Miri's weak-memory
+            # emulation an unlucky scheduling seed can spin that RwLock/join path
+            # for hours. Disabling weak-memory emulation and pinning preemption to 0
+            # removes that nondeterminism. This disables *detection* of weak-memory
+            # ordering bugs only — no memory-safety check is weakened, and the test
+            # is a lock-poisoning assertion, not a lock-free algorithm.
+            extra_flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
           - crate: deep_causality_core
             extra_flags: -Zmiri-disable-isolation       # EffectLog::add_entry -> SystemTime::now (log_effect.rs:57)
           - crate: deep_causality_file
@@ -86,7 +101,10 @@ jobs:
 
       - name: Run Miri
         env:
-          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check ${{ matrix.extra_flags }}
+          # -Zmiri-seed=0 pins Miri's per-run nondeterminism (thread interleaving,
+          # ASLR, HashMap seeding) so runs are reproducible. If a crate still times
+          # out at a fixed seed, the cause is the runner environment, not the code.
+          MIRIFLAGS: -Zmiri-seed=0 -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check ${{ matrix.extra_flags }}
         # `--lib --tests` excludes doctests: rustdoc-synthesized doctest
         # binaries don't reliably honor the `cfg(miri)` flag cargo-miri sets,
         # so doctest-level skip shims (e.g. `# if cfg!(miri) { return; }`) do


### PR DESCRIPTION
## Describe your changes

ap runaway jobs and pin Miri nondeterminism

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Miri CI by capping runaway jobs, pinning Miri’s randomness, and running tests per-test with `cargo-nextest` so hung tests are named and killed. This cuts multi-hour wedges down to minutes and makes failures reproducible.

- **Bug Fixes**
  - Add `timeout-minutes: 20` to the Miri job; matrix stays isolated with `fail-fast: false`.
  - Pin `-Zmiri-seed=0` in `MIRIFLAGS` for reproducible runs.
  - Run via `cargo miri nextest run --profile ci`; add `.config/nextest.toml` with `slow-timeout = { period = "180s", terminate-after = 2 }`, `test-threads = 2`, `retries = 0`.
  - For `deep_causality`, add `-Zmiri-disable-weak-memory-emulation` and `-Zmiri-preemption-rate=0`; keep `-Zmiri-disable-isolation` where clock/file access is needed.
  - Exclude doctests; run `deep_causality_uncertain` with `cargo test` due to `rusty-fork` incompatibility with `cargo-nextest`.

<sup>Written for commit fcd16f70015ff37e834e0d542c13b2a9a15c8d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

