### PR TITLE
docs(deep_causality_cfd): edited website

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,10 @@ common --reuse_sandbox_directories
 # Debug toolchain resolution
 # build --toolchain_resolution_debug='@bazel_tools//tools/cpp:toolchain_type
 
+# Required to resolve C/C++ toolchain.
+# https://github.com/bazel-contrib/musl-toolchain?tab=readme-ov-file#setup
+build --incompatible_enable_cc_toolchain_resolution
+
 # Required to support cross compilation from different host systems i.e Mac and Linux
 # https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
 common --enable_platform_specific_config
@@ -68,13 +72,36 @@ build:linux --extra_execution_platforms=//build/platforms:linux-x86_64
 ## Remote configuration
 ###############################################################################
 
-# N/A. Add later to configure RBE.
+# Flags shared across remote configs
+common:remote-shared --remote_timeout=600
+common:remote-shared --remote_download_minimal
+common:remote-shared --remote_cache_compression
+common:remote-shared --verbose_failures
+# Avoid inflating blobs smaller than 100 bytes with ZSTD compression.
+common:remote-shared --experimental_remote_cache_compression_threshold=100
+# Enable remote cache chunking
+common:remote-shared--experimental_remote_cache_chunking
+
+# Remote host platform
+# https://github.com/buildbuddy-io/buildbuddy/blob/8579ca30f1a1f401ed8279d99d9b47ec5637873f/.bazelrc#L30
+common:remote-shared --host_platform=//build/platforms:linux_x86_64_remote
+common:remote-shared --extra_execution_platforms=//build/platforms:linux_x86_64_remote
+
+# Remote cross compilation
+common:remote-shared --extra_execution_platforms=//build/platforms:linux-aarch64
+common:remote-shared --extra_execution_platforms=//build/platforms:linux-x86_64
+
+# Build with --config=remote to enable Remote Build Execution (RBE)
+common:remote --config=remote-shared
+common:remote --remote_cache=grpcs://remote.buildbuddy.io
+common:remote --remote_executor=remote.buildbuddy.io
 
 ###############################################################################
-## Custom user flags
+## Custom user or remote flags
 ##
-## This should always be the last thing in the `.bazelrc` file to ensure
-## consistent behavior when setting flags in that file as `.bazelrc` files are
-## evaluated top to bottom.
+## This should always be the last thing in the `.bazelrc` beccause
+# `.bazelrc` files are evaluated top to bottom.
 ###############################################################################
 try-import %workspace%/user.bazelrc
+
+try-import %workspace%/.bazelrc.remote

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -1,0 +1,1 @@
+common --remote_header=x-buildbuddy-api-key=UY5NcW3qrQuWrBvhTLy9

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage
 .cargo/config.toml
 .cargo/config
 
