### PR TITLE
test(miri): ignore compute-heavy FFT/multivector tests; fix nextest period

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,7 +9,7 @@
 # stays slow for `terminate-after` consecutive periods is KILLED and NAMED --
 # turning a multi-hour binary hang into "test X terminated after 6 minutes".
 # Tune `period` up if a legitimately slow Miri test is falsely terminated.
-slow-timeout = { period = "180s", terminate-after = 2 }
+slow-timeout = { period = "360s", terminate-after = 2 }
 # Miri shadow-memory is heavy; cap parallel test processes so a crate like
 # deep_causality_multivector cannot exhaust runner RAM.
 test-threads = 2

--- a/.github/workflows/rust_miri.yml
+++ b/.github/workflows/rust_miri.yml
@@ -24,7 +24,7 @@ jobs:
     # single crate for hours. Clean crates finish in seconds, so 20 minutes is a
     # generous ceiling. `fail-fast: false` + the crate matrix already isolate the
     # blast radius to one job, so a timeout here never affects the other crates.
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,6 @@ jobs:
           - deep_causality_fft
           - deep_causality_file
           - deep_causality_haft
-          - deep_causality_macros
           - deep_causality_metric
           - deep_causality_multivector
           - deep_causality_num
@@ -83,6 +82,8 @@ jobs:
             extra_flags: -Zmiri-disable-isolation       # Needs file open / write access
           - crate: deep_causality_discovery
             extra_flags: -Zmiri-disable-isolation       # DSL opens files
+          - crate: deep_causality_multivector
+            extra_flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
           - crate: deep_causality_uncertain
             extra_flags: -Zmiri-disable-isolation       # open() in tests/mod.rs binary
             runner: cargo-test                          # rusty-fork (rusty_fork_test!) is incompatible with nextest

--- a/deep_causality/tests/mod.rs
+++ b/deep_causality/tests/mod.rs
@@ -6,6 +6,7 @@
 mod errors;
 #[cfg(not(miri))]
 mod extensions;
+#[cfg(not(miri))]
 mod formalization_lean;
 #[cfg(not(miri))]
 mod traits;

--- a/deep_causality_algebra/tests/mod.rs
+++ b/deep_causality_algebra/tests/mod.rs
@@ -4,5 +4,6 @@
  */
 mod algebra;
 mod float106;
+#[cfg(not(miri))]
 mod formalization_lean;
 mod iso;

--- a/deep_causality_core/tests/mod.rs
+++ b/deep_causality_core/tests/mod.rs
@@ -3,6 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 mod errors;
+#[cfg(not(miri))]
 mod formalization_lean;
 mod iso;
 mod traits;

--- a/deep_causality_fft/tests/types/fft_plan/fft_plan_tests.rs
+++ b/deep_causality_fft/tests/types/fft_plan/fft_plan_tests.rs
@@ -45,6 +45,10 @@ fn test_small_kernels_match_naive() {
 }
 
 #[test]
