### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.14.0...deep_causality-v0.15.0) - 2026-07-14
+
+### Added
+
+- *(deep_causality)* the Context hypergraph — parent-set threading = bind, acyclicity a separable freeze gate
+- *(deep_causality)* relay-round composition — multi-round adaptive evaluation is sequential Kleisli composition of rounds
+- *(deep_causality)* causaloid-layer theorems — collection permutation-invariance + the F-3 command-input theorem
+- *(deep_causality)* the keystone — evaluate is the unique catamorphism, per fixed carrier (roadmap Stage 5)
+- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
+- *(deep_causality_core)* formalize the carrier stack — transformer stack, fold universality, relay termination (roadmap Stage 1)
+
+### Fixed
+
+- *(deep_causality)* Miri config
+- *(deep_causality)* reject out-of-range state_writers in freeze_verified
+- *(deep_causality)* satisfy clippy::for_kv_map in eval_all_states
+- *(deep_causality_algebra)* CommutativeMonoid requires the Commutative marker
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- Merge remote-tracking branch 'origin/main'
+- Improved test coverage.
+- drop Aeneas / L4 from the verification program (non-goal)
+- *(num)* add crate-local Lean verification status notes for the numeric tower
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.14.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.13.10...deep_causality-v0.14.0) - 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -533,14 +533,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algebra"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "deep_causality_num",
 ]
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -554,11 +554,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -590,14 +590,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "deep_causality_algebra",
 ]
@@ -663,11 +663,11 @@ version = "0.9.5"
 
 [[package]]
 name = "deep_causality_metric"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -680,14 +680,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_dual"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -703,11 +703,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_sparse"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_tensor"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2170,7 +2170,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.14.0"
+version = "0.15.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -43,11 +43,11 @@ os-random = ["deep_causality_uncertain/os-random"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"
-version = "0.4"
+version = "0.5"
 
 [dependencies.deep_causality_ast]
 path = "../deep_causality_ast"

--- a/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_algebra/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14
+
+### Added
+
+- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Fixed
+
+- *(deep_causality_algebra)* CommutativeMonoid requires the Commutative marker
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- Improved test coverage.
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.0...deep_causality_algebra-v0.1.1) - 2026-07-08
 
 ### Other

--- a/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algebra"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.0...deep_causality_algorithms-v0.4.1) - 2026-07-14
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- Improved test coverage.
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.3.0...deep_causality_algorithms-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -36,7 +36,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"

--- a/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.7...deep_causality_ast-v0.1.8) - 2026-07-08
 
 ### Other

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.1...deep_causality_calculus-v0.1.2) - 2026-07-08
 
 ### Other

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -42,7 +42,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -58,7 +58,7 @@ parallel = [
 
 [dependencies.deep_causality_physics]
 path = "../deep_causality_physics"
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [dependencies.deep_causality_calculus]
@@ -83,7 +83,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
@@ -101,7 +101,7 @@ version = "0.5"
 # sample cache. Gated behind `std` so the `alloc`-only build stays uncertain-free.
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dependencies.deep_causality_topology]

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
+
+### Added
+
+- *(deep_causality_core)* formalize the carrier stack — transformer stack, fold universality, relay termination (roadmap Stage 1)
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- build(bazel)P: Updated Bazel config
+- Improved test coverage.
+- drop Aeneas / L4 from the verification program (non-goal)
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.11.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.10.0...deep_causality_core-v0.11.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.10.15](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.14...deep_causality_data_structures-v0.10.15) - 2026-07-08
 
 ### Other

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.15"
+version = "0.10.16"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.4.1...deep_causality_discovery-v0.5.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -38,7 +38,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.8...deep_causality_ethos-v0.2.9) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Other
+
+- add user-facing SKILLS.md agent file for building with deep_causality
+
 ## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.7...deep_causality_ethos-v0.2.8) - 2026-07-08
 
 ### Other

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.8"
+version = "0.2.9"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -38,7 +38,7 @@ exclude = [
 
 [dependencies.deep_causality]
 path = "../deep_causality"
-version = "0.14"
+version = "0.15"
 
 [dependencies.ultragraph]
 path = "../ultragraph"

--- a/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_fft/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Other
+
+- *(miri)* Gated two more FFI tests to skip MIRI.
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+
 ## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.0...deep_causality_fft-v0.1.1) - 2026-07-08
 
 ### Other

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -45,7 +45,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_num_complex]