+# Bazel config
+.bazelrc.remote
+
 # Bazel stuff
 /target-bzl/
 /target-bzl/*

--- a/website/README.md
+++ b/website/README.md
@@ -12,7 +12,7 @@ hostname.
 | --- | --- | --- | --- | --- |
 | [`web/`](./web) | Website (home, blog, examples, short getting-started/overview) | Astro (custom) | `deepcausality-prod` | https://www.deepcausality.com |
 | [`docs/`](./docs) | Reference documentation (concepts, guides, overview, single-PDF export) | [Starlight](https://starlight.astro.build) on Astro | `deepcausality-docs` | https://docs.deepcausality.com |
-| [`cfd/`](./cfd) | `deep_causality_cfd`: blueprints, validation status, worked examples, capability boundaries | Astro (custom) | `deepcausality-cfd` | https://cfd.deepcausality.com |
+| [`cfd/`](./cfd) | `deep_causality_cfd`: blueprints, validation status, worked examples, capability boundaries | Astro (custom) | `deep-causality-cfd-prod` | https://cfd.deepcausality.com |
 
 A fourth directory, [`web_design/`](./web_design), is documentation rather
 than a site: it describes the shipped visual system as implemented. The binding
@@ -99,8 +99,7 @@ All three sites are fully static and deployed as Cloudflare Workers Static Asset
 Custom domains are bound in the Cloudflare dashboard. Per-origin caching and
 security headers are configured via each project's `public/_headers` file.
 
-Each Worker's build configuration lives in the Cloudflare dashboard, not in
-this repo, and every project needs the same three settings:
+Each Worker's build configuration lives in the Cloudflare dashboard:
 
 | Setting | Value |
 | --- | --- |
@@ -108,16 +107,24 @@ this repo, and every project needs the same three settings:
 | Build command | `pnpm run build` |
 | Deploy command | `npx wrangler deploy` |
 
-The build command is the one that is easy to leave empty. Cloudflare installs
-dependencies on its own, so a missing build command does not fail the build
-step. It fails later, in the deploy, with `The directory specified by the
-"assets.directory" field in your configuration file does not exist` — because
-nothing ever produced `dist/`.
+Two of these fail quietly, and both cost a debugging session on `cfd/`.
 
-The Worker name in each `wrangler.toml` must match the Worker the build is
-attached to. `wrangler deploy` takes the name from the file, so a mismatch
-deploys to a second Worker that has no custom domain bound, and reports
-success while the live site stays unchanged.
+**An empty build command does not fail the build.** Cloudflare installs
+dependencies by itself, so the build step reports success, and the run dies
+later in the deploy with `The directory specified by the "assets.directory"
+field in your configuration file does not exist`, because nothing produced
+`dist/`. `cfd/wrangler.toml` therefore carries its own `[build]` command;
+wrangler runs it before reading `assets.directory`, so the dashboard field is
+belt-and-braces there rather than load-bearing. `web/` and `docs/` still rely
+on the dashboard field alone.
+
+**A wrong Worker name does not fail either.** `wrangler deploy` takes the name
+from `wrangler.toml`, so a name that does not match the Worker the build is
+attached to creates a second Worker with no custom domain bound, then reports
+success while the live site stays unchanged. Note that the three names do not
+follow one convention: `deepcausality-prod`, `deepcausality-docs`, and
+`deep-causality-cfd-prod`, the last hyphenated throughout. Match the dashboard,
+not the pattern.
 
 ## License
 

--- a/website/cfd/README.md
+++ b/website/cfd/README.md
@@ -25,11 +25,14 @@ in `.bazelignore`.
 
 ## Deploy
 
-Cloudflare Workers Builds, configured in the dashboard: root directory
-`/website/cfd/`, build command `pnpm run build`, deploy command
-`npx wrangler deploy`. The Worker is `deepcausality-cfd`, which is the name
-`wrangler.toml` must carry. See [`../README.md`](../README.md) for why both of
-those settings fail quietly when they are wrong.
+Cloudflare Workers Builds. The dashboard supplies the root directory
+(`/website/cfd/`) and the deploy command (`npx wrangler deploy`); the build
+lives in `wrangler.toml` as a `[build]` command, so an empty dashboard build
+field cannot break the deploy.
+
+The Worker is **`deep-causality-cfd-prod`**, spelled with hyphens throughout,
+and `wrangler.toml` must carry that exact name. See
+[`../README.md`](../README.md) for the two ways this fails quietly.
 
 ## Design
 

--- a/website/cfd/src/components/home/Hero.astro
+++ b/website/cfd/src/components/home/Hero.astro
@@ -12,10 +12,10 @@
 <section class="hero">
   <div class="hero-inner">
     <p class="eyebrow">DeepCausality · CFD</p>
-    <h1>Counterfactual fluid dynamics</h1>
+    <h1>Counterfactual Fluid Dynamics</h1>
 
     <p class="tagline">
-      Counterfactual fluid dynamics and multidisciplinary analysis and
+      Counterfactual Fluid Dynamics and multidisciplinary analysis and
       optimization, by coupling fluid dynamics, multiple physics, navigation
       and control in one typed dynamic process.
     </p>

--- a/website/cfd/src/layouts/BaseLayout.astro
+++ b/website/cfd/src/layouts/BaseLayout.astro
@@ -71,7 +71,7 @@ const year = 2026;
         <div class="footer-brand">
           <p class="eyebrow">DeepCausality CFD</p>
           <p class="footer-note">
-            Counterfactual fluid dynamics in Rust. Part of the
+            Counterfactual Fluid Dynamics in Rust. Part of the
             <a href={SITE_URL}>DeepCausality</a> project, hosted at the Linux Foundation
             for Data &amp; AI.
           </p>

--- a/website/cfd/src/pages/index.astro
+++ b/website/cfd/src/pages/index.astro
@@ -12,7 +12,7 @@ import ValidationSnapshot from '../components/home/ValidationSnapshot.astro';
 import ExampleLadder from '../components/home/ExampleLadder.astro';
 import { GITHUB_URL } from '../consts';
 
-const title = 'DeepCausality CFD — counterfactual fluid dynamics in Rust';
+const title = 'DeepCausality CFD — Counterfactual Fluid Dynamics in Rust';
 const description =
   'A Rust CFD toolbox that couples flow, chemistry, navigation and control in one typed process, then forks the running simulation into counterfactual worlds. Validated against Sod, Ghia, Williamson and RAM-C II, with measured capability boundaries.';
 

--- a/website/cfd/wrangler.toml
+++ b/website/cfd/wrangler.toml
@@ -3,15 +3,26 @@
 # Fully static — no SSR, no API routes, no `main` worker entry. Wrangler
 # uploads dist/ as the Worker's static assets. Mirrors website/web/wrangler.toml.
 
-# No `-prod` suffix, unlike website/web's "deepcausality-prod": this must match
-# the Worker the Cloudflare build is attached to, which is the one holding the
-# cfd.deepcausality.com binding. A mismatch here deploys to a second, unbound
-# Worker instead of failing, so do not "fix" this for consistency.
-name = "deepcausality-cfd"
+# Hyphenated "deep-causality", unlike website/web's "deepcausality-prod". This
+# must match the Worker the Cloudflare build is attached to, which is the one
+# holding the cfd.deepcausality.com binding, so do not "fix" the spelling for
+# consistency with the other two sites. A mismatch does not fail: `wrangler
+# deploy` takes the name from this file, creates a second Worker with no domain
+# bound, and reports success while the live site stays unchanged.
+name = "deep-causality-cfd-prod"
 # Same account as the marketing site; pinned explicitly because this credential
 # is linked to two Cloudflare accounts.
 account_id = "222139bff18ce0390d15f59a78d3d6b2"
 compatibility_date = "2026-05-01"
+
+# Build here, not in the Cloudflare dashboard's "Build command" field. Wrangler
+# runs this custom build before it reads `assets.directory`, so `dist/` exists
+# by the time the deploy needs it. Left to the dashboard, an empty field does
+# not fail the build step at all: Cloudflare installs dependencies, skips
+# straight to `npx wrangler deploy`, and the deploy dies on
+# `The directory specified by the "assets.directory" field ... does not exist`.
+[build]
+command = "pnpm run build"
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
## Describe your changes

docs(deep_causality_cfd): edited website

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CFD site deploy by moving the build command into `wrangler.toml` and correcting the Worker name; standardizes CFD copy. Adds Bazel remote build settings to support the C/C++ toolchain and optional RBE.

- **Bug Fixes**
  - CFD deploy: add `[build]` command in `website/cfd/wrangler.toml`, set Worker to `deep-causality-cfd-prod`, and update READMEs to document both silent-failure pitfalls.
  - Copy polish: capitalize “Counterfactual Fluid Dynamics” in UI and page title.

- **Refactors**
  - Bazel: enable C/C++ toolchain resolution; add remote build/cache flags; import `.bazelrc.remote` and ignore it in `.gitignore`.
  - Add `.bazelrc.remote` with BuildBuddy API header and hook up `--config=remote` for cache/execution.

<sup>Written for commit d31041a12e84c518b25ac44aee807f3ca8cbdbae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