+// Ignored under Miri: the O(n^2) naive-DFT reference at n up to 1024 is
+// interpreter-pathological (>6 min). The Stockham kernel's UB is covered under
+// Miri by the O(n log n) round-trip test; full correctness runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_stockham_powers_of_two_match_naive() {
     for n in [64usize, 128, 256, 512, 1024] {
         assert_matches_naive_f64(n, 1e-9);
@@ -52,6 +56,10 @@ fn test_stockham_powers_of_two_match_naive() {
 }
 
 #[test]
+// Ignored under Miri: the O(n^2) naive-DFT reference at n up to 1009 is
+// interpreter-pathological (>6 min). The Bluestein kernel's UB is covered under
+// Miri by the O(n log n) round-trip test; full correctness runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_bluestein_lengths_match_naive() {
     // Primes and composites that are not powers of two, including ones
     // below the small-kernel cutoff.

--- a/deep_causality_fft/tests/types/fft_plan_nd/fft_plan_nd_tests.rs
+++ b/deep_causality_fft/tests/types/fft_plan_nd/fft_plan_nd_tests.rs
@@ -73,6 +73,10 @@ fn test_3d_matches_naive() {
 }
 
 #[test]
+// Ignored under Miri: the N-D naive-DFT reference over a 16x32x8 grid is
+// O(N^2) in the 4096-point volume (~56 s under Miri). The N-D FFT walk's UB is
+// covered under Miri by the round-trip tests; full correctness runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_anisotropic_shape_matches_naive() {
     // Unequal axis lengths, including a non-power-of-two axis
     // (Bluestein inside the N-D walk).

--- a/deep_causality_fft/tests/types/fft_plan_nd/fft_plan_nd_tests.rs
+++ b/deep_causality_fft/tests/types/fft_plan_nd/fft_plan_nd_tests.rs
@@ -111,6 +111,10 @@ fn test_round_trip_16_cubed() {
 }
 
 #[test]
+// Ignored under Miri: a 32x32x32 = 32768-point 3-D FFT round-trip is ~117 s
+// under Miri (large buffer + allocation churn). The N-D walk's UB is covered
+// under Miri by the smaller-shape tests; full correctness runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_round_trip_32_cubed() {
     let shape = [32usize, 32, 32];
     let n = 32 * 32 * 32;

--- a/deep_causality_fft/tests/types/rfft_plan_nd/rfft_plan_nd_tests.rs
+++ b/deep_causality_fft/tests/types/rfft_plan_nd/rfft_plan_nd_tests.rs
@@ -72,6 +72,10 @@ fn test_1d_shape() {
 }
 
 #[test]
+// Ignored under Miri: the 32x32x32 = 32768-point real N-D round-trip is ~72 s
+// under Miri (large buffer + allocation churn). The real N-D walk's UB is
+// covered under Miri by the smaller-shape tests; full correctness runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_round_trip_3d() {
     for shape in [[16usize, 16, 16], [8, 4, 32], [32, 32, 32]] {
         let n: usize = shape.iter().product();

--- a/deep_causality_multivector/tests/alias/alias_hilbert_ket_bridge_tests.rs
+++ b/deep_causality_multivector/tests/alias/alias_hilbert_ket_bridge_tests.rs
@@ -51,6 +51,10 @@ fn test_to_ket_from_ket_round_trip_cl02() {
 }
 
 #[test]
+// Ignored under Miri: Cl(0,10) has 2^10 = 1024 blades and the D=32 matrix-rep
+// round-trip is ~9 s natively -> hours under Miri. The from_ket/to_ket UB path
+// is covered under Miri by the small Cl(0,2) case; full check runs in normal CI.
+#[cfg_attr(miri, ignore)]
 fn test_to_ket_from_ket_round_trip_cl010() {
     let metric = Metric::NonEuclidean(10); // Cl(0,10), D = 32
     let v = pseudo_random_ket(32);

--- a/deep_causality_num/tests/mod.rs
+++ b/deep_causality_num/tests/mod.rs
@@ -6,6 +6,7 @@ mod casts;
 mod float;
 mod float_double;
 mod float_option;
+#[cfg(not(miri))]
 mod formalization_lean;
 mod identity;
 mod integer;

--- a/deep_causality_num_complex/tests/mod.rs
+++ b/deep_causality_num_complex/tests/mod.rs
@@ -4,4 +4,5 @@
  */
 mod algebra_impls;
 mod complex;
+#[cfg(not(miri))]
 mod formalization_lean;

--- a/deep_causality_num_dual/tests/mod.rs
+++ b/deep_causality_num_dual/tests/mod.rs
@@ -4,4 +4,5 @@
  */
 mod algebra_impls;
 mod dual;
+#[cfg(not(miri))]
 mod formalization_lean;


### PR DESCRIPTION
## Describe your changes

 ignore compute-heavy FFT/multivector tests; fix nextest period

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Miri runs by skipping compute-heavy FFT and multivector tests and tuning timeouts. Keeps UB coverage with smaller, faster tests and fixes the nextest slow-timeout.

- **Bug Fixes**
  - Ignore O(n^2) naive-DFT comparison tests under Miri in `deep_causality_fft` and the large `Cl(0,10)` round-trip in `deep_causality_multivector`; small O(n log n) round-trips still run.
  - Gate `formalization_lean` tests behind `#[cfg(not(miri))]` across `deep_causality`, `deep_causality_algebra`, `deep_causality_core`, `deep_causality_num`, `deep_causality_num_complex`, and `deep_causality_num_dual`.
  - Gate two additional FFI tests under `#[cfg(not(miri))]` to avoid Miri-incompatible paths.
  - Increase nextest slow-timeout period to "360s" to reduce false terminations.

- **CI**
  - Raise Miri job timeout to 30 minutes.
  - Add `-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0` for `deep_causality_multivector`.
  - Remove `deep_causality_macros` from the Miri matrix.

<sup>Written for commit 8b85df9035fc75576cad1d4691d89f8788c9f9c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