--- a/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Other
+
+- Improved test coverage.
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.1...deep_causality_file-v0.1.2) - 2026-07-08
 
 ### Other

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -34,7 +34,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies]
 # External dependencies

--- a/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14
+
+### Added
+
+- *(haft)* add more tests.
+- *(haft)* add EqFunctor/DebugFunctor capability traits + opt-in Eq/Debug for Free
+- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
+- *(deep_causality_haft)* symmetric-monoidal PROP — Δ/ε, ∇/η, σ (H5)
+- *(deep_causality_haft)* one-way interpreter ArrowTerm → Kleisli<M> (H4)
+- *(deep_causality_haft)* reified free Arrow — ArrowTerm (H3)
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+- *(haft)* add Foldable::fold_map (monoidal fold) — H1 of haft-categorical-machinery
+
+### Fixed
+
+- *(deep_causality_haft)* Signed-off-by: Marvin Hansen <marvin.hansen@gmail.com>
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- *(openspec)* propose haft Cofree comonad twin + opt-in Eq/Debug (capability traits)
+- Improved test coverage.
+- drop Aeneas / L4 from the verification program (non-goal)
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.3.3...deep_causality_haft-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -34,7 +34,7 @@ no-std = ["alloc", "deep_causality_algebra/no-std"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [[example]]

--- a/deep_causality_metric/CHANGELOG.md
+++ b/deep_causality_metric/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.3...deep_causality_metric-v0.2.4) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.2...deep_causality_metric-v0.2.3) - 2026-07-08
 
 ### Other

--- a/deep_causality_metric/Cargo.toml
+++ b/deep_causality_metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_metric"
-version = "0.2.3"
+version = "0.2.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14
+
+### Added
+
+- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)
+
+### Fixed
+
+- *(deep_causality_multivector)* Minor fix
+- *(deep_causality_multivector)* Code formatting
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- *(deep_causality_multivector)* updated README
+- Improved test coverage.
+
 ## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.2...deep_causality_multivector-v0.5.3) - 2026-07-08
 
 ### Added

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.5.3"
+version = "0.5.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -36,7 +36,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"

--- a/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Fixed
+
+- *(deep_causality_num)* use core::num::FpCategory; wire haft no_std
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- drop Aeneas / L4 from the verification program (non-goal)
+- *(num)* add crate-local Lean verification status notes for the numeric tower
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.3.3...deep_causality_num-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_num/Cargo.toml
+++ b/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.4.0"
+version = "0.4.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- drop Aeneas / L4 from the verification program (non-goal)
+- *(num)* add crate-local Lean verification status notes for the numeric tower
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.2...deep_causality_num_complex-v0.1.3) - 2026-07-08
 
 ### Other

--- a/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -36,7 +36,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [lints]

--- a/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14
+
+### Other
+
+- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
+- drop Aeneas / L4 from the verification program (non-goal)
+- *(num)* add crate-local Lean verification status notes for the numeric tower
+- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.2...deep_causality_num_dual-v0.1.3) - 2026-07-08
 
 ### Other

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_dual"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -37,7 +37,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [lints]

--- a/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.0...deep_causality_par-v0.1.1) - 2026-07-08
 
 ### Added

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.7.0...deep_causality_physics-v0.8.0) - 2026-07-14
+
+### Added
+
+- *(deep_causality_quantum)* new crate — quantum-information kernels move out of physics (Phase 1)
+
+### Other
+
+- build(bazel)P: Updated Bazel config
+- Improved test coverage.
+
 ## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.6.3...deep_causality_physics-v0.7.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.7.0"
+version = "0.8.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -53,7 +53,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
@@ -73,7 +73,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -38,15 +38,15 @@ qpu = ["dep:deep_causality_uncertain"]
 
 [dependencies.deep_causality]
 path = "../deep_causality"
-version = "0.14"
+version = "0.15"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
@@ -74,7 +74,7 @@ version = "0.5"
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"
-version = "0.4"
+version = "0.5"
 optional = true
 
 [lints]

--- a/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.1.16...deep_causality_rand-v0.2.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.0"
+version = "0.2.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -31,7 +31,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 
 [features]

--- a/deep_causality_sparse/CHANGELOG.md
+++ b/deep_causality_sparse/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.1...deep_causality_sparse-v0.2.2) - 2026-07-14
+
+### Added
+
+- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.0...deep_causality_sparse-v0.2.1) - 2026-07-08
 
 ### Added

--- a/deep_causality_sparse/Cargo.toml
+++ b/deep_causality_sparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_sparse"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -41,7 +41,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_haft]

--- a/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14
+
+### Added
+
+- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)
+
+### Fixed
+
+- *(deep_causality)* code formatting
+- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
+- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
+- *(deep_causality)* Minor fix
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- *(deep_causality_tensor)* Improved testing
+- Improved test coverage.
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.4.4...deep_causality_tensor-v0.5.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_tensor"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -39,7 +39,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"

--- a/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- Improved test coverage.
+
 ## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.6.1...deep_causality_topology-v0.7.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.7.0"
+version = "0.7.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -62,7 +62,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_par]

--- a/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
+
+### Added
+
+- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
+### Other
+
+- strengthen arrow_choice witnesses; fix archived-note paths; clarify Lean scope —
+- Improved test coverage.
+
 ## [0.4.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.3.16...deep_causality_uncertain-v0.4.0) - 2026-07-08
 
 ### Added

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.4.0"
+version = "0.5.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -47,7 +47,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.1"
+version = "0.2"
 
 [dev-dependencies]
 rusty-fork = "0.3"

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
+
+### Fixed
+
+- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
+
 ## [0.9.2](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.1...ultragraph-v0.9.2) - 2026-07-08
 
 ### Other

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.2"
+version = "0.9.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `deep_causality_algebra`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `deep_causality_ast`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `deep_causality_haft`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `deep_causality_core`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.15 -> 0.10.16 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `deep_causality_uncertain`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `ultragraph`: 0.9.2 -> 0.9.3 (✓ API compatible changes)
* `deep_causality`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)
* `deep_causality_par`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_num_dual`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_tensor`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `deep_causality_fft`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_metric`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `deep_causality_multivector`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `deep_causality_sparse`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `deep_causality_topology`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `deep_causality_calculus`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_file`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_physics`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `deep_causality_discovery`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.8 -> 0.2.9 (✓ API compatible changes)

### ⚠ `deep_causality_algebra` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait deep_causality_algebra::CommutativeMonoid gained Commutative in file /tmp/.tmpmYlLc5/deep_causality/deep_causality_algebra/src/algebra/commutative_monoid.rs:20
```

### ⚠ `deep_causality_uncertain` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ArithmeticOperator:Min in /tmp/.tmpmYlLc5/deep_causality/deep_causality_uncertain/src/types/computation/operator/arithmetic_operator.rs:16
  variant ArithmeticOperator:Max in /tmp/.tmpmYlLc5/deep_causality/deep_causality_uncertain/src/types/computation/operator/arithmetic_operator.rs:18
```

### ⚠ `deep_causality` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait deep_causality::Causable gained Sealed in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/mod.rs:16
  trait deep_causality::MonadicCausable gained Sealed in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/mod.rs:30
  trait deep_causality::monadic_collection_utils::Aggregatable gained Verdict in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/utils/monadic_collection_utils.rs:40
  trait deep_causality::StatefulMonadicCausable gained Sealed in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/stateful.rs:39

--- failure trait_newly_sealed: pub trait became sealed ---

Description:
A publicly-visible trait became sealed, so downstream crates are no longer able to implement it
        ref: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_newly_sealed.ron

Failed in:
  trait deep_causality::MonadicCausable in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/mod.rs:30
  trait deep_causality::StatefulMonadicCausable in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/stateful.rs:39
  trait deep_causality::Causable in file /tmp/.tmpmYlLc5/deep_causality/deep_causality/src/traits/causable/mod.rs:16
```

### ⚠ `deep_causality_physics` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function deep_causality_physics::haruna_x_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:234
  function deep_causality_physics::logical_x, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:111
  function deep_causality_physics::haruna_t_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:293
  function deep_causality_physics::logical_cz, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:158
  function deep_causality_physics::born_probability, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:35
  function deep_causality_physics::commutator, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:74
  function deep_causality_physics::born_probability_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:85
  function deep_causality_physics::haruna_x_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:107
  function deep_causality_physics::commutator_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:174
  function deep_causality_physics::haruna_t_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:146
  function deep_causality_physics::haruna_z_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:223
  function deep_causality_physics::logical_z, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:100
  function deep_causality_physics::haruna_cz_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:268
  function deep_causality_physics::logical_hadamard, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:134
  function deep_causality_physics::apply_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:63
  function deep_causality_physics::haruna_z_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:96
  function deep_causality_physics::apply_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:143
  function deep_causality_physics::haruna_cz_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:132
  function deep_causality_physics::haruna_s_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:212
  function deep_causality_physics::haruna_hadamard_gate_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:245
  function deep_causality_physics::logical_s, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:122
  function deep_causality_physics::logical_t, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates_haruna.rs:173
  function deep_causality_physics::expectation_value, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:52
  function deep_causality_physics::haruna_s_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:85
  function deep_causality_physics::expectation_value_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:123
  function deep_causality_physics::haruna_hadamard_gate, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:118
  function deep_causality_physics::fidelity_kernel, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/mechanics.rs:201
  function deep_causality_physics::fidelity, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/wrappers.rs:157

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait deep_causality_physics::QuantumOps, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates.rs:24
  trait deep_causality_physics::QuantumGates, previously in file /tmp/.tmpTXLEDs/deep_causality_physics/src/kernels/quantum/gates.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Fixed

- *(deep_causality_num)* use core::num::FpCategory; wire haft no_std

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- drop Aeneas / L4 from the verification program (non-goal)
- *(num)* add crate-local Lean verification status notes for the numeric tower
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14

### Added

- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Fixed

- *(deep_causality_algebra)* CommutativeMonoid requires the Commutative marker

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- Improved test coverage.
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_ast`

<blockquote>

## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14

### Added

- *(haft)* add more tests.
- *(haft)* add EqFunctor/DebugFunctor capability traits + opt-in Eq/Debug for Free
- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
- *(deep_causality_haft)* symmetric-monoidal PROP — Δ/ε, ∇/η, σ (H5)
- *(deep_causality_haft)* one-way interpreter ArrowTerm → Kleisli<M> (H4)
- *(deep_causality_haft)* reified free Arrow — ArrowTerm (H3)
- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
- *(haft)* add Foldable::fold_map (monoidal fold) — H1 of haft-categorical-machinery

### Fixed

- *(deep_causality_haft)* Signed-off-by: Marvin Hansen <marvin.hansen@gmail.com>
- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- *(openspec)* propose haft Cofree comonad twin + opt-in Eq/Debug (capability traits)
- Improved test coverage.
- drop Aeneas / L4 from the verification program (non-goal)
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14

### Added

- *(deep_causality_core)* formalize the carrier stack — transformer stack, fold universality, relay termination (roadmap Stage 1)

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- build(bazel)P: Updated Bazel config
- Improved test coverage.
- drop Aeneas / L4 from the verification program (non-goal)
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14

### Added

- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- strengthen arrow_choice witnesses; fix archived-note paths; clarify Lean scope —
- Improved test coverage.
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io
</blockquote>

## `deep_causality`

<blockquote>

## [0.15.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.14.0...deep_causality-v0.15.0) - 2026-07-14

### Added

- *(deep_causality)* the Context hypergraph — parent-set threading = bind, acyclicity a separable freeze gate
- *(deep_causality)* relay-round composition — multi-round adaptive evaluation is sequential Kleisli composition of rounds
- *(deep_causality)* causaloid-layer theorems — collection permutation-invariance + the F-3 command-input theorem
- *(deep_causality)* the keystone — evaluate is the unique catamorphism, per fixed carrier (roadmap Stage 5)
- *(deep_causality)* the graph algebra — schedule-invariant ∇∘(Λ⊗Λ) joins + freeze checks (roadmap Stage 4)
- *(deep_causality_core)* formalize the carrier stack — transformer stack, fold universality, relay termination (roadmap Stage 1)

### Fixed

- *(deep_causality)* Miri config
- *(deep_causality)* reject out-of-range state_writers in freeze_verified
- *(deep_causality)* satisfy clippy::for_kv_map in eval_all_states
- *(deep_causality_algebra)* CommutativeMonoid requires the Commutative marker
- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- Merge remote-tracking branch 'origin/main'
- Improved test coverage.
- drop Aeneas / L4 from the verification program (non-goal)
- *(num)* add crate-local Lean verification status notes for the numeric tower
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- drop Aeneas / L4 from the verification program (non-goal)
- *(num)* add crate-local Lean verification status notes for the numeric tower
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- drop Aeneas / L4 from the verification program (non-goal)
- *(num)* add crate-local Lean verification status notes for the numeric tower
- *(openspec)* close out formalize-main-crate — main-crate Lean status note, sync + archive
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14

### Added

- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)

### Fixed

- *(deep_causality)* code formatting
- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
- *(deep_causality)* Minor fix
- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- *(deep_causality_tensor)* Improved testing
- Improved test coverage.
</blockquote>

## `deep_causality_fft`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Other

- *(miri)* Gated two more FFI tests to skip MIRI.
- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
</blockquote>

## `deep_causality_metric`

<blockquote>

## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.3...deep_causality_metric-v0.2.4) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14

### Added

- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)

### Fixed

- *(deep_causality_multivector)* Minor fix
- *(deep_causality_multivector)* Code formatting
- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- *(miri)* ignore compute-heavy FFT/multivector tests; fix nextest period
- *(deep_causality_multivector)* updated README
- Improved test coverage.
</blockquote>

## `deep_causality_sparse`

<blockquote>

## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.1...deep_causality_sparse-v0.2.2) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- Improved test coverage.
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.0...deep_causality_algorithms-v0.4.1) - 2026-07-14

### Fixed

- *(deep_causality_physics)* Fixing 10MB max upload limit on crates.io

### Other

- Improved test coverage.
</blockquote>

## `deep_causality_calculus`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Other

- Improved test coverage.
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.8.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.7.0...deep_causality_physics-v0.8.0) - 2026-07-14

### Added

- *(deep_causality_quantum)* new crate — quantum-information kernels move out of physics (Phase 1)

### Other

- build(bazel)P: Updated Bazel config
- Improved test coverage.
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.8...deep_causality_ethos-v0.2.9) - 2026-07-14

### Added

- *(deep_causality_haft)* add Category + Kleisli (named category, compose = bind) — H2

### Other

- add user-facing SKILLS.md agent file for building with deep_causality
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release the workspace with `deep_causality` v0.15.0, adding the graph algebra and Context hypergraph, and moving quantum kernels to `deep_causality_quantum`. Includes breaking changes in `deep_causality`, `deep_causality_algebra`, `deep_causality_uncertain`, and `deep_causality_physics`.

- **New Features**
  - Graph algebra with schedule‑invariant joins and freeze checks.
  - Context hypergraph and relay‑round composition; evaluate as a catamorphism.
  - Categorical machinery in `deep_causality_haft` (Category/Kleisli, free Arrow).
  - Quantum‑information kernels split out to `deep_causality_quantum`.

- **Migration**
  - Update to `deep_causality` 0.15, `deep_causality_algebra` 0.2, `deep_causality_uncertain` 0.5, `deep_causality_physics` 0.8.
  - `deep_causality_algebra`: `CommutativeMonoid` now requires `Commutative` — adjust trait bounds/impls.
  - `deep_causality`: traits `Causable`, `MonadicCausable`, `StatefulMonadicCausable` are now sealed and gained supertraits — downstream impls must be removed or refactored.
  - `deep_causality_uncertain`: handle new `ArithmeticOperator::{Min, Max}` in exhaustive matches.
  - `deep_causality_physics`: quantum gate/ops APIs were removed — replace imports and calls with `deep_causality_quantum` equivalents.

<sup>Written for commit 91fdeecbbfd5090f50156a7c70d0e003504ded1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

