### PR TITLE
feat: Added non-std to 18 crates

### DIFF
--- a/README_NO_STD.md
+++ b/README_NO_STD.md
@@ -1,0 +1,248 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+-->
+
+# Building DeepCausality without `std`
+
+Seventeen of the twenty-seven active crates build on bare metal. That covers the whole numeric
+tower, the causal monad, tensors, multivectors, sparse matrices, FFT, and the quantum layer. What
+stays behind is the graph engine, uncertainty, topology, and everything that touches files.
+
+Verified against `aarch64-unknown-none` on 2026-08-21. Every crate listed as covered was compiled
+for that target; nothing here is inferred from a host build with `std` switched off.
+
+## Quick start
+
+```bash
+rustup target add aarch64-unknown-none
+
+cargo build -p deep_causality_core \
+  --no-default-features --features no-std \
+  --target aarch64-unknown-none
+```
+
+Five crates need only `core`. The other twelve need an allocator. See
+[Allocators](#allocators) for what that does and does not rule out; the short answer is that it
+rules out very little.
+
+## The three feature levels
+
+Every covered crate declares the same three levels:
+
+```toml
+[features]
+default = ["std"]
+std     = ["alloc", "<dep>/std", ...]
+alloc   = []
+no-std  = ["alloc", "<dep>/no-std", ...]
+```
+
+`std` implies `alloc`; `no-std` selects `alloc` without `std`. Dependencies are declared with
+`default-features = false` so that `--no-default-features` actually reaches them. Without that,
+Cargo hands a dependency its own defaults and `std` returns through the back door, which compiles
+fine on a host and fails only when you cross-compile.
+
+## Covered crates
+
+### Allocator-free (`core` only)
+
+These need no `#[global_allocator]`, so they can be used inside a deadline-bound loop without
+reasoning about allocator behaviour.
+
+| Crate | What it gives you |
+|---|---|
+| `deep_causality_num` | Float, integer and `Float106` extended precision; the libm routing |
+| `deep_causality_algebra` | The trait tower: `Magma` through `Field`, `Real`, `RealField`, `Prob` |
+| `deep_causality_num_complex` | Complex scalars over the tower |
+| `deep_causality_num_dual` | Dual numbers for forward-mode differentiation |
+| `deep_causality_calculus` | Euler and RK4 integrators as causal arrows |
+
+### Allocator required
+
+| Crate | What it gives you |
+|---|---|
+| `deep_causality_haft` | HKT witnesses, `Functor`/`Monad`/`Arrow`, `SymMonoidal` |
+| `deep_causality_core` | The causal monad, `CausalFlow`, `EffectLog`, `alternate_value` |
+| `deep_causality_metric` | Metric signatures shared by tensor, multivector and physics |
+| `deep_causality_ast` | `ConstTree`, the persistent tree behind the HKT impls |
+| `deep_causality_data_structures` | Array grids, ring buffers, sliding windows |
+| `deep_causality_tensor` | `CausalTensor`, einsum, SVD, QR, eigen, tensor trains |
+| `deep_causality_multivector` | Geometric algebra, `HilbertState`, `CausalMultiVector` |
+| `deep_causality_sparse` | CSR matrices, conjugate-gradient solver |
+| `deep_causality_fft` | 1-D and N-D FFT, real transforms |
+| `deep_causality_rand` | Xoshiro256, Sobol sequences, normal and uniform distributions |
+| `deep_causality_par` | The `MaybeParallel` marker and `scoped_map` |
+| `deep_causality_quantum` | Density matrices, quantum gates, channels, Born read-out |
+
+## Allocators
+
+A `#[global_allocator]` is a software choice, not a hardware capability. Any target with RAM can
+have one, and with [`embedded-alloc`](https://github.com/rust-embedded/embedded-alloc) it takes
+about ten lines:
+
+```rust
+use embedded_alloc::LlffHeap as Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+// once, at init
+unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
+```
+
+The attribute has been stable since Rust 1.28. A Cortex-M0+ with 8 KB of RAM can carry a heap, so
+the twelve allocator-dependent crates are not gated on device class.
+
+**The constraint that matters is timing, not availability.** Allocation is not bounded-time, so the
+question is whether a given crate allocates in the deadline path or only at init. A system can have
+a perfectly good heap and still be unable to afford a `Vec::push` inside a 235 µs syndrome round.
+
+Two things soften that. `embedded-alloc` ships `TlsfHeap` as well as `LlffHeap`, and Two-Level
+Segregated Fit allocates in bounded O(1), which answers the timing objection though not
+fragmentation. And the usual embedded pattern is to allocate during init and never again, which
+makes the heap a startup convenience rather than a runtime hazard.
+
+What genuinely rules out a heap is policy. Safety-certified work under DO-178C, IEC 61508 or MISRA
+commonly forbids dynamic allocation after init whatever the RAM budget. That is the case where the
+five allocator-free crates carry weight: the scalar tower and the RK4 and Euler integrators, usable
+with no heap at all.
+
+Note that `deep_causality_core` allocates per stage. `EffectLog::add_entry` pushes an owned
+`String` on every entry, so a hard-deadline loop wants a bounded log rather than the default one.
+
+## What you give up
+
+### Threads
+
+`deep_causality_par` exposes `scoped_map`, which fans out over `std::thread::scope` under its
+`parallel` feature. On bare metal the feature is unavailable: `parallel = ["std"]`, so `no-std`
+combined with `parallel` will not resolve. `scoped_map` still works and still returns results in
+input order; it runs the map inline.
+
+Everything downstream inherits this. `deep_causality_fft` and `deep_causality_topology` forward
+their own `parallel` features to the same definition, so their parallel paths are host-only.
+
+### Ambient entropy, not randomness
+
+`deep_causality_rand` builds, and the generators work. Two things change.
+
+`ThreadRng` is gone, because there is no thread to be local to. `rng()` returns an owned
+`Xoshiro256` instead of a handle to a process-wide one, so the caller holds it.
+
+`Xoshiro256::new()` still exists, but its seed comes from a different place. On `std` it mixes a
+fresh `RandomState` with the thread id. On bare metal there is no ambient entropy and no thread
+identity, so it mixes a per-call counter into a fixed base: successive calls within one run differ,
+and **the sequence repeats identically after every reset**.
+
+When the stream has to differ per boot, seed it yourself:
+
+```rust
+let rng = Xoshiro256::from_seed(seed_from_hardware_rng());
+```
+
+On an embedded target the entropy belongs to the board, whether that is an RNG peripheral, ADC
+noise, or a timer capture. The crate cannot know what the board offers, so it does not pretend to.
+Targets without atomic compare-and-swap must also use `from_seed` directly.
+
+### The causal graph
+
+`deep_causality_core` gives you the causal monad: `PropagatingEffect`, `PropagatingProcess`,
+`bind`, `CausalFlow`, the `EffectLog`, and `alternate_value` for counterfactual substitution. The
+five closed-loop programs in `examples/causal_correction_examples` are built from exactly these.
+
+`deep_causality` itself, which holds `CausableGraph` and the hypergraph reasoning engine, is not
+covered. So you get the monad and not the graph. For a control loop that monitors, tests an
+envelope, and intervenes, the monad is the part you need.
+
+### The quantum causal-model slice
+
+`deep_causality_quantum` reaches bare metal with `qcm` off. That feature carries `CausalStructure`,
+the Markov freeze check and the C₃-exclusion faithfulness check, and it pulls in `deep_causality`
+for the graph. Density matrices, gates, channels, Born read-out and the QPU seam are all
+unaffected.
+
+```bash
+# host: everything
+cargo build -p deep_causality_quantum
+
+# bare metal: gates and states, no causal-structure validation
+cargo build -p deep_causality_quantum \
+  --no-default-features --features no-std --target aarch64-unknown-none
+```
+
+### Files, and everything shaped like a file
+
+`deep_causality_file`, `deep_causality_discovery` and `deep_causality_cfd` read and write files.
+Nothing to reclaim there.
+
+## Not covered
+
+Two things block a crate: its own use of `std`, and any dependency that is itself uncovered. The
+second matters more, because it cannot be worked around locally.
+
+**Out of scope by choice.** A controller does not open files, so crates built on `std::fs` and
+`std::io` are not candidates and are not counted as gaps.
+
+| Crate | Uncovered dependencies | Own blockers |
+|---|---|---|
+| `ultragraph` | none | `HashMap`, `HashSet`, `VecDeque`; 5 sites |
+| `deep_causality_uncertain` | none | `HashMap`, `Arc`, `std::sync::atomic`; 19 sites |
+| `deep_causality_topology` | none | `HashMap`/`HashSet` 67 sites, `OnceLock` (one lazy field) |
+| `deep_causality_physics` | `deep_causality_topology` | one `HashMap` in the MHD kernel |
+| `deep_causality_algorithms` | `deep_causality_topology` | `HashMap`/`HashSet`; 90 sites |
+| `deep_causality` | `deep_causality_uncertain`, `ultragraph` | `HashMap`, `Arc`, `std::time`; 67 sites |
+| `deep_causality_ethos` | `deep_causality`, `ultragraph` | `HashMap`/`HashSet`; 28 sites |
+| `deep_causality_file` | none | `std::fs`, `std::io`; out of scope |
+| `deep_causality_discovery` | `deep_causality_algorithms`, `deep_causality_topology` | `std::fs`, `std::io`; out of scope |
+| `deep_causality_cfd` | `deep_causality_file`, `deep_causality_physics`, `deep_causality_topology`, `deep_causality_uncertain` | `std::fs`, `std::io`; out of scope |
+
+Only four crates have no uncovered dependency, so only four can be worked on today: `ultragraph`,
+`deep_causality_uncertain`, `deep_causality_topology`, and `deep_causality_file`. Everything else
+waits on one of them.
+
+`ultragraph` is the smallest at five sites. `deep_causality_topology` is the one that unblocks the
+most: `deep_causality_physics` needs only it, and `deep_causality_algorithms` likewise.
+
+### The `HashMap` question
+
+`std::collections::HashMap` has wrapped [hashbrown](https://github.com/rust-lang/hashbrown) since
+Rust 1.36, and hashbrown itself is `no_std` with `alloc`. The map is not the problem. The default
+hasher is: `RandomState` seeds SipHash from OS entropy, and that is what bare metal cannot supply.
+
+So the port names a hasher instead of switching container:
+
+```rust
+use hashbrown::{HashMap, HashSet};
+use rustc_hash::FxBuildHasher;
+
+pub type FxMap<K, V> = HashMap<K, V, FxBuildHasher>;
+pub type FxSet<T> = HashSet<T, FxBuildHasher>;
+```
+
+Note that `rustc_hash::FxHashMap` and `FxHashSet` are aliases over *std's* containers and are
+therefore std-only. Take `FxBuildHasher` from `rustc-hash` and the container from `hashbrown`.
+
+Unlike the libm split, this needs no `cfg`. std hands you hashbrown anyway, so using it directly on
+both paths costs nothing on the host and removes a divergence that would otherwise go untested.
+
+Dropping SipHash is not a security regression in these crates. HashDoS resistance guards against an
+adversary choosing keys to force collisions, and the keys here are internal: lattice cells, simplex
+and edge indices, node ids, `Vec<usize>` paths. On integer keys FxHash is faster than SipHash, so
+the `no_std` path would likely be the quicker one. The exception is
+`deep_causality_ethos`, which keys on `String` and `TeloidTag`; if those arrive from configuration,
+that is the one place where the default hasher earns its cost.
+
+## Verification
+
+```bash
+for c in num algebra haft num_complex num_dual metric ast core calculus \
+         data_structures par fft tensor multivector sparse rand quantum; do
+  cargo build -p deep_causality_$c \
+    --no-default-features --features no-std \
+    --target aarch64-unknown-none || echo "FAIL: $c"
+done
+```
+
+All seventeen build clean. `cargo build --workspace` reports no warnings and no errors, and
+`cargo clippy` is clean on both the `std` and `no-std` paths.

--- a/README_NO_STD.md
+++ b/README_NO_STD.md
@@ -5,9 +5,10 @@ Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Right
 
 # Building DeepCausality without `std`
 
-Seventeen of the twenty-seven active crates build on bare metal. That covers the whole numeric
-tower, the causal monad, tensors, multivectors, sparse matrices, FFT, and the quantum layer. What
-stays behind is the graph engine, uncertainty, topology, and everything that touches files.
+Eighteen of the twenty-seven active crates build on bare metal. That covers the whole numeric
+tower, the causal monad, tensors, multivectors, sparse matrices, FFT, the quantum layer, and the
+`ultragraph` graph store. What stays behind is uncertainty, topology, the hypergraph reasoning
+engine in `deep_causality`, and everything that touches files.
 
 Verified against `aarch64-unknown-none` on 2026-08-21. Every crate listed as covered was compiled
 for that target; nothing here is inferred from a host build with `std` switched off.
@@ -22,13 +23,13 @@ cargo build -p deep_causality_core \
   --target aarch64-unknown-none
 ```
 
-Five crates need only `core`. The other twelve need an allocator. See
+Four crates need only `core`. The other fourteen need an allocator. See
 [Allocators](#allocators) for what that does and does not rule out; the short answer is that it
 rules out very little.
 
-## The three feature levels
+## The feature levels
 
-Every covered crate declares the same three levels:
+The fourteen allocator-required crates declare the same three levels:
 
 ```toml
 [features]
@@ -43,6 +44,39 @@ no-std  = ["alloc", "<dep>/no-std", ...]
 Cargo hands a dependency its own defaults and `std` returns through the back door, which compiles
 fine on a host and fails only when you cross-compile.
 
+The four `core`-only crates declare no `alloc` feature at all, because nothing in them touches the
+heap. They carry `default`, `std` and `no-std`, and `no-std` does not name `alloc`.
+`deep_causality_num` is where the float-math backend is chosen:
+
+```toml
+# deep_causality_num
+[features]
+default   = ["std"]
+std       = []
+no-std    = ["libm_math"]
+libm_math = ["dep:libm"]
+```
+
+`std` takes the intrinsics; `no-std` routes through `libm`. The other three core-only crates,
+`deep_causality_algebra`, `deep_causality_num_complex` and `deep_causality_num_dual`, only forward
+that choice, for example `no-std = ["deep_causality_num/no-std"]`.
+
+### `alloc` on its own is not a configuration
+
+`alloc` is a level, not a platform. It says a heap is available; it says nothing about where float
+math comes from. `--no-default-features --features alloc` therefore selects neither `std` nor
+`no-std`, `deep_causality_num` gets no backend, and its `Float` impls compile with no bodies:
+
+```
+error[E0425]: cannot find value `n` in this scope
+  --> deep_causality_num/src/float_106/ops_arithmetic.rs:259:38
+```
+
+`deep_causality_core` declares a `compile_error!` for this combination whose message names the fix,
+though it does not always get the chance to fire: when `deep_causality_num` is in the tree, that
+crate fails first and the errors above are what you see. Always pick a platform level, `std` or
+`no-std`, and add `alloc` only through one of them.
+
 ## Covered crates
 
 ### Allocator-free (`core` only)
@@ -56,13 +90,15 @@ reasoning about allocator behaviour.
 | `deep_causality_algebra` | The trait tower: `Magma` through `Field`, `Real`, `RealField`, `Prob` |
 | `deep_causality_num_complex` | Complex scalars over the tower |
 | `deep_causality_num_dual` | Dual numbers for forward-mode differentiation |
-| `deep_causality_calculus` | Euler and RK4 integrators as causal arrows |
+
+These four are exactly the crates that declare no `alloc` feature.
 
 ### Allocator required
 
 | Crate | What it gives you |
 |---|---|
 | `deep_causality_haft` | HKT witnesses, `Functor`/`Monad`/`Arrow`, `SymMonoidal` |
+| `deep_causality_calculus` | Euler and RK4 integrators as causal arrows; see the note below |
 | `deep_causality_core` | The causal monad, `CausalFlow`, `EffectLog`, `alternate_value` |
 | `deep_causality_metric` | Metric signatures shared by tensor, multivector and physics |
 | `deep_causality_ast` | `ConstTree`, the persistent tree behind the HKT impls |
@@ -74,6 +110,13 @@ reasoning about allocator behaviour.
 | `deep_causality_rand` | Xoshiro256, Sobol sequences, normal and uniform distributions |
 | `deep_causality_par` | The `MaybeParallel` marker and `scoped_map` |
 | `deep_causality_quantum` | Density matrices, quantum gates, channels, Born read-out |
+| `ultragraph` | `CsmGraph`, `DynamicGraph`, traversal, centrality, biconnectivity |
+
+`deep_causality_calculus` is the borderline case. Its own operators allocate nothing: the
+integrators step over stack values and `gradient` seeds one coordinate per pass. It is listed here
+because it depends on `deep_causality_haft`, and both its `std` and its `no-std` feature enable
+`alloc = ["deep_causality_haft/alloc"]`. Differentiation and integration therefore arrive with the
+same allocator requirement as the rest of this table.
 
 ## Allocators
 
@@ -92,7 +135,7 @@ unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 ```
 
 The attribute has been stable since Rust 1.28. A Cortex-M0+ with 8 KB of RAM can carry a heap, so
-the twelve allocator-dependent crates are not gated on device class.
+the fourteen allocator-dependent crates are not gated on device class.
 
 **The constraint that matters is timing, not availability.** Allocation is not bounded-time, so the
 question is whether a given crate allocates in the deadline path or only at init. A system can have
@@ -105,8 +148,10 @@ makes the heap a startup convenience rather than a runtime hazard.
 
 What genuinely rules out a heap is policy. Safety-certified work under DO-178C, IEC 61508 or MISRA
 commonly forbids dynamic allocation after init whatever the RAM budget. That is the case where the
-five allocator-free crates carry weight: the scalar tower and the RK4 and Euler integrators, usable
-with no heap at all.
+four allocator-free crates carry weight: the scalar tower, `Float106` extended precision, complex
+numbers and dual numbers, usable with no heap at all. The Euler and RK4 integrators allocate
+nothing either, but they arrive through `deep_causality_calculus`, which links
+`deep_causality_haft` and brings the allocator with it.
 
 Note that `deep_causality_core` allocates per stage. `EffectLog::add_entry` pushes an owned
 `String` on every entry, so a hard-deadline loop wants a bounded log rather than the default one.
@@ -151,9 +196,12 @@ Targets without atomic compare-and-swap must also use `from_seed` directly.
 `bind`, `CausalFlow`, the `EffectLog`, and `alternate_value` for counterfactual substitution. The
 five closed-loop programs in `examples/causal_correction_examples` are built from exactly these.
 
-`deep_causality` itself, which holds `CausableGraph` and the hypergraph reasoning engine, is not
-covered. So you get the monad and not the graph. For a control loop that monitors, tests an
-envelope, and intervenes, the monad is the part you need.
+`ultragraph` is covered too, so the graph store underneath is available: `CsmGraph`,
+`DynamicGraph`, traversal, centrality, biconnectivity. `deep_causality` itself, which holds
+`CausableGraph` and the hypergraph reasoning engine, is not covered; it waits on
+`deep_causality_uncertain`. So you get the monad and the graph store, not the causal-graph engine.
+For a control loop that monitors, tests an envelope, and intervenes, the monad is the part you
+need.
 
 ### The quantum causal-model slice
 
@@ -186,23 +234,23 @@ second matters more, because it cannot be worked around locally.
 
 | Crate | Uncovered dependencies | Own blockers |
 |---|---|---|
-| `ultragraph` | none | `HashMap`, `HashSet`, `VecDeque`; 5 sites |
 | `deep_causality_uncertain` | none | `HashMap`, `Arc`, `std::sync::atomic`; 19 sites |
 | `deep_causality_topology` | none | `HashMap`/`HashSet` 67 sites, `OnceLock` (one lazy field) |
 | `deep_causality_physics` | `deep_causality_topology` | one `HashMap` in the MHD kernel |
 | `deep_causality_algorithms` | `deep_causality_topology` | `HashMap`/`HashSet`; 90 sites |
-| `deep_causality` | `deep_causality_uncertain`, `ultragraph` | `HashMap`, `Arc`, `std::time`; 67 sites |
-| `deep_causality_ethos` | `deep_causality`, `ultragraph` | `HashMap`/`HashSet`; 28 sites |
+| `deep_causality` | `deep_causality_uncertain` | `HashMap`, `Arc`, `std::time`; 67 sites |
+| `deep_causality_ethos` | `deep_causality` | `HashMap`/`HashSet`; 28 sites |
 | `deep_causality_file` | none | `std::fs`, `std::io`; out of scope |
 | `deep_causality_discovery` | `deep_causality_algorithms`, `deep_causality_topology` | `std::fs`, `std::io`; out of scope |
 | `deep_causality_cfd` | `deep_causality_file`, `deep_causality_physics`, `deep_causality_topology`, `deep_causality_uncertain` | `std::fs`, `std::io`; out of scope |
 
-Only four crates have no uncovered dependency, so only four can be worked on today: `ultragraph`,
+Only three crates have no uncovered dependency, so only three can be worked on today:
 `deep_causality_uncertain`, `deep_causality_topology`, and `deep_causality_file`. Everything else
 waits on one of them.
 
-`ultragraph` is the smallest at five sites. `deep_causality_topology` is the one that unblocks the
-most: `deep_causality_physics` needs only it, and `deep_causality_algorithms` likewise.
+`deep_causality_topology` is the one that unblocks the most: `deep_causality_physics` needs only
+it, and `deep_causality_algorithms` likewise. `deep_causality_uncertain` is the last uncovered
+dependency of `deep_causality`, and so of `deep_causality_ethos` behind it.
 
 ### The `HashMap` question
 
@@ -210,7 +258,7 @@ most: `deep_causality_physics` needs only it, and `deep_causality_algorithms` li
 Rust 1.36, and hashbrown itself is `no_std` with `alloc`. The map is not the problem. The default
 hasher is: `RandomState` seeds SipHash from OS entropy, and that is what bare metal cannot supply.
 
-So the port names a hasher instead of switching container:
+The remedy is to name a hasher rather than switch container:
 
 ```rust
 use hashbrown::{HashMap, HashSet};
@@ -226,6 +274,13 @@ therefore std-only. Take `FxBuildHasher` from `rustc-hash` and the container fro
 Unlike the libm split, this needs no `cfg`. std hands you hashbrown anyway, so using it directly on
 both paths costs nothing on the host and removes a divergence that would otherwise go untested.
 
+`ultragraph` did not need either crate; it still has no dependencies. Its two hash sites were small
+enough to remove: the `HashSet` deduplicating neighbours in the centrality traversal became a
+sort-and-dedup over a `Vec`, and the edge-multiplicity map in the biconnectivity pass became an
+`alloc::collections::BTreeMap`. Both changes also dropped a per-run ordering dependence that
+`RandomState` had introduced. That trade goes the other way at sixty or ninety sites, which is what
+`deep_causality_topology` and `deep_causality_algorithms` face.
+
 Dropping SipHash is not a security regression in these crates. HashDoS resistance guards against an
 adversary choosing keys to force collisions, and the keys here are internal: lattice cells, simplex
 and edge indices, node ids, `Vec<usize>` paths. On integer keys FxHash is faster than SipHash, so
@@ -236,13 +291,17 @@ that is the one place where the default hasher earns its cost.
 ## Verification
 
 ```bash
-for c in num algebra haft num_complex num_dual metric ast core calculus \
-         data_structures par fft tensor multivector sparse rand quantum; do
-  cargo build -p deep_causality_$c \
+for c in deep_causality_num deep_causality_algebra deep_causality_haft \
+         deep_causality_num_complex deep_causality_num_dual deep_causality_metric \
+         deep_causality_ast deep_causality_core deep_causality_calculus \
+         deep_causality_data_structures deep_causality_par deep_causality_fft \
+         deep_causality_tensor deep_causality_multivector deep_causality_sparse \
+         deep_causality_rand deep_causality_quantum ultragraph; do
+  cargo build -p $c \
     --no-default-features --features no-std \
     --target aarch64-unknown-none || echo "FAIL: $c"
 done
 ```
 
-All seventeen build clean. `cargo build --workspace` reports no warnings and no errors, and
+All eighteen build clean. `cargo build --workspace` reports no warnings and no errors, and
 `cargo clippy` is clean on both the `std` and `no-std` paths.

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -25,5 +25,11 @@ exclude = [
     "papers/*",
 ]
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+no-std = ["alloc"]
+
 [lints]
 workspace = true

--- a/deep_causality_ast/src/const_tree/accessors.rs
+++ b/deep_causality_ast/src/const_tree/accessors.rs
@@ -4,8 +4,8 @@
  */
 
 use crate::ConstTree;
-use std::collections::VecDeque;
-use std::sync::Arc;
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
 
 impl<T> ConstTree<T> {
     /// Returns a reference to the value stored at the root of the tree.

--- a/deep_causality_ast/src/const_tree/api.rs
+++ b/deep_causality_ast/src/const_tree/api.rs
@@ -5,7 +5,7 @@
 
 use crate::ConstTree;
 use crate::const_tree::Node;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 impl<T: Clone> ConstTree<T> {
     /// Returns a new `ConstTree` with an additional child appended to the end of the

--- a/deep_causality_ast/src/const_tree/debug.rs
+++ b/deep_causality_ast/src/const_tree/debug.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::ConstTree;
-use std::fmt;
+use core::fmt;
 
 impl<T: fmt::Debug> fmt::Debug for ConstTree<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/deep_causality_ast/src/const_tree/display.rs
+++ b/deep_causality_ast/src/const_tree/display.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::ConstTree;
-use std::fmt;
+use core::fmt;
 
 impl<T: fmt::Display> fmt::Display for ConstTree<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/deep_causality_ast/src/const_tree/into_iter.rs
+++ b/deep_causality_ast/src/const_tree/into_iter.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::ConstTree;
 
 /// An iterator that consumes a `ConstTree` and yields its values.
@@ -16,7 +19,7 @@ impl<T: Clone> Iterator for IntoIter<T> {
     fn next(&mut self) -> Option<Self::Item> {
         let tree = self.stack.pop()?;
 
-        match std::sync::Arc::try_unwrap(tree.node) {
+        match alloc::sync::Arc::try_unwrap(tree.node) {
             Ok(node) => {
                 self.stack.extend(node.children.into_iter().rev());
                 Some(node.value)

--- a/deep_causality_ast/src/const_tree/into_iter.rs
+++ b/deep_causality_ast/src/const_tree/into_iter.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::ConstTree;
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::ConstTree;
 
 /// An iterator that consumes a `ConstTree` and yields its values.
 /// Traverses the tree in pre-order.

--- a/deep_causality_ast/src/const_tree/iter.rs
+++ b/deep_causality_ast/src/const_tree/iter.rs
@@ -3,8 +3,11 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::ConstTree;
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
 
 impl<T> ConstTree<T> {
     /// Returns an iterator that traverses the tree's values in pre-order (root, then children).
@@ -96,7 +99,7 @@ impl<'a, T> Iterator for PreOrderNodeIter<'a, T> {
 /// An iterator that traverses a `ConstTree` in post-order (children, then root).
 /// It maintains a stack containing tuples of a node and an iterator over its children.
 pub struct PostOrderIter<'a, T> {
-    stack: Vec<(&'a ConstTree<T>, std::slice::Iter<'a, ConstTree<T>>)>,
+    stack: Vec<(&'a ConstTree<T>, core::slice::Iter<'a, ConstTree<T>>)>,
 }
 
 impl<'a, T> PostOrderIter<'a, T> {

--- a/deep_causality_ast/src/const_tree/map.rs
+++ b/deep_causality_ast/src/const_tree/map.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::ConstTree;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 impl<T: Clone> ConstTree<ConstTree<T>> {
     /// Flattens a tree of trees into a single tree.

--- a/deep_causality_ast/src/const_tree/map.rs
+++ b/deep_causality_ast/src/const_tree/map.rs
@@ -2,8 +2,10 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::ConstTree;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 impl<T: Clone> ConstTree<ConstTree<T>> {
     /// Flattens a tree of trees into a single tree.

--- a/deep_causality_ast/src/const_tree/mod.rs
+++ b/deep_causality_ast/src/const_tree/mod.rs
@@ -3,7 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::sync::Arc;
+use alloc::vec::Vec;
+
+use alloc::sync::Arc;
 
 mod accessors;
 mod api;

--- a/deep_causality_ast/src/const_tree/partial_eq.rs
+++ b/deep_causality_ast/src/const_tree/partial_eq.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::ConstTree;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 // Allow comparing trees for equality if their values can be compared.
 impl<T: PartialEq> PartialEq for ConstTree<T> {

--- a/deep_causality_ast/src/lib.rs
+++ b/deep_causality_ast/src/lib.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! A persistent, immutable tree data structure.
 //!
 //! This crate provides `ConstTree<T>`, a thread-safe, reference-counted,
@@ -25,6 +27,8 @@
 //! This crate serves as a foundational building block for implementing Higher-Kinded Type
 //! traits (like `Functor`, `Monad`, etc.) on other data structures, such as `Uncertain<T>`,
 //! by providing the necessary tree manipulation primitives.
+extern crate alloc;
+
 mod const_tree;
 
 pub use crate::const_tree::ConstTree;

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -27,6 +27,9 @@ exclude = [
 
 
 [features]
+# `alloc` is the allocator level only: it forwards everything it legitimately can, but it does
+# not pick a float-math backend for deep_causality_num. Build with `std` or `no-std`; `alloc`
+# on its own is rejected by a compile_error! guard in src/lib.rs.
 default = ["std"]
 std = ["alloc", "deep_causality_haft/std", "deep_causality_num/std", "deep_causality_algebra/std", "deep_causality_num_dual/std"]
 alloc = ["deep_causality_haft/alloc"]

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -30,23 +30,28 @@ exclude = [
 default = ["std"]
 std = ["alloc", "deep_causality_haft/std", "deep_causality_num/std", "deep_causality_algebra/std", "deep_causality_num_dual/std"]
 alloc = ["deep_causality_haft/alloc"]
+no-std = ["alloc", "deep_causality_haft/no-std", "deep_causality_num/no-std", "deep_causality_algebra/no-std", "deep_causality_num_dual/no-std"]
 
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 version = "0.2"
+default-features = false
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
 version = "0.1"
+default-features = false
 
 [lints]
 workspace = true

--- a/deep_causality_calculus/src/lib.rs
+++ b/deep_causality_calculus/src/lib.rs
@@ -30,6 +30,18 @@
 //! user writes a model once over `Scalar` and applies operators; `Dual`, `ε`, seeding,
 //! stepper coefficients, and loops are never visible.
 
+// `alloc` is a level, not a complete configuration. It says a heap is available; it does not
+// say where float math comes from. Selected on its own it leaves `deep_causality_num` with
+// neither `std` nor `libm_math`, so every `Float` method loses its body and the build dies in
+// a dependency the caller never named. Reject the incomplete combination here instead.
+#[cfg(not(any(feature = "std", feature = "no-std")))]
+compile_error!(
+    "deep_causality_calculus needs one of the `std` or `no-std` features. The `alloc` feature \
+     only selects the allocator level; it does not choose a float-math backend, which leaves \
+     `deep_causality_num` without one. Build with `--features std` (the default), or for bare \
+     metal with `--no-default-features --features no-std`."
+);
+
 mod extensions;
 mod ops;
 mod traits;

--- a/deep_causality_calculus/src/types/euler_arrow.rs
+++ b/deep_causality_calculus/src/types/euler_arrow.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::{Euler, Scalar};
-use deep_causality_haft::Arrow;
 use core::ops::{Add, Mul};
+use deep_causality_haft::Arrow;
 
 impl<S, R, F> Arrow for Euler<S, R, F>
 where

--- a/deep_causality_calculus/src/types/euler_arrow.rs
+++ b/deep_causality_calculus/src/types/euler_arrow.rs
@@ -4,7 +4,7 @@
  */
 use crate::{Euler, Scalar};
 use deep_causality_haft::Arrow;
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 impl<S, R, F> Arrow for Euler<S, R, F>
 where

--- a/deep_causality_calculus/src/types/rk4_arrow.rs
+++ b/deep_causality_calculus/src/types/rk4_arrow.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::{Rk4, Scalar};
-use deep_causality_haft::Arrow;
 use core::ops::{Add, Mul};
+use deep_causality_haft::Arrow;
 
 impl<S, R, F> Arrow for Rk4<S, R, F>
 where

--- a/deep_causality_calculus/src/types/rk4_arrow.rs
+++ b/deep_causality_calculus/src/types/rk4_arrow.rs
@@ -4,7 +4,7 @@
  */
 use crate::{Rk4, Scalar};
 use deep_causality_haft::Arrow;
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 impl<S, R, F> Arrow for Rk4<S, R, F>
 where

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -42,6 +42,11 @@ std = [
     "deep_causality_num_complex/std",
     "deep_causality_num_dual/std",
     "deep_causality_physics/std",
+    "deep_causality_calculus/std",
+    "deep_causality_haft/std",
+    "deep_causality_tensor/std",
+    "deep_causality_par/std",
+    "deep_causality_fft/std",
     "dep:deep_causality_uncertain",
 ]
 
@@ -58,16 +63,18 @@ parallel = [
 
 [dependencies.deep_causality_physics]
 path = "../deep_causality_physics"
-version = "0.8"
 default-features = false
+version = "0.8"
 
 [dependencies.deep_causality_calculus]
 path = "../deep_causality_calculus"
+default-features = false
 version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
 version = "0.11"
+default-features = false
 
 [dependencies.deep_causality_file]
 path = "../deep_causality_file"
@@ -75,26 +82,32 @@ version = "0.1"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
+default-features = false
 version = "0.4"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
+default-features = false
 version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
+default-features = false
 version = "0.2"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
+default-features = false
 version = "0.1"
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
+default-features = false
 version = "0.1"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
+default-features = false
 version = "0.5"
 
 # Std-only: the uncertain-inflow zone consumes `MaybeUncertain<R>` and its global
@@ -110,12 +123,13 @@ version = "0.7"
 
 [dependencies.deep_causality_par]
 path = "../deep_causality_par"
+default-features = false
 version = "0.1"
 
 [dependencies.deep_causality_fft]
 path = "../deep_causality_fft"
-version = "0.1"
 default-features = false
+version = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.8" }

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 [features]
 default = ["std"]
 std = ["alloc", "deep_causality_haft/std"]
-alloc = []
+alloc = ["deep_causality_haft/alloc"]
 no-std = ["alloc", "deep_causality_haft/no-std"]
 
 [dependencies]

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -27,9 +27,10 @@ exclude = [
 default = ["std"]
 std = ["alloc", "deep_causality_haft/std"]
 alloc = []
+no-std = ["alloc", "deep_causality_haft/no-std"]
 
 [dependencies]
-deep_causality_haft = { path = "../deep_causality_haft", version = "0.4" }
+deep_causality_haft = { path = "../deep_causality_haft", version = "0.4", default-features = false }
 
 [lints]
 workspace = true

--- a/deep_causality_core/README.md
+++ b/deep_causality_core/README.md
@@ -53,9 +53,12 @@ The crate defines the core types for modeling causal systems using **Monadic Eff
 | Feature | Default | Description |
 | :--- | :--- | :--- |
 | **`std`** | Yes | Enables standard library support. Suitable for servers, desktops, and research. |
-| **`alloc`** | Yes | Enables heap allocation (`Vec`, `Box`). Required for `no_std` use on embedded Linux / RTOS. |
+| **`no-std`** | No | Builds without the standard library and routes float math through `libm`. Suitable for bare metal, embedded Linux / RTOS. |
+| **`alloc`** | Yes | Enables heap allocation (`Vec`, `Box`). Enabled by both `std` and `no-std`, which are the two features to choose between. |
 
-Use **default features** for general applications. For bare-metal `no_std`, disable defaults and enable only `alloc` (see [non-std Support](#non-std-support) below).
+Pick exactly one platform level: `std` or `no-std`. Because `alloc` sits on top of either one and leaves the float-math backend unselected, enabling it alone fails the build with a message pointing back here.
+
+Use **default features** for general applications. For bare-metal `no_std`, disable defaults and enable `no-std` (see [non-std Support](#non-std-support) below).
 
 ## Usage Examples
 
@@ -199,7 +202,7 @@ To use this crate in a bare-metal `no_std` environment:
 
 ```toml
 [dependencies]
-deep_causality_core = { version = "...", default-features = false, features = ["alloc"] }
+deep_causality_core = { version = "...", default-features = false, features = ["no-std"] }
 ```
 
 ## License

--- a/deep_causality_core/src/lib.rs
+++ b/deep_causality_core/src/lib.rs
@@ -4,6 +4,20 @@
  */
 
 #![cfg_attr(not(feature = "std"), no_std)]
+
+// `alloc` is a level, not a complete configuration: it grants heap support but says nothing
+// about where float math comes from. Selected on its own it leaves `deep_causality_num`
+// without a math backend, which surfaces as a wall of unrelated errors deep in the
+// dependency tree. Reject the incomplete combination here with an actionable message.
+#[cfg(not(any(feature = "std", feature = "no-std")))]
+compile_error!(
+    "deep_causality_core needs one platform level: `std` or `no-std`. \
+     The `alloc` feature is a level on top of those and does not select a float-math backend \
+     for deep_causality_num, so it cannot be enabled on its own. \
+     Use the default features for hosted targets, or \
+     `--no-default-features --features no-std` for bare metal."
+);
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 extern crate core;

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -44,6 +44,12 @@ name = "window_type_vector_storage"
 path = "examples/window_type/vector_storage.rs"
 
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+no-std = ["alloc"]
+
 [dev-dependencies]
 criterion = {  version = "0.8" }
 deep_causality_rand = { path = "../deep_causality_rand"}

--- a/deep_causality_data_structures/src/grid_type/grid.rs
+++ b/deep_causality_data_structures/src/grid_type/grid.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::cell::RefCell;
-use std::fmt::Debug;
+use core::cell::RefCell;
+use core::fmt::Debug;
 
 use crate::{PointIndex, Storage};
 
@@ -49,7 +49,7 @@ where
     /// Internal storage wrapped in `RefCell` to allow interior mutability.
     storage: RefCell<S>,
     // Type marker to retain generic parameter `T` even though it's not stored directly.
-    _marker: std::marker::PhantomData<T>,
+    _marker: core::marker::PhantomData<T>,
 }
 
 impl<S, T> Grid<S, T>
@@ -70,7 +70,7 @@ where
     pub fn new(storage: S) -> Self {
         Self {
             storage: RefCell::new(storage),
-            _marker: std::marker::PhantomData,
+            _marker: core::marker::PhantomData,
         }
     }
 

--- a/deep_causality_data_structures/src/grid_type/mod.rs
+++ b/deep_causality_data_structures/src/grid_type/mod.rs
@@ -11,7 +11,7 @@ pub mod storage_array_2d;
 pub mod storage_array_3d;
 pub mod storage_array_4d;
 
-use std::fmt::{Debug, Display, Formatter};
+use core::fmt::{Debug, Display, Formatter};
 
 pub use point::PointIndexType;
 
@@ -179,7 +179,7 @@ impl<T, const W: usize, const H: usize, const D: usize, const C: usize> Display
 where
     T: Copy + Default + Debug,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             ArrayGrid::ArrayGrid1D(_) => write!(f, "ArrayGrid1D"),
             ArrayGrid::ArrayGrid2D(_) => write!(f, "ArrayGrid2D"),

--- a/deep_causality_data_structures/src/grid_type/point.rs
+++ b/deep_causality_data_structures/src/grid_type/point.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::fmt;
+use core::fmt;
 
 /// Enumeration representing the dimensionality of a `PointIndex`.
 ///

--- a/deep_causality_data_structures/src/lib.rs
+++ b/deep_causality_data_structures/src/lib.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 pub mod grid_type;
 pub mod window_type;
 

--- a/deep_causality_data_structures/src/window_type/mod.rs
+++ b/deep_causality_data_structures/src/window_type/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
 
 use core::marker::PhantomData;
 

--- a/deep_causality_data_structures/src/window_type/mod.rs
+++ b/deep_causality_data_structures/src/window_type/mod.rs
@@ -3,7 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::marker::PhantomData;
+use alloc::vec::Vec;
+use alloc::string::String;
+
+use core::marker::PhantomData;
 
 use crate::{ArrayStorage, VectorStorage, WindowStorage};
 

--- a/deep_causality_data_structures/src/window_type/storage.rs
+++ b/deep_causality_data_structures/src/window_type/storage.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+use alloc::string::String;
+use alloc::string::ToString;
+
 /// Trait defining the interface for a sliding window data structure
 ///
 /// # Type Parameters

--- a/deep_causality_data_structures/src/window_type/storage.rs
+++ b/deep_causality_data_structures/src/window_type/storage.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 
 /// Trait defining the interface for a sliding window data structure
 ///

--- a/deep_causality_data_structures/src/window_type/storage_safe/storage_array.rs
+++ b/deep_causality_data_structures/src/window_type/storage_safe/storage_array.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::string::String;
+use alloc::string::ToString;
 use crate::WindowStorage;
 
 const ERROR_EMPTY_ARRAY: &str = "Array is empty";

--- a/deep_causality_data_structures/src/window_type/storage_safe/storage_array.rs
+++ b/deep_causality_data_structures/src/window_type/storage_safe/storage_array.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::WindowStorage;
 use alloc::string::String;
 use alloc::string::ToString;
-use crate::WindowStorage;
 
 const ERROR_EMPTY_ARRAY: &str = "Array is empty";
 const ERROR_ARRAY_NOT_FILLED: &str = "Array is not yet filled";

--- a/deep_causality_data_structures/src/window_type/storage_safe/storage_vec.rs
+++ b/deep_causality_data_structures/src/window_type/storage_safe/storage_vec.rs
@@ -2,6 +2,10 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
+use alloc::string::String;
+use alloc::string::ToString;
 use crate::WindowStorage;
 
 /// A highly optimized vector-based sliding window implementation using only safe Rust.

--- a/deep_causality_data_structures/src/window_type/storage_safe/storage_vec.rs
+++ b/deep_causality_data_structures/src/window_type/storage_safe/storage_vec.rs
@@ -3,10 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
+use crate::WindowStorage;
 use alloc::string::String;
 use alloc::string::ToString;
-use crate::WindowStorage;
+use alloc::vec::Vec;
 
 /// A highly optimized vector-based sliding window implementation using only safe Rust.
 ///

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -27,9 +27,19 @@ exclude = [
 [features]
 default = ["std"]
 std = [
-    "deep_causality_num/default",
-    "deep_causality_algebra/default",
-    "deep_causality_num_complex/default",
+    "alloc",
+    "deep_causality_num/std",
+    "deep_causality_algebra/std",
+    "deep_causality_num_complex/std",
+    "deep_causality_par/std",
+]
+alloc = []
+no-std = [
+    "alloc",
+    "deep_causality_num/no-std",
+    "deep_causality_algebra/no-std",
+    "deep_causality_num_complex/no-std",
+    "deep_causality_par/no-std",
 ]
 # Opt-in Rayon parallelism for the batched 1-D transforms inside
 # N-dimensional plans (the SURD pattern used across the workspace).
@@ -56,6 +66,7 @@ default-features = false
 [dependencies.deep_causality_par]
 path = "../deep_causality_par"
 version = "0.1"
+default-features = false
 
 [dependencies.rayon]
 version = "1.11"

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -46,7 +46,10 @@ no-std = [
 # Serial behavior and results are unchanged; small transforms stay
 # serial behind a measured granularity threshold. Forwards to the
 # shared MaybeParallel definition in deep_causality_par.
-parallel = ["dep:rayon", "deep_causality_par/parallel"]
+# Rayon needs threads, so `parallel` requires `std`. Declaring the dependency
+# here makes the `parallel`-without-`std` combination unrepresentable; it used
+# to compile the Rayon scratch buffers under `no_std`, where `vec!` is absent.
+parallel = ["std", "dep:rayon", "deep_causality_par/parallel"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"

--- a/deep_causality_fft/src/lib.rs
+++ b/deep_causality_fft/src/lib.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! Fast Fourier transforms for the DeepCausality stack.
 //!
 //! The crate provides plan-based forward and inverse transforms, generic
@@ -38,6 +40,8 @@
 //! caller-provided scratch buffer of at least [`FftPlan::scratch_len`]
 //! elements and performs no heap allocation (the opt-in `parallel`
 //! feature allocates per-thread scratch inside parallel sections).
+
+extern crate alloc;
 
 pub mod errors;
 pub mod traits;

--- a/deep_causality_fft/src/types/dct_plan/mod.rs
+++ b/deep_causality_fft/src/types/dct_plan/mod.rs
@@ -37,6 +37,7 @@
 //! length O(N log N) through the planner's Bluestein fallback. The
 //! naïve references live in [`crate::utils::dct`].
 
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::errors::fft_error::FftError;

--- a/deep_causality_fft/src/types/fft_plan/bluestein.rs
+++ b/deep_causality_fft/src/types/fft_plan/bluestein.rs
@@ -12,6 +12,9 @@
 //! angle is reduced as `π·t²/n = 2π·(t² mod 2n)/(2n)` in integer
 //! arithmetic before any trigonometry.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::boxed::Box;
 use deep_causality_num_complex::Complex;
 
 use crate::traits::fft_scalar::FftScalar;

--- a/deep_causality_fft/src/types/fft_plan/bluestein.rs
+++ b/deep_causality_fft/src/types/fft_plan/bluestein.rs
@@ -12,9 +12,9 @@
 //! angle is reduced as `π·t²/n = 2π·(t² mod 2n)/(2n)` in integer
 //! arithmetic before any trigonometry.
 
+use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::boxed::Box;
 use deep_causality_num_complex::Complex;
 
 use crate::traits::fft_scalar::FftScalar;

--- a/deep_causality_fft/src/types/fft_plan/small.rs
+++ b/deep_causality_fft/src/types/fft_plan/small.rs
@@ -12,6 +12,7 @@
 //! decimation-in-time split over the next-smaller kernel with a
 //! precomputed twiddle row.
 
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::traits::fft_scalar::FftScalar;

--- a/deep_causality_fft/src/types/fft_plan/stockham.rs
+++ b/deep_causality_fft/src/types/fft_plan/stockham.rs
@@ -13,6 +13,7 @@
 //! between the data buffer and the caller's scratch; if the stage count
 //! is odd the result is copied back once.
 
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::traits::fft_scalar::FftScalar;

--- a/deep_causality_fft/src/types/fft_plan_nd/mod.rs
+++ b/deep_causality_fft/src/types/fft_plan_nd/mod.rs
@@ -7,6 +7,7 @@
 //! along each axis (row-column decomposition), with one shared 1-D plan
 //! per distinct axis length.
 
+use alloc::vec::Vec;
 pub(crate) mod axis;
 
 use deep_causality_num_complex::Complex;

--- a/deep_causality_fft/src/types/rfft_plan/mod.rs
+++ b/deep_causality_fft/src/types/rfft_plan/mod.rs
@@ -17,6 +17,7 @@
 //! Normalization matches the complex plans: forward unnormalized,
 //! inverse scaled by `1/n`.
 
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::errors::fft_error::FftError;

--- a/deep_causality_fft/src/types/rfft_plan_nd/mod.rs
+++ b/deep_causality_fft/src/types/rfft_plan_nd/mod.rs
@@ -8,6 +8,7 @@
 //! then complex transforms run along every other axis of that array.
 //! This is the transform pair the spectral Poisson solve consumes.
 
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::errors::fft_error::FftError;

--- a/deep_causality_fft/src/utils/dct.rs
+++ b/deep_causality_fft/src/utils/dct.rs
@@ -15,6 +15,7 @@
 //!
 //! Pairings: `DCT-III(DCT-II(x)) = (n/2)·x`; `DCT-I(DCT-I(x)) = ((n−1)/2)·x`.
 
+use alloc::vec::Vec;
 use crate::traits::fft_scalar::FftScalar;
 
 fn cos_pi_ratio<R: FftScalar>(numer: usize, denom: usize) -> R {

--- a/deep_causality_fft/src/utils/dct.rs
+++ b/deep_causality_fft/src/utils/dct.rs
@@ -15,8 +15,8 @@
 //!
 //! Pairings: `DCT-III(DCT-II(x)) = (n/2)·x`; `DCT-I(DCT-I(x)) = ((n−1)/2)·x`.
 
-use alloc::vec::Vec;
 use crate::traits::fft_scalar::FftScalar;
+use alloc::vec::Vec;
 
 fn cos_pi_ratio<R: FftScalar>(numer: usize, denom: usize) -> R {
     let pi = R::pi();

--- a/deep_causality_fft/src/utils/dft.rs
+++ b/deep_causality_fft/src/utils/dft.rs
@@ -9,6 +9,8 @@
 //! tests, the same role the naïve DFT plays in RustFFT. The planner never
 //! selects them.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex;
 
 use crate::traits::fft_scalar::FftScalar;

--- a/deep_causality_metric/Cargo.toml
+++ b/deep_causality_metric/Cargo.toml
@@ -29,6 +29,7 @@ exclude = [
 default = ["std"]
 std = ["alloc"]
 alloc = []
+no-std = ["alloc"]
 
 # This crate has ZERO external dependencies
 # It is a foundational crate

--- a/deep_causality_metric/src/types/metric/hash.rs
+++ b/deep_causality_metric/src/types/metric/hash.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::Metric;
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 impl Hash for Metric {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -25,31 +25,41 @@ exclude = [
     "papers/*",
 ]
 
+[features]
+default = ["std"]
+std = ["alloc", "deep_causality_haft/std", "deep_causality_num/std", "deep_causality_algebra/std", "deep_causality_num_complex/std", "deep_causality_tensor/std", "deep_causality_metric/std"]
+alloc = []
+no-std = ["alloc", "deep_causality_haft/no-std", "deep_causality_num/no-std", "deep_causality_algebra/no-std", "deep_causality_num_complex/no-std", "deep_causality_tensor/no-std", "deep_causality_metric/no-std"]
+
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
 version = "0.4"
-
+default-features = false
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 version = "0.2"
+default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
 version = "0.1"
-
+default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
 version = "0.5"
+default-features = false
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"
 version = "0.2"
+default-features = false
 
 
 [dev-dependencies]

--- a/deep_causality_multivector/src/alias/alias_complex.rs
+++ b/deep_causality_multivector/src/alias/alias_complex.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{ComplexMultiVector, Metric};
+use alloc::vec::Vec;
 use deep_causality_num_complex::Complex64;
 
 impl ComplexMultiVector {

--- a/deep_causality_multivector/src/alias/alias_complex.rs
+++ b/deep_causality_multivector/src/alias/alias_complex.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{ComplexMultiVector, Metric};
 use deep_causality_num_complex::Complex64;
 

--- a/deep_causality_multivector/src/alias/alias_hilbert_state.rs
+++ b/deep_causality_multivector/src/alias/alias_hilbert_state.rs
@@ -2,12 +2,15 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CausalMultiVector, CausalMultiVectorError, Metric};
 use deep_causality_algebra::RealField;
 use deep_causality_num::Zero;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::CausalTensor;
-use std::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 
 /// The distinguished minimal-left-ideal column of the matrix representation
 /// used by the ket ↔ matrix bridge: the image of the primitive idempotent
@@ -202,7 +205,7 @@ impl<R: RealField> core::ops::Mul<Complex<R>> for HilbertState<R> {
 }
 
 impl<R: RealField + core::fmt::Debug> Display for HilbertState<R> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self.mv)
     }
 }

--- a/deep_causality_multivector/src/alias/alias_hilbert_state.rs
+++ b/deep_causality_multivector/src/alias/alias_hilbert_state.rs
@@ -3,14 +3,14 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CausalMultiVector, CausalMultiVectorError, Metric};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CausalMultiVector, CausalMultiVectorError, Metric};
+use core::fmt::{Display, Formatter};
 use deep_causality_algebra::RealField;
 use deep_causality_num::Zero;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::CausalTensor;
-use core::fmt::{Display, Formatter};
 
 /// The distinguished minimal-left-ideal column of the matrix representation
 /// used by the ket ↔ matrix bridge: the image of the primitive idempotent

--- a/deep_causality_multivector/src/alias/alias_hopf_state.rs
+++ b/deep_causality_multivector/src/alias/alias_hopf_state.rs
@@ -7,10 +7,10 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::{CausalMultiVector, CausalMultiVectorError, HilbertState, Metric, MultiVector};
+use core::fmt::{Display, Formatter};
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;
-use core::fmt::{Display, Formatter};
 
 /// A point on the 3-Sphere ($S^3$), representing a unit spinor or rotor in 3D Euclidean space.
 ///

--- a/deep_causality_multivector/src/alias/alias_hopf_state.rs
+++ b/deep_causality_multivector/src/alias/alias_hopf_state.rs
@@ -3,11 +3,14 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::{CausalMultiVector, CausalMultiVectorError, HilbertState, Metric, MultiVector};
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;
-use std::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 
 /// A point on the 3-Sphere ($S^3$), representing a unit spinor or rotor in 3D Euclidean space.
 ///
@@ -174,7 +177,7 @@ impl<R: RealField> TryFrom<HopfState<R>> for HilbertState<R> {
 }
 
 impl<R: RealField + core::fmt::Debug> Display for HopfState<R> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "HopfState({:?})", self.0)
     }
 }

--- a/deep_causality_multivector/src/alias/alias_pga3d.rs
+++ b/deep_causality_multivector/src/alias/alias_pga3d.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 // 3D Projective Geometric Algebra
 // Signature: R(3, 0, 1) -> 3 Euclidean, 0 Negative, 1 Zero
 

--- a/deep_causality_multivector/src/alias/alias_real.rs
+++ b/deep_causality_multivector/src/alias/alias_real.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{Metric, RealMultiVector};
 
 // Generic Algebras

--- a/deep_causality_multivector/src/alias/alias_real.rs
+++ b/deep_causality_multivector/src/alias/alias_real.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{Metric, RealMultiVector};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{Metric, RealMultiVector};
 
 // Generic Algebras
 impl RealMultiVector {

--- a/deep_causality_multivector/src/errors/causal_multivector_error.rs
+++ b/deep_causality_multivector/src/errors/causal_multivector_error.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::Metric;
-use std::fmt;
+use core::fmt;
 
 /// The main error type for CausalMultiVector operations.
 ///
@@ -27,7 +27,7 @@ pub enum CausalMultiVectorErrorInner {
     MetricMismatch { left: Metric, right: Metric },
 }
 
-impl std::error::Error for CausalMultiVectorError {}
+impl core::error::Error for CausalMultiVectorError {}
 
 impl CausalMultiVectorError {
     /// Creates a DimensionMismatch error.

--- a/deep_causality_multivector/src/extensions/hkt_multifield/mod.rs
+++ b/deep_causality_multivector/src/extensions/hkt_multifield/mod.rs
@@ -39,16 +39,16 @@
 //! 3. **Future resolution**: This limitation will be resolved when the new trait
 //!    solver stabilizes, enabling proper generic constraints.
 
+use crate::CausalMultiField;
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::CausalMultiField;
+use core::marker::PhantomData;
 use deep_causality_algebra::Field;
 use deep_causality_haft::{
     Applicative, CoMonad, Functor, HKT, Monad, NoConstraint, Pure, Satisfies,
 };
 use deep_causality_metric::Metric;
 use deep_causality_tensor::CausalTensor;
-use core::marker::PhantomData;
 
 /// HKT witness for `CausalMultiField<T>`.
 ///

--- a/deep_causality_multivector/src/extensions/hkt_multifield/mod.rs
+++ b/deep_causality_multivector/src/extensions/hkt_multifield/mod.rs
@@ -39,6 +39,8 @@
 //! 3. **Future resolution**: This limitation will be resolved when the new trait
 //!    solver stabilizes, enabling proper generic constraints.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::CausalMultiField;
 use deep_causality_algebra::Field;
 use deep_causality_haft::{
@@ -46,7 +48,7 @@ use deep_causality_haft::{
 };
 use deep_causality_metric::Metric;
 use deep_causality_tensor::CausalTensor;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// HKT witness for `CausalMultiField<T>`.
 ///
@@ -104,9 +106,9 @@ where
                 .iter()
                 .map(|x| {
                     // Transmute T -> A, apply f, transmute result -> T
-                    let a_val = std::mem::transmute_copy::<T, A>(x);
+                    let a_val = core::mem::transmute_copy::<T, A>(x);
                     let c_val = f(a_val);
-                    std::mem::transmute_copy::<C, T>(&c_val)
+                    core::mem::transmute_copy::<C, T>(&c_val)
                 })
                 .collect();
 
@@ -124,9 +126,9 @@ where
 
             // Transmute to CausalMultiField<C>
             let result_ptr = &result as *const CausalMultiField<T> as *const CausalMultiField<C>;
-            let ret = std::ptr::read(result_ptr);
-            std::mem::forget(result);
-            // std::mem::forget(fa); // Do not forget the input `fa`, let it drop naturally.
+            let ret = core::ptr::read(result_ptr);
+            core::mem::forget(result);
+            // core::mem::forget(fa); // Do not forget the input `fa`, let it drop naturally.
             ret
         }
     }
@@ -174,9 +176,9 @@ where
             };
 
             let result_ptr = &result as *const CausalMultiField<T> as *const CausalMultiField<A>;
-            let ret = std::ptr::read(result_ptr);
-            std::mem::forget(result);
-            // std::mem::forget(value); // This causes a memory leak.
+            let ret = core::ptr::read(result_ptr);
+            core::mem::forget(result);
+            // core::mem::forget(value); // This causes a memory leak.
             ret
         }
     }
@@ -240,9 +242,9 @@ where
             // Extract first coefficient and apply f
             let data_vec = ma_concrete.data().as_slice();
             if let Some(&first_val) = data_vec.first() {
-                let a_val = std::mem::transmute_copy::<T, A>(&first_val);
+                let a_val = core::mem::transmute_copy::<T, A>(&first_val);
                 let result = f(a_val);
-                // std::mem::forget(ma); // This causes a memory leak.
+                // core::mem::forget(ma); // This causes a memory leak.
                 return result;
             }
 
@@ -266,9 +268,9 @@ where
             };
 
             let result_ptr = &result as *const CausalMultiField<T> as *const CausalMultiField<C>;
-            let ret = std::ptr::read(result_ptr);
-            std::mem::forget(result);
-            // std::mem::forget(ma); // This causes a memory leak.
+            let ret = core::ptr::read(result_ptr);
+            core::mem::forget(result);
+            // core::mem::forget(ma); // This causes a memory leak.
             ret
         }
     }
@@ -297,7 +299,7 @@ where
             let data_vec = fa_concrete.data().as_slice();
             let first_val = data_vec.first().copied().unwrap_or_else(T::zero);
 
-            std::mem::transmute_copy::<T, A>(&first_val)
+            core::mem::transmute_copy::<T, A>(&first_val)
         }
     }
 
@@ -314,7 +316,7 @@ where
         // as a constant field.
         unsafe {
             let c_val = f(fa);
-            let c_t = std::mem::transmute_copy::<C, T>(&c_val);
+            let c_t = core::mem::transmute_copy::<C, T>(&c_val);
 
             let fa_ptr = fa as *const CausalMultiField<A> as *const CausalMultiField<T>;
             let fa_concrete = &*fa_ptr;
@@ -338,9 +340,9 @@ where
             };
 
             let result_ptr = &result as *const CausalMultiField<T> as *const CausalMultiField<C>;
-            let ret = std::ptr::read(result_ptr);
-            std::mem::forget(result);
-            std::mem::forget(c_val);
+            let ret = core::ptr::read(result_ptr);
+            core::mem::forget(result);
+            core::mem::forget(c_val);
             ret
         }
     }

--- a/deep_causality_multivector/src/extensions/hkt_multivector/mod.rs
+++ b/deep_causality_multivector/src/extensions/hkt_multivector/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalMultiVector;
 use deep_causality_haft::{
     Adjunction, Applicative, CoMonad, Foldable, Functor, HKT, Monad, NoConstraint, Pure, Satisfies,

--- a/deep_causality_multivector/src/extensions/scalar_eval/mod.rs
+++ b/deep_causality_multivector/src/extensions/scalar_eval/mod.rs
@@ -4,7 +4,7 @@
  */
 use crate::ScalarEval;
 use deep_causality_algebra::Normed;
-use std::iter::Sum;
+use core::iter::Sum;
 
 // `ScalarEval` is the multivector-side facade over `deep_causality_algebra::Normed`. Every scalar with
 // a real modulus, every real float and `Complex<T>`, satisfies `Normed`, so this single blanket

--- a/deep_causality_multivector/src/extensions/scalar_eval/mod.rs
+++ b/deep_causality_multivector/src/extensions/scalar_eval/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::ScalarEval;
-use deep_causality_algebra::Normed;
 use core::iter::Sum;
+use deep_causality_algebra::Normed;
 
 // `ScalarEval` is the multivector-side facade over `deep_causality_algebra::Normed`. Every scalar with
 // a real modulus, every real float and `Complex<T>`, satisfies `Normed`, so this single blanket

--- a/deep_causality_multivector/src/lib.rs
+++ b/deep_causality_multivector/src/lib.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod alias;
 mod errors;
 mod extensions;

--- a/deep_causality_multivector/src/traits/l2_norm.rs
+++ b/deep_causality_multivector/src/traits/l2_norm.rs
@@ -8,7 +8,7 @@ use deep_causality_algebra::{Field, RealField};
 /// Defines L2 norm operations for multivectors, treating their coefficients as a vector space.
 pub trait MultiVectorL2Norm<T>
 where
-    T: Field + Copy + std::iter::Sum,
+    T: Field + Copy + core::iter::Sum,
 {
     /// Returns the Real magnitude type (e.g. f64 for `Complex<f64>`)
     type Output: RealField + Copy;

--- a/deep_causality_multivector/src/traits/scalar_eval.rs
+++ b/deep_causality_multivector/src/traits/scalar_eval.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use deep_causality_algebra::RealField;
-use std::iter::Sum;
+use core::iter::Sum;
 
 // This trait abstracts the differences between Real (f64) and Complex (Complex<f64>)
 // specifically for norm calculations.

--- a/deep_causality_multivector/src/traits/scalar_eval.rs
+++ b/deep_causality_multivector/src/traits/scalar_eval.rs
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-use deep_causality_algebra::RealField;
 use core::iter::Sum;
+use deep_causality_algebra::RealField;
 
 // This trait abstracts the differences between Real (f64) and Complex (Complex<f64>)
 // specifically for norm calculations.

--- a/deep_causality_multivector/src/types/multifield/algebra/mod.rs
+++ b/deep_causality_multivector/src/types/multifield/algebra/mod.rs
@@ -18,6 +18,7 @@
 //! All operations preserve the Matrix Isomorphism: they work directly on the
 //! matrix representation, avoiding costly coefficient extraction.
 
+use alloc::vec::Vec;
 // Import local modules
 use crate::CausalMultiField;
 use crate::MultiVector;
@@ -90,7 +91,7 @@ where
 
 impl<T> CausalMultiField<T>
 where
-    T: Field + Copy + Default + PartialOrd + std::ops::Neg<Output = T> + 'static,
+    T: Field + Copy + Default + PartialOrd + core::ops::Neg<Output = T> + 'static,
 {
     /// Computes the reversion (reversal) of the field.
     ///

--- a/deep_causality_multivector/src/types/multifield/arithmetic/mod.rs
+++ b/deep_causality_multivector/src/types/multifield/arithmetic/mod.rs
@@ -10,7 +10,7 @@ use crate::types::multifield::ops::batched_matmul::BatchedMatMul;
 use deep_causality_algebra::{Field, Ring};
 use deep_causality_num::Zero;
 use deep_causality_tensor::CausalTensor;
-use std::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 
 // === Zero Implementation ===
 

--- a/deep_causality_multivector/src/types/multifield/arithmetic/mod.rs
+++ b/deep_causality_multivector/src/types/multifield/arithmetic/mod.rs
@@ -7,10 +7,10 @@
 
 use super::CausalMultiField;
 use crate::types::multifield::ops::batched_matmul::BatchedMatMul;
+use core::ops::{Add, Mul, Neg, Sub};
 use deep_causality_algebra::{Field, Ring};
 use deep_causality_num::Zero;
 use deep_causality_tensor::CausalTensor;
-use core::ops::{Add, Mul, Neg, Sub};
 
 // === Zero Implementation ===
 

--- a/deep_causality_multivector/src/types/multifield/ops/batched_matmul.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/batched_matmul.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use deep_causality_algebra::{Field, Ring};
 use deep_causality_tensor::{CausalTensor, Tensor};
 

--- a/deep_causality_multivector/src/types/multifield/ops/conversions.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/conversions.rs
@@ -9,6 +9,7 @@
 //! - `to_coefficients`: Extract CausalMultiVector collection
 //! - Factory methods: `zeros`, `ones`
 
+use alloc::vec::Vec;
 use crate::types::multifield::ops::gamma;
 use crate::{CausalMultiField, CausalMultiVector};
 use deep_causality_algebra::Field;
@@ -71,7 +72,7 @@ where
     /// * `dx` - Grid spacing [dx, dy, dz]
     pub fn from_coefficients(mvs: &[CausalMultiVector<T>], shape: [usize; 3], dx: [T; 3]) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         let expected_len = shape[0] * shape[1] * shape[2];
         assert_eq!(
@@ -126,7 +127,7 @@ where
     /// Converts from Matrix Representation back to coefficient form using trace projection.
     pub fn to_coefficients(&self) -> Vec<CausalMultiVector<T>>
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         let num_cells = self.num_cells();
         let num_blades = 1 << self.metric.dimension();

--- a/deep_causality_multivector/src/types/multifield/ops/conversions.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/conversions.rs
@@ -9,9 +9,9 @@
 //! - `to_coefficients`: Extract CausalMultiVector collection
 //! - Factory methods: `zeros`, `ones`
 
-use alloc::vec::Vec;
 use crate::types::multifield::ops::gamma;
 use crate::{CausalMultiField, CausalMultiVector};
+use alloc::vec::Vec;
 use deep_causality_algebra::Field;
 use deep_causality_metric::Metric;
 use deep_causality_tensor::{CausalTensor, Tensor};

--- a/deep_causality_multivector/src/types/multifield/ops/differential.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/differential.rs
@@ -7,6 +7,7 @@
 //!
 //! Implements curl, divergence, and gradient using central-difference stencils.
 
+use alloc::vec;
 use crate::CausalMultiField;
 use crate::types::multifield::ops::gamma;
 use deep_causality_algebra::{Field, Ring};
@@ -35,7 +36,7 @@ where
     /// Returns the grade-2 component of the gradient ∇F.
     pub fn curl(&self) -> Self
     where
-        T: Ring + std::ops::Neg<Output = T>,
+        T: Ring + core::ops::Neg<Output = T>,
     {
         self.gradient().grade_project(2)
     }
@@ -45,7 +46,7 @@ where
     /// Returns the scalar part (Grade 0) of the gradient ∇F.
     pub fn divergence(&self) -> Self
     where
-        T: Ring + std::ops::Neg<Output = T>,
+        T: Ring + core::ops::Neg<Output = T>,
     {
         self.gradient().grade_project(0)
     }
@@ -55,7 +56,7 @@ where
     /// Returns the full geometric derivative field (all grades).
     pub fn gradient(&self) -> Self
     where
-        T: Ring + std::ops::Neg<Output = T>,
+        T: Ring + core::ops::Neg<Output = T>,
     {
         let dx = self.partial_derivative(Axis::X);
         let dy = self.partial_derivative(Axis::Y);
@@ -132,7 +133,7 @@ where
         dz: &CausalTensor<T>,
     ) -> Self
     where
-        T: Ring + std::ops::Neg<Output = T>,
+        T: Ring + core::ops::Neg<Output = T>,
     {
         let n = self.metric.dimension();
         let gammas = gamma::get_gammas::<T>(&self.metric);

--- a/deep_causality_multivector/src/types/multifield/ops/differential.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/differential.rs
@@ -7,9 +7,9 @@
 //!
 //! Implements curl, divergence, and gradient using central-difference stencils.
 
-use alloc::vec;
 use crate::CausalMultiField;
 use crate::types::multifield::ops::gamma;
+use alloc::vec;
 use deep_causality_algebra::{Field, Ring};
 use deep_causality_tensor::{CausalTensor, Tensor};
 

--- a/deep_causality_multivector/src/types/multifield/ops/gamma.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/gamma.rs
@@ -8,6 +8,7 @@
 //! This module provides generator matrices (gamma matrices) for matrix representations
 //! of Clifford algebras. These are used to convert between coefficient and matrix forms.
 
+use alloc::vec;
 use deep_causality_algebra::Field;
 use deep_causality_metric::Metric;
 use deep_causality_tensor::CausalTensor;
@@ -31,7 +32,7 @@ pub fn num_blades(n: usize) -> usize {
 /// Uses the Brauer-Weyl construction for Clifford algebra representations.
 pub fn compute_gamma_element<T>(gamma_idx: usize, row: usize, col: usize, metric: &Metric) -> T
 where
-    T: Field + std::ops::Neg<Output = T>,
+    T: Field + core::ops::Neg<Output = T>,
 {
     let n = metric.dimension();
     let num_bits = n.div_ceil(2); // Number of tensor factors (M)
@@ -124,7 +125,7 @@ where
 /// and D is the matrix dimension.
 pub fn get_gammas<T>(metric: &Metric) -> CausalTensor<T>
 where
-    T: Field + Copy + Default + PartialOrd + std::ops::Neg<Output = T>,
+    T: Field + Copy + Default + PartialOrd + core::ops::Neg<Output = T>,
 {
     let n = metric.dimension();
     let dim = matrix_dim(n);
@@ -140,7 +141,7 @@ where
 /// Returns a tensor of shape [2^N, D, D] containing the matrix for each blade.
 pub fn get_basis_gammas<T>(metric: &Metric) -> CausalTensor<T>
 where
-    T: Field + Copy + Default + PartialOrd + std::ops::Neg<Output = T>,
+    T: Field + Copy + Default + PartialOrd + core::ops::Neg<Output = T>,
 {
     let n = metric.dimension();
     let num_blades = num_blades(n);
@@ -202,7 +203,7 @@ where
 /// Returns a tensor of shape [2^N, D, D] containing the dual (inverse transpose) of each blade matrix.
 pub fn get_dual_basis_gammas<T>(metric: &Metric) -> CausalTensor<T>
 where
-    T: Field + Copy + Default + PartialOrd + std::ops::Neg<Output = T>,
+    T: Field + Copy + Default + PartialOrd + core::ops::Neg<Output = T>,
 {
     let n = metric.dimension();
     let num_blades = num_blades(n);

--- a/deep_causality_multivector/src/types/multifield/ops/grades.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/grades.rs
@@ -21,7 +21,7 @@ where
     /// * `k` - The grade to project onto (0=scalar, 1=vector, 2=bivector, etc.)
     pub fn grade_project(&self, k: usize) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         // Download to Coefficients
         let mut mvs = self.to_coefficients();
@@ -38,7 +38,7 @@ where
     /// Extracts the scalar part (grade 0): ⟨F⟩₀.
     pub fn scalar_part(&self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         self.grade_project(0)
     }
@@ -46,7 +46,7 @@ where
     /// Extracts the vector part (grade 1): ⟨F⟩₁.
     pub fn vector_part(&self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         self.grade_project(1)
     }
@@ -54,7 +54,7 @@ where
     /// Extracts the bivector part (grade 2): ⟨F⟩₂.
     pub fn bivector_part(&self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         self.grade_project(2)
     }
@@ -62,7 +62,7 @@ where
     /// Extracts the trivector part (grade 3): ⟨F⟩₃.
     pub fn trivector_part(&self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         self.grade_project(3)
     }
@@ -70,7 +70,7 @@ where
     /// Extracts the pseudoscalar part (highest grade).
     pub fn pseudoscalar_part(&self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         let n = self.metric.dimension();
         self.grade_project(n)

--- a/deep_causality_multivector/src/types/multifield/ops/products.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/products.rs
@@ -11,6 +11,7 @@
 //! - Outer product → antisymmetrization
 //! - Commutator → AB - BA
 
+use alloc::vec::Vec;
 use crate::CausalMultiField;
 use crate::traits::multi_vector::MultiVector as MultiVectorTrait;
 use crate::types::multifield::ops::batched_matmul::BatchedMatMul;
@@ -25,7 +26,7 @@ where
     /// Computes the inner product (grade-0 projection of geometric product).
     pub fn inner_product(&self, rhs: &Self) -> Self
     where
-        T: std::ops::Neg<Output = T>,
+        T: core::ops::Neg<Output = T>,
     {
         assert_eq!(self.metric, rhs.metric, "Metric mismatch");
         assert_eq!(self.shape, rhs.shape, "Shape mismatch");
@@ -46,7 +47,7 @@ where
     /// for mixed-grade multivectors. (AB - BA)/2 is only valid for vectors.
     pub fn outer_product(&self, rhs: &Self) -> Self
     where
-        T: std::ops::Neg<Output = T> + std::ops::AddAssign + std::ops::SubAssign,
+        T: core::ops::Neg<Output = T> + core::ops::AddAssign + core::ops::SubAssign,
     {
         assert_eq!(self.metric, rhs.metric, "Metric mismatch");
         assert_eq!(self.shape, rhs.shape, "Shape mismatch");
@@ -68,7 +69,7 @@ where
     /// A × B = -I(A ∧ B) where I is the pseudoscalar.
     pub fn cross(&self, rhs: &Self) -> Self
     where
-        T: std::ops::AddAssign + std::ops::SubAssign + std::ops::Neg<Output = T>,
+        T: core::ops::AddAssign + core::ops::SubAssign + core::ops::Neg<Output = T>,
     {
         let wedge = self.outer_product(rhs);
         wedge.hodge_dual()
@@ -79,7 +80,7 @@ where
     /// A* = A · I⁻¹ where I is the pseudoscalar.
     pub fn hodge_dual(&self) -> Self
     where
-        T: std::ops::AddAssign + std::ops::SubAssign + std::ops::Neg<Output = T>,
+        T: core::ops::AddAssign + core::ops::SubAssign + core::ops::Neg<Output = T>,
     {
         // Download to Coefficients
         let mut mvs = self.to_coefficients();

--- a/deep_causality_multivector/src/types/multifield/ops/products.rs
+++ b/deep_causality_multivector/src/types/multifield/ops/products.rs
@@ -11,10 +11,10 @@
 //! - Outer product → antisymmetrization
 //! - Commutator → AB - BA
 
-use alloc::vec::Vec;
 use crate::CausalMultiField;
 use crate::traits::multi_vector::MultiVector as MultiVectorTrait;
 use crate::types::multifield::ops::batched_matmul::BatchedMatMul;
+use alloc::vec::Vec;
 use deep_causality_algebra::{Field, Ring};
 use deep_causality_tensor::CausalTensor;
 

--- a/deep_causality_multivector/src/types/multivector/algebra/mod.rs
+++ b/deep_causality_multivector/src/types/multivector/algebra/mod.rs
@@ -4,9 +4,11 @@
  */
 
 //! Algebra module for CausalMultiVector.
+
+use alloc::vec;
 use crate::{CausalMultiVector, CausalMultiVectorError, Metric};
 use deep_causality_algebra::{AbelianGroup, AssociativeRing, Field, Module, RealField, Ring};
-use std::ops::{AddAssign, Neg, SubAssign};
+use core::ops::{AddAssign, Neg, SubAssign};
 
 // Algebraic Composition
 //

--- a/deep_causality_multivector/src/types/multivector/algebra/mod.rs
+++ b/deep_causality_multivector/src/types/multivector/algebra/mod.rs
@@ -5,10 +5,10 @@
 
 //! Algebra module for CausalMultiVector.
 
-use alloc::vec;
 use crate::{CausalMultiVector, CausalMultiVectorError, Metric};
-use deep_causality_algebra::{AbelianGroup, AssociativeRing, Field, Module, RealField, Ring};
+use alloc::vec;
 use core::ops::{AddAssign, Neg, SubAssign};
+use deep_causality_algebra::{AbelianGroup, AssociativeRing, Field, Module, RealField, Ring};
 
 // Algebraic Composition
 //

--- a/deep_causality_multivector/src/types/multivector/api/mod.rs
+++ b/deep_causality_multivector/src/types/multivector/api/mod.rs
@@ -9,8 +9,8 @@ use crate::{CausalMultiVector, CausalMultiVectorError};
 use crate::{MultiVector, MultiVectorL2Norm, ScalarEval};
 use deep_causality_algebra::{Field, Real};
 use deep_causality_num::{One, Zero};
-use std::iter::Sum;
-use std::ops::{AddAssign, Neg, SubAssign};
+use core::iter::Sum;
+use core::ops::{AddAssign, Neg, SubAssign};
 
 impl<T> MultiVector<T> for CausalMultiVector<T> {
     fn grade_projection(&self, k: u32) -> Self

--- a/deep_causality_multivector/src/types/multivector/api/mod.rs
+++ b/deep_causality_multivector/src/types/multivector/api/mod.rs
@@ -7,10 +7,10 @@
 
 use crate::{CausalMultiVector, CausalMultiVectorError};
 use crate::{MultiVector, MultiVectorL2Norm, ScalarEval};
-use deep_causality_algebra::{Field, Real};
-use deep_causality_num::{One, Zero};
 use core::iter::Sum;
 use core::ops::{AddAssign, Neg, SubAssign};
+use deep_causality_algebra::{Field, Real};
+use deep_causality_num::{One, Zero};
 
 impl<T> MultiVector<T> for CausalMultiVector<T> {
     fn grade_projection(&self, k: u32) -> Self

--- a/deep_causality_multivector/src/types/multivector/mod.rs
+++ b/deep_causality_multivector/src/types/multivector/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalMultiVectorError;
 use crate::Metric;
 use deep_causality_algebra::Field;

--- a/deep_causality_multivector/src/types/multivector/ops/ops_matrix_rep.rs
+++ b/deep_causality_multivector/src/types/multivector/ops/ops_matrix_rep.rs
@@ -10,10 +10,10 @@
 
 use crate::CausalMultiVector;
 use crate::types::multifield::ops::gamma;
+use core::ops::Neg;
 use deep_causality_algebra::Field;
 use deep_causality_metric::Metric;
 use deep_causality_tensor::{CausalTensor, Tensor};
-use core::ops::Neg;
 
 impl<T> CausalMultiVector<T>
 where

--- a/deep_causality_multivector/src/types/multivector/ops/ops_matrix_rep.rs
+++ b/deep_causality_multivector/src/types/multivector/ops/ops_matrix_rep.rs
@@ -13,7 +13,7 @@ use crate::types::multifield::ops::gamma;
 use deep_causality_algebra::Field;
 use deep_causality_metric::Metric;
 use deep_causality_tensor::{CausalTensor, Tensor};
-use std::ops::Neg;
+use core::ops::Neg;
 
 impl<T> CausalMultiVector<T>
 where

--- a/deep_causality_multivector/src/types/multivector/ops/ops_misc_impl.rs
+++ b/deep_causality_multivector/src/types/multivector/ops/ops_misc_impl.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
 use crate::CausalMultiVector;
+use alloc::vec;
 use core::ops::Neg;
 use deep_causality_algebra::Field;
 

--- a/deep_causality_multivector/src/types/multivector/ops/ops_misc_impl.rs
+++ b/deep_causality_multivector/src/types/multivector/ops/ops_misc_impl.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
 use crate::CausalMultiVector;
 use core::ops::Neg;
 use deep_causality_algebra::Field;

--- a/deep_causality_multivector/src/types/multivector/ops/ops_product_impl.rs
+++ b/deep_causality_multivector/src/types/multivector/ops/ops_product_impl.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalMultiVector;
 use core::ops::{AddAssign, Neg, SubAssign};
 use deep_causality_algebra::Field;

--- a/deep_causality_num/src/float/float_32_impl.rs
+++ b/deep_causality_num/src/float/float_32_impl.rs
@@ -6,9 +6,6 @@
 use crate::Float;
 use core::num::FpCategory;
 
-#[cfg(all(not(feature = "std"), feature = "libm_math"))]
-use libm;
-
 // F32 Helper functions for integer_decode
 fn integer_decode_f32(f: f32) -> (u64, i16, i8) {
     let bits: u32 = f.to_bits();

--- a/deep_causality_num/src/float/float_64_impl.rs
+++ b/deep_causality_num/src/float/float_64_impl.rs
@@ -6,9 +6,6 @@
 use crate::Float;
 use core::num::FpCategory;
 
-#[cfg(all(not(feature = "std"), feature = "libm_math"))]
-use libm;
-
 fn integer_decode_f64(f: f64) -> (u64, i16, i8) {
     let bits: u64 = f.to_bits();
     let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -33,8 +33,14 @@ no-std = ["alloc"]
 # `scoped_map` from an inline map to scoped fork-join threads. Downstream
 # crates forward their own `parallel` feature here so the single
 # definition unifies across the workspace.
-# `parallel` spawns `std::thread::scope` threads, so it requires `std`.
-# Declaring the dependency here makes `no-std + parallel` unrepresentable.
+# `parallel` spawns `std::thread::scope` threads, so it requires `std`, and
+# declaring that here is what lets a bare `--features parallel` — and a
+# downstream crate that forwards only `deep_causality_par/parallel` — resolve
+# to a working host build. It does not make `no-std + parallel` unrepresentable:
+# Cargo features are additive, so `--features no-std,parallel` turns `std` back
+# on rather than failing. That is harmless on a host and impossible on a target
+# without `std`, where `src/lib.rs` rejects the combination with an explicit
+# `compile_error!` instead of a `can't find crate for std` cascade.
 parallel = ["std"]
 
 [dependencies]

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -25,12 +25,17 @@ exclude = [
 ]
 
 [features]
-default = []
+default = ["std"]
+std = ["alloc"]
+alloc = []
+no-std = ["alloc"]
 # Turns `MaybeParallel` into a `Send + Sync` alias and switches
 # `scoped_map` from an inline map to scoped fork-join threads. Downstream
 # crates forward their own `parallel` feature here so the single
 # definition unifies across the workspace.
-parallel = []
+# `parallel` spawns `std::thread::scope` threads, so it requires `std`.
+# Declaring the dependency here makes `no-std + parallel` unrepresentable.
+parallel = ["std"]
 
 [dependencies]
 # Intentionally empty. The fork-join surface (`scoped_map`) rides

--- a/deep_causality_par/src/functions/scoped_map.rs
+++ b/deep_causality_par/src/functions/scoped_map.rs
@@ -22,6 +22,8 @@
 //! matches Rayon without the dependency. For many small, irregular tasks a
 //! real scheduler would win; nothing in the workspace needs one.
 
+use alloc::vec::Vec;
+
 use crate::MaybeParallel;
 
 /// Map `f` over `items`, preserving input order in the returned `Vec`.

--- a/deep_causality_par/src/lib.rs
+++ b/deep_causality_par/src/lib.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! Shared parallelism primitives for the DeepCausality workspace.
 //!
 //! Two items live here:
@@ -18,6 +20,8 @@
 //!   an order-preserving parallel map over a slice on
 //!   [`std::thread::scope`] threads under the `parallel` feature, a plain
 //!   inline map without it. No thread pool, no external dependency.
+
+extern crate alloc;
 
 mod functions;
 pub mod traits;

--- a/deep_causality_par/src/lib.rs
+++ b/deep_causality_par/src/lib.rs
@@ -20,6 +20,57 @@
 //!   an order-preserving parallel map over a slice on
 //!   [`std::thread::scope`] threads under the `parallel` feature, a plain
 //!   inline map without it. No thread pool, no external dependency.
+//!
+//! # Feature levels
+//!
+//! `default = ["std"]`, `std = ["alloc"]`, `alloc = []`, and
+//! `no-std = ["alloc"]` follow the workspace three-level convention. The
+//! crate's own needs are small: `core` for the marker trait, `alloc` for
+//! the [`Vec`](alloc::vec::Vec) that [`scoped_map`] returns. There is no
+//! external dependency to forward a level to, so `std` and `no-std` differ
+//! only in whether the crate declares `no_std`. Bare-metal builds use
+//! `--no-default-features --features no-std` and get the serial inline
+//! map.
+//!
+//! # Why `parallel = ["std"]` stays
+//!
+//! The parallel arm of [`scoped_map`] calls [`std::thread::scope`] and
+//! [`std::thread::available_parallelism`], and neither exists in `core` or
+//! `alloc`. `parallel` therefore declares a dependency on `std`, and that
+//! declaration earns its place: it is what makes a bare `--features
+//! parallel` resolve to a working configuration, and what lets a
+//! downstream crate forward `deep_causality_par/parallel` on its own
+//! (`deep_causality_algorithms`, `deep_causality_topology`,
+//! `deep_causality_cfd`, and `deep_causality_physics` all do) without also
+//! having to remember `deep_causality_par/std`. Dropping it would turn
+//! every one of those into a build error on the host, which is the common
+//! case. `deep_causality_fft` states the same requirement the same way.
+//!
+//! What the declaration does **not** do is make `no-std` plus `parallel`
+//! unrepresentable. Cargo features are additive and cannot express mutual
+//! exclusion: `--features no-std,parallel` does not disable `parallel`, it
+//! re-enables `std` underneath the `no-std` request. On a host that is
+//! harmless, because the resulting `std` build is a valid one and only the
+//! `no-std` request is dropped; `--all-features` relies on exactly that.
+//! On a target that has no `std` to re-enable, it used to surface as
+//! `can't find crate for `std`` plus a cascade of prelude errors that name
+//! neither the feature that caused them nor the way out. The
+//! `compile_error!` below states both instead.
+
+// Rejects `parallel` on a target that has no `std` to fall back on, which
+// is the one place where the additive `parallel = ["std"]` edge cannot
+// deliver what it promises. Keyed on the target rather than on
+// `feature = "no-std"` so that host builds carrying both flags — every
+// `--all-features` build in CI does — stay unaffected.
+#[cfg(all(feature = "parallel", target_os = "none"))]
+compile_error!(
+    "deep_causality_par: the `parallel` feature requires `std`, because `scoped_map` fans out \
+     over `std::thread::scope`, but the selected target has no `std`. Cargo features are \
+     additive, so `--features no-std,parallel` does not turn `parallel` off; it turns `std` back \
+     on through `parallel = [\"std\"]`, and the build then fails to find the `std` crate. Build \
+     bare-metal targets without `parallel` — `--no-default-features --features no-std` — and \
+     `scoped_map` runs the serial inline map."
+);
 
 extern crate alloc;
 

--- a/deep_causality_quantum/BUILD.bazel
+++ b/deep_causality_quantum/BUILD.bazel
@@ -9,6 +9,7 @@ rust_library(
     # compiled and tested; the default *cargo* build stays verifiable-only
     # (`default = []`), which is the modality guarantee the spec states.
     crate_features = [
+        "qcm",
         "qpu",
     ],
     crate_root = "src/lib.rs",
@@ -35,6 +36,7 @@ rust_doc(
     name = "doc",
     crate = ":deep_causality_quantum",
     crate_features = [
+        "qcm",
         "qpu",
     ],
     tags = ["doc"],
@@ -45,6 +47,7 @@ rust_doc_test(
     name = "doc_test",
     crate = ":deep_causality_quantum",
     crate_features = [
+        "qcm",
         "qpu",
     ],
     tags = ["doc-test"],

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -30,7 +30,15 @@ publish = false
 all-features = true
 
 [features]
-default = []
+default = ["std", "qcm"]
+std = ["alloc", "deep_causality_algebra/std", "deep_causality_core/std", "deep_causality_haft/std", "deep_causality_metric/std", "deep_causality_multivector/std", "deep_causality_num/std", "deep_causality_num_complex/std", "deep_causality_tensor/std"]
+alloc = []
+no-std = ["alloc", "deep_causality_algebra/no-std", "deep_causality_core/no-std", "deep_causality_haft/no-std", "deep_causality_metric/no-std", "deep_causality_multivector/no-std", "deep_causality_num/no-std", "deep_causality_num_complex/no-std", "deep_causality_tensor/no-std"]
+
+# The quantum causal-model slice: CausalStructure, the Markov freeze check and the
+# C3-exclusion faithfulness check. Pulls in `deep_causality` for the causal graph,
+# which is std-only, so this is off on bare-metal builds.
+qcm = ["dep:deep_causality"]
 # The emergent QPU seam: QpuSampler / ShotHistogram / the shots→Uncertain
 # bridges / qpu_effect / the in-process SimQpu. Off by default; adds no
 # network or async dependency.
@@ -39,38 +47,47 @@ qpu = ["dep:deep_causality_uncertain"]
 [dependencies.deep_causality]
 path = "../deep_causality"
 version = "0.15"
+optional = true
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 version = "0.2"
+default-features = false
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
 version = "0.11.1"
+default-features = false
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"
 version = "0.2"
+default-features = false
 
 [dependencies.deep_causality_multivector]
 path = "../deep_causality_multivector"
 version = "0.5"
+default-features = false
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
 version = "0.1"
+default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
 version = "0.5"
+default-features = false
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -37,8 +37,8 @@ no-std = ["alloc", "deep_causality_algebra/no-std", "deep_causality_core/no-std"
 
 # The quantum causal-model slice: CausalStructure, the Markov freeze check and the
 # C3-exclusion faithfulness check. Pulls in `deep_causality` for the causal graph,
-# which is std-only, so this is off on bare-metal builds.
-qcm = ["dep:deep_causality"]
+# which is std-only, so `qcm` implies `std` and is off on bare-metal builds.
+qcm = ["std", "dep:deep_causality"]
 # The emergent QPU seam: QpuSampler / ShotHistogram / the shots→Uncertain
 # bridges / qpu_effect / the in-process SimQpu. Off by default; adds no
 # network or async dependency.

--- a/deep_causality_quantum/src/error/quantum_error.rs
+++ b/deep_causality_quantum/src/error/quantum_error.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::String;
+use alloc::format;
+
 use core::fmt::{Debug, Display, Formatter};
 use deep_causality_core::{CausalityError, CausalityErrorEnum};
 

--- a/deep_causality_quantum/src/error/quantum_error.rs
+++ b/deep_causality_quantum/src/error/quantum_error.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::string::String;
 use alloc::format;
+use alloc::string::String;
 
 use core::fmt::{Debug, Display, Formatter};
 use deep_causality_core::{CausalityError, CausalityErrorEnum};

--- a/deep_causality_quantum/src/lib.rs
+++ b/deep_causality_quantum/src/lib.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! Quantum causal models on the causal monad.
 //!
 //! This crate carries the quantum-information layer of DeepCausality: the
@@ -19,11 +21,14 @@
 //! All metric signatures come from `deep_causality_metric`, the single source
 //! of truth; this crate defines no metric type of its own.
 
+extern crate alloc;
+
 pub(crate) mod error;
 pub(crate) mod types;
 
 pub use crate::error::quantum_error::{QuantumError, QuantumErrorEnum};
 
+#[cfg(feature = "qcm")]
 pub use crate::types::qcm::*;
 pub use crate::types::qgates::*;
 pub use crate::types::verdict::*;

--- a/deep_causality_quantum/src/types/density_matrix.rs
+++ b/deep_causality_quantum/src/types/density_matrix.rs
@@ -6,6 +6,9 @@
 //! The mixed-state density matrix with enforced invariants (L1 of the
 //! operator build ladder, design B4).
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{
     frobenius_norm, hermiticity_defect, matrix_trace, square_dim,

--- a/deep_causality_quantum/src/types/density_matrix.rs
+++ b/deep_causality_quantum/src/types/density_matrix.rs
@@ -6,13 +6,13 @@
 //! The mixed-state density matrix with enforced invariants (L1 of the
 //! operator build ladder, design B4).
 
-use alloc::vec;
-use alloc::vec::Vec;
-use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{
     frobenius_norm, hermiticity_defect, matrix_trace, square_dim,
 };
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/src/types/mod.rs
+++ b/deep_causality_quantum/src/types/mod.rs
@@ -4,6 +4,7 @@
  */
 
 pub(crate) mod density_matrix;
+#[cfg(feature = "qcm")]
 pub(crate) mod qcm;
 pub(crate) mod qgates;
 #[cfg(feature = "qpu")]

--- a/deep_causality_quantum/src/types/qcm/faithfulness.rs
+++ b/deep_causality_quantum/src/types/qcm/faithfulness.rs
@@ -16,12 +16,12 @@
 //! commuting CNOTs, `U₃`). A `C₃`-containing structure provably has no
 //! traditional-circuit faithful decomposition and is rejected at freeze.
 
+use crate::QuantumError;
+use alloc::collections::BTreeSet;
+use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::format;
-use crate::QuantumError;
 use deep_causality::CausableGraph;
-use alloc::collections::BTreeSet;
 
 /// A causal structure: a bipartite influence relation between input systems and
 /// output systems. `contains(i, o)` holds when input `i` influences output `o`.

--- a/deep_causality_quantum/src/types/qcm/faithfulness.rs
+++ b/deep_causality_quantum/src/types/qcm/faithfulness.rs
@@ -16,9 +16,12 @@
 //! commuting CNOTs, `U₃`). A `C₃`-containing structure provably has no
 //! traditional-circuit faithful decomposition and is rejected at freeze.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use deep_causality::CausableGraph;
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 /// A causal structure: a bipartite influence relation between input systems and
 /// output systems. `contains(i, o)` holds when input `i` influences output `o`.

--- a/deep_causality_quantum/src/types/qcm/markov_freeze.rs
+++ b/deep_causality_quantum/src/types/qcm/markov_freeze.rs
@@ -11,6 +11,8 @@
 //! not linear-in-depth). It is sound (never accepts a non-commuting model) and
 //! MAY be incomplete.
 
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use crate::types::qcm::faithfulness::CausalStructure;
 use crate::types::qcm::process_factors::{FactorSupports, ProcessFactors};
@@ -18,8 +20,8 @@ use crate::types::qgates::operator_linalg::{embed_on_legs, frobenius_norm, matri
 use deep_causality::{CausableGraph, CausalityGraphError};
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
-use std::cell::RefCell;
-use std::collections::BTreeSet;
+use core::cell::RefCell;
+use alloc::collections::BTreeSet;
 
 /// The orphan-rule-legal bridge from the crate-local [`QuantumError`] into the
 /// engine's `CausalityGraphError`, so a quantum freeze hook can surface a
@@ -42,7 +44,7 @@ impl From<QuantumError> for CausalityGraphError {
 pub struct CommutatorTolerance<R: RealField> {
     safety_factor: R,
     unit_roundoff: R,
-    budgets: std::collections::BTreeMap<usize, R>,
+    budgets: alloc::collections::BTreeMap<usize, R>,
 }
 
 impl<R: RealField + FromPrimitive> Default for CommutatorTolerance<R> {
@@ -50,7 +52,7 @@ impl<R: RealField + FromPrimitive> Default for CommutatorTolerance<R> {
         Self {
             safety_factor: R::from_f64(8.0).unwrap_or_else(R::one),
             unit_roundoff: R::epsilon(),
-            budgets: std::collections::BTreeMap::new(),
+            budgets: alloc::collections::BTreeMap::new(),
         }
     }
 }

--- a/deep_causality_quantum/src/types/qcm/markov_freeze.rs
+++ b/deep_causality_quantum/src/types/qcm/markov_freeze.rs
@@ -11,17 +11,17 @@
 //! not linear-in-depth). It is sound (never accepts a non-commuting model) and
 //! MAY be incomplete.
 
-use alloc::vec::Vec;
-use alloc::format;
 use crate::QuantumError;
 use crate::types::qcm::faithfulness::CausalStructure;
 use crate::types::qcm::process_factors::{FactorSupports, ProcessFactors};
 use crate::types::qgates::operator_linalg::{embed_on_legs, frobenius_norm, matrix_commutator};
+use alloc::collections::BTreeSet;
+use alloc::format;
+use alloc::vec::Vec;
+use core::cell::RefCell;
 use deep_causality::{CausableGraph, CausalityGraphError};
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
-use core::cell::RefCell;
-use alloc::collections::BTreeSet;
 
 /// The orphan-rule-legal bridge from the crate-local [`QuantumError`] into the
 /// engine's `CausalityGraphError`, so a quantum freeze hook can surface a

--- a/deep_causality_quantum/src/types/qcm/process_factors.rs
+++ b/deep_causality_quantum/src/types/qcm/process_factors.rs
@@ -8,14 +8,14 @@
 //! `LambdaEdges` (R3). `σ` is **static freeze-time decoration**, consulted only
 //! at the freeze boundary; it never rides the runtime STATE channel.
 
-use alloc::vec::Vec;
-use alloc::format;
 use crate::QuantumError;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::format;
+use alloc::vec::Vec;
 use deep_causality::CausableGraph;
 use deep_causality_algebra::RealField;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::CausalTensor;
-use alloc::collections::{BTreeMap, BTreeSet};
 
 /// A single Choi–Jamiołkowski factor `ρ_{Aᵢ|Pa(Aᵢ)}` — a complex matrix on the
 /// composite Hilbert space of node `Aᵢ` and its parents.

--- a/deep_causality_quantum/src/types/qcm/process_factors.rs
+++ b/deep_causality_quantum/src/types/qcm/process_factors.rs
@@ -8,12 +8,14 @@
 //! `LambdaEdges` (R3). `σ` is **static freeze-time decoration**, consulted only
 //! at the freeze boundary; it never rides the runtime STATE channel.
 
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use deep_causality::CausableGraph;
 use deep_causality_algebra::RealField;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::CausalTensor;
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 /// A single Choi–Jamiołkowski factor `ρ_{Aᵢ|Pa(Aᵢ)}` — a complex matrix on the
 /// composite Hilbert space of node `Aᵢ` and its parents.

--- a/deep_causality_quantum/src/types/qgates/bridge.rs
+++ b/deep_causality_quantum/src/types/qgates/bridge.rs
@@ -20,6 +20,8 @@
 //!   conjugation** (grade involution ∘ reversion) + coefficient conjugation
 //!   is the metric-correct adjoint.
 
+use alloc::vec::Vec;
+use alloc::format;
 use crate::{QuantumError, QuantumOps};
 use deep_causality_algebra::RealField;
 use deep_causality_multivector::{CausalMultiVector, HilbertState, MultiVector};

--- a/deep_causality_quantum/src/types/qgates/bridge.rs
+++ b/deep_causality_quantum/src/types/qgates/bridge.rs
@@ -20,9 +20,9 @@
 //!   conjugation** (grade involution ∘ reversion) + coefficient conjugation
 //!   is the metric-correct adjoint.
 
-use alloc::vec::Vec;
-use alloc::format;
 use crate::{QuantumError, QuantumOps};
+use alloc::format;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 use deep_causality_multivector::{CausalMultiVector, HilbertState, MultiVector};
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/src/types/qgates/channel.rs
+++ b/deep_causality_quantum/src/types/qgates/channel.rs
@@ -17,13 +17,13 @@
 //! Reichenbach's principle" (2022); M.-D. Choi, "Completely positive linear
 //! maps on complex matrices", Linear Algebra Appl. 10 (1975) 285–290.
 
-use alloc::vec;
-use alloc::vec::Vec;
-use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{
     hermiticity_defect, identity_matrix, partial_trace, square_dim,
 };
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/src/types/qgates/channel.rs
+++ b/deep_causality_quantum/src/types/qgates/channel.rs
@@ -17,6 +17,9 @@
 //! Reichenbach's principle" (2022); M.-D. Choi, "Completely positive linear
 //! maps on complex matrices", Linear Algebra Appl. 10 (1975) 285–290.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{
     hermiticity_defect, identity_matrix, partial_trace, square_dim,

--- a/deep_causality_quantum/src/types/qgates/gates.rs
+++ b/deep_causality_quantum/src/types/qgates/gates.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use deep_causality_algebra::RealField;
 use deep_causality_multivector::{CausalMultiVector, MultiVector};
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/src/types/qgates/mechanics.rs
+++ b/deep_causality_quantum/src/types/qgates/mechanics.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::format;
+
 use crate::QuantumError;
 use crate::types::qgates::bridge::metric_adjoint;
 use crate::types::qgates::gates_haruna;

--- a/deep_causality_quantum/src/types/qgates/operator_linalg.rs
+++ b/deep_causality_quantum/src/types/qgates/operator_linalg.rs
@@ -11,15 +11,15 @@
 //! everything is plain index arithmetic over the existing tensor substrate;
 //! no new numeric substance.
 
+use crate::QuantumError;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::format;
-use crate::QuantumError;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::{CausalTensor, Tensor};
-use alloc::collections::{BTreeMap, BTreeSet};
 
 /// Validates that `op` is a non-empty square matrix and returns its dimension.
 pub(crate) fn square_dim<R>(op: &CausalTensor<Complex<R>>) -> Result<usize, QuantumError>

--- a/deep_causality_quantum/src/types/qgates/operator_linalg.rs
+++ b/deep_causality_quantum/src/types/qgates/operator_linalg.rs
@@ -11,12 +11,15 @@
 //! everything is plain index arithmetic over the existing tensor substrate;
 //! no new numeric substance.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;
 use deep_causality_tensor::{CausalTensor, Tensor};
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 /// Validates that `op` is a non-empty square matrix and returns its dimension.
 pub(crate) fn square_dim<R>(op: &CausalTensor<Complex<R>>) -> Result<usize, QuantumError>

--- a/deep_causality_quantum/src/types/qpu/bridge.rs
+++ b/deep_causality_quantum/src/types/qpu/bridge.rs
@@ -9,10 +9,10 @@
 //! measurement statistics surface as `Uncertain<_>`, and a job failure routes to
 //! the error channel with the value absent.
 
-use alloc::format;
 use crate::QuantumError;
 use crate::types::qpu::circuit::QuantumCircuit;
 use crate::types::qpu::sampler::{QpuSampler, ShotHistogram};
+use alloc::format;
 use core::fmt::Debug;
 use deep_causality_core::{
     CausalEffectPropagationProcess, CausalityError, EffectLog, PropagatingEffect,

--- a/deep_causality_quantum/src/types/qpu/bridge.rs
+++ b/deep_causality_quantum/src/types/qpu/bridge.rs
@@ -9,6 +9,7 @@
 //! measurement statistics surface as `Uncertain<_>`, and a job failure routes to
 //! the error channel with the value absent.
 
+use alloc::format;
 use crate::QuantumError;
 use crate::types::qpu::circuit::QuantumCircuit;
 use crate::types::qpu::sampler::{QpuSampler, ShotHistogram};

--- a/deep_causality_quantum/src/types/qpu/circuit.rs
+++ b/deep_causality_quantum/src/types/qpu/circuit.rs
@@ -8,6 +8,9 @@
 //! as inert input so both an in-process simulator and a future cloud adapter
 //! satisfy the same `QpuSampler` trait.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
 use crate::QuantumError;
 
 /// A single reified gate over the migrated gate alphabet. Plain data — no

--- a/deep_causality_quantum/src/types/qpu/circuit.rs
+++ b/deep_causality_quantum/src/types/qpu/circuit.rs
@@ -8,10 +8,10 @@
 //! as inert input so both an in-process simulator and a future cloud adapter
 //! satisfy the same `QpuSampler` trait.
 
+use crate::QuantumError;
+use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::format;
-use crate::QuantumError;
 
 /// A single reified gate over the migrated gate alphabet. Plain data — no
 /// function pointers, no amplitudes.

--- a/deep_causality_quantum/src/types/qpu/sampler.rs
+++ b/deep_causality_quantum/src/types/qpu/sampler.rs
@@ -8,10 +8,10 @@
 //! by [`ShotHistogram`], which exposes a classical outcome-count map — never
 //! amplitudes — pinning the Kleisli/coherence boundary at the type level.
 
-use alloc::vec::Vec;
 use crate::QuantumError;
 use crate::types::qpu::circuit::QuantumCircuit;
 use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 /// A classical measurement histogram: outcome bitstrings (packed LSB-first over
 /// the circuit's measured qubits) to shot counts. Never exposes amplitudes.

--- a/deep_causality_quantum/src/types/qpu/sampler.rs
+++ b/deep_causality_quantum/src/types/qpu/sampler.rs
@@ -8,9 +8,10 @@
 //! by [`ShotHistogram`], which exposes a classical outcome-count map — never
 //! amplitudes — pinning the Kleisli/coherence boundary at the type level.
 
+use alloc::vec::Vec;
 use crate::QuantumError;
 use crate::types::qpu::circuit::QuantumCircuit;
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 /// A classical measurement histogram: outcome bitstrings (packed LSB-first over
 /// the circuit's measured qubits) to shot counts. Never exposes amplitudes.

--- a/deep_causality_quantum/src/types/qpu/sim.rs
+++ b/deep_causality_quantum/src/types/qpu/sim.rs
@@ -8,6 +8,10 @@
 //! examples can exercise the emergent path without any network/async/vendor
 //! dependency. Given a fixed seed it reproduces the same histogram exactly.
 
+use alloc::vec;
+use alloc::string::String;
+use alloc::format;
+use alloc::string::ToString;
 use crate::QuantumError;
 use crate::types::qpu::circuit::{GateOp, QuantumCircuit};
 use crate::types::qpu::sampler::{CountHistogram, QpuSampler};
@@ -149,8 +153,8 @@ impl QpuSampler for SimQpu {
         let mut state = vec![C::new(0.0, 0.0); dim];
         state[0] = C::new(1.0, 0.0);
 
-        let s = 1.0 / std::f64::consts::SQRT_2;
-        let pi4 = std::f64::consts::FRAC_PI_4;
+        let s = 1.0 / core::f64::consts::SQRT_2;
+        let pi4 = core::f64::consts::FRAC_PI_4;
         for op in circuit.ops() {
             // Exhaustive over all GateOp variants — no catch-all, so a new gate
             // must be handled explicitly rather than silently mis-applied.

--- a/deep_causality_quantum/src/types/qpu/sim.rs
+++ b/deep_causality_quantum/src/types/qpu/sim.rs
@@ -8,13 +8,13 @@
 //! examples can exercise the emergent path without any network/async/vendor
 //! dependency. Given a fixed seed it reproduces the same histogram exactly.
 
-use alloc::vec;
-use alloc::string::String;
-use alloc::format;
-use alloc::string::ToString;
 use crate::QuantumError;
 use crate::types::qpu::circuit::{GateOp, QuantumCircuit};
 use crate::types::qpu::sampler::{CountHistogram, QpuSampler};
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
 
 /// The calibration surfaced to the context channel by `qpu_effect`.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/deep_causality_quantum/src/types/verdict/born.rs
+++ b/deep_causality_quantum/src/types/verdict/born.rs
@@ -10,10 +10,10 @@
 //! measurement projection — the Born rule `Tr(Pρ)` for a probability, or the
 //! projection itself for a proposition in the orthomodular lattice.
 
-use alloc::format;
 use crate::QuantumError;
 use crate::types::density_matrix::DensityMatrix;
 use crate::types::verdict::projection::Projection;
+use alloc::format;
 use deep_causality_algebra::{Prob, RealField};
 use deep_causality_num::FromPrimitive;
 

--- a/deep_causality_quantum/src/types/verdict/born.rs
+++ b/deep_causality_quantum/src/types/verdict/born.rs
@@ -10,6 +10,7 @@
 //! measurement projection — the Born rule `Tr(Pρ)` for a probability, or the
 //! projection itself for a proposition in the orthomodular lattice.
 
+use alloc::format;
 use crate::QuantumError;
 use crate::types::density_matrix::DensityMatrix;
 use crate::types::verdict::projection::Projection;

--- a/deep_causality_quantum/src/types/verdict/projection.rs
+++ b/deep_causality_quantum/src/types/verdict/projection.rs
@@ -17,6 +17,8 @@
 //! meet/join. Verdicts are extracted from operators at the measurement boundary
 //! (see [`crate::verdict::born`]).
 
+use alloc::vec;
+use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{hermiticity_defect, identity_matrix, square_dim};
 use deep_causality_algebra::{RealField, Verdict};

--- a/deep_causality_quantum/src/types/verdict/projection.rs
+++ b/deep_causality_quantum/src/types/verdict/projection.rs
@@ -17,10 +17,10 @@
 //! meet/join. Verdicts are extracted from operators at the measurement boundary
 //! (see [`crate::verdict::born`]).
 
-use alloc::vec;
-use alloc::format;
 use crate::QuantumError;
 use crate::types::qgates::operator_linalg::{hermiticity_defect, identity_matrix, square_dim};
+use alloc::format;
+use alloc::vec;
 use deep_causality_algebra::{RealField, Verdict};
 use deep_causality_num::FromPrimitive;
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/tests/BUILD.bazel
+++ b/deep_causality_quantum/tests/BUILD.bazel
@@ -82,6 +82,9 @@ rust_test_suite(
     srcs = glob([
         "types/qcm/*_tests.rs",
     ]),
+    crate_features = [
+        "qcm",
+    ],
     tags = [
         "unit-test",
     ],

--- a/deep_causality_quantum/tests/types/qcm/environment_tests.rs
+++ b/deep_causality_quantum/tests/types/qcm/environment_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg(feature = "qcm")]
+
 use deep_causality_num_complex::Complex;
 use deep_causality_quantum::{DensityMatrix, EnvironmentalPrep};
 use deep_causality_tensor::CausalTensor;

--- a/deep_causality_quantum/tests/types/qcm/faithfulness_tests.rs
+++ b/deep_causality_quantum/tests/types/qcm/faithfulness_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg(feature = "qcm")]
+
 use deep_causality::utils_test::test_utils;
 use deep_causality::{CausableGraph, CausaloidGraph};
 use deep_causality_quantum::{CausalStructure, QuantumErrorEnum};

--- a/deep_causality_quantum/tests/types/qcm/markov_freeze_tests.rs
+++ b/deep_causality_quantum/tests/types/qcm/markov_freeze_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg(feature = "qcm")]
+
 use deep_causality::utils_test::test_utils;
 use deep_causality::{CausableGraph, CausalityGraphError, CausaloidGraph};
 use deep_causality_num_complex::Complex;

--- a/deep_causality_quantum/tests/types/qcm/mod.rs
+++ b/deep_causality_quantum/tests/types/qcm/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+#![cfg(feature = "qcm")]
 #[cfg(test)]
 mod environment_tests;
 #[cfg(test)]

--- a/deep_causality_quantum/tests/types/qcm/process_factors_tests.rs
+++ b/deep_causality_quantum/tests/types/qcm/process_factors_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg(feature = "qcm")]
+
 use deep_causality::utils_test::test_utils;
 use deep_causality::{CausableGraph, CausaloidGraph};
 use deep_causality_num_complex::Complex;

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -28,13 +28,19 @@ exclude = [
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 version = "0.2"
+default-features = false
 
 
 [features]
+default = ["std"]
+std = ["alloc", "deep_causality_num/std", "deep_causality_algebra/std"]
+alloc = []
+no-std = ["alloc", "deep_causality_num/no-std", "deep_causality_algebra/no-std"]
 # Enables random number generator from the host OS.
 # Enabling os-random adds an indirect depdency on getrandom and libc.
 # Disabled by default. Use aead-random instead to protect against hardware RNG attacks.

--- a/deep_causality_rand/README.md
+++ b/deep_causality_rand/README.md
@@ -61,7 +61,15 @@ There are many valid reasons and use cases for macros, and, in fact, this crate 
 
 ## No-Std
 
-Unfortunately, a `no-std` option is not yet supported in this first release. It can be added at some point but requires more work. If you need `no-std`, please file an issue. Alternatively, explore the `no-std` option in the [rand](https://crates.io/crates/rand) crate.
+This crate builds without a standard library. Three feature levels select the target environment:
+
+* `std` (the default) builds against the standard library. This is the level that enables the thread-local generator behind `rng()` and host entropy for seeding.
+* `alloc` adds the heap without the standard library. It is a level rather than a complete configuration, because it does not say where floating-point math comes from; select it through `std` or `no-std` rather than on its own.
+* `no-std` builds against `core` plus `alloc` and routes float math through the pure-Rust `libm` crate that `deep_causality_num` pulls in, so still no libc. Build with `cargo build --no-default-features --features no-std`, and cross-compile to a bare-metal target the same way, for example `--target aarch64-unknown-none`.
+
+Seeding deserves attention on bare metal. A bare-metal target offers no ambient entropy and no thread identity, so `Xoshiro256::new()` falls back to a per-call counter mixed into a fixed base seed. Successive calls within one run yield distinct streams, but the whole sequence repeats identically after every reset, which makes the default seeding reproducible rather than random. When the stream has to differ per boot, seed explicitly with `Xoshiro256::from_seed` from whatever entropy the board offers, such as a hardware RNG peripheral, ADC noise, or a timer capture. This crate cannot know what a given board provides, so that entropy belongs to the firmware. The counter also uses a 32-bit atomic, so targets without atomic compare-and-swap must call `Xoshiro256::from_seed` directly.
+
+`ThreadRng` and the thread-local generator it wraps require `std` and are therefore unavailable under `no-std`; there, `rng()` hands back an owned `Xoshiro256` that the caller keeps. The "os-random" feature flag is a separate matter: `getrandom` ships no backend for a bare-metal target, so that combination fails to build unless the firmware registers a custom backend.
 
 ## Contributions
 

--- a/deep_causality_rand/src/errors/bernoulli_error.rs
+++ b/deep_causality_rand/src/errors/bernoulli_error.rs
@@ -10,7 +10,7 @@ pub enum BernoulliDistributionError {
     InvalidProbability,
 }
 
-impl std::error::Error for BernoulliDistributionError {}
+impl core::error::Error for BernoulliDistributionError {}
 
 impl fmt::Display for BernoulliDistributionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/deep_causality_rand/src/errors/normal_error.rs
+++ b/deep_causality_rand/src/errors/normal_error.rs
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-use core::fmt;
 use core::error::Error;
+use core::fmt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NormalDistributionError {

--- a/deep_causality_rand/src/errors/normal_error.rs
+++ b/deep_causality_rand/src/errors/normal_error.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use core::fmt;
-use std::error::Error;
+use core::error::Error;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NormalDistributionError {

--- a/deep_causality_rand/src/errors/rng_error.rs
+++ b/deep_causality_rand/src/errors/rng_error.rs
@@ -3,8 +3,11 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::String;
+use alloc::string::ToString;
+
 use crate::UniformDistributionError;
-use std::error::Error;
+use core::error::Error;
 
 #[derive(Debug, PartialEq)]
 pub enum RngError {
@@ -15,8 +18,8 @@ pub enum RngError {
 
 impl Error for RngError {}
 
-impl std::fmt::Display for RngError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for RngError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             RngError::OsRandomGenerator(e) => write!(f, "OS random generator error: {}", e),
             RngError::InvalidRange(e) => write!(f, "Invalid range: {}", e),

--- a/deep_causality_rand/src/errors/uniform_error.rs
+++ b/deep_causality_rand/src/errors/uniform_error.rs
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-use core::fmt;
 use core::error::Error;
+use core::fmt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UniformDistributionError {

--- a/deep_causality_rand/src/errors/uniform_error.rs
+++ b/deep_causality_rand/src/errors/uniform_error.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use core::fmt;
-use std::error::Error;
+use core::error::Error;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UniformDistributionError {

--- a/deep_causality_rand/src/extensions/uniform/uniform_u32.rs
+++ b/deep_causality_rand/src/extensions/uniform/uniform_u32.rs
@@ -5,7 +5,7 @@
 
 use crate::{Rng, SampleBorrow, SampleRange, SampleUniform, UniformSampler};
 use crate::{RngError, UniformDistributionError};
-use std::ops::Range;
+use core::ops::Range;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct UniformU32 {

--- a/deep_causality_rand/src/extensions/uniform/uniform_u64.rs
+++ b/deep_causality_rand/src/extensions/uniform/uniform_u64.rs
@@ -6,7 +6,7 @@
 use crate::{Rng, SampleBorrow, SampleRange, SampleUniform, UniformSampler};
 use crate::{RngError, UniformDistributionError};
 
-use std::ops::Range;
+use core::ops::Range;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct UniformU64 {

--- a/deep_causality_rand/src/extensions/uniform/uniform_usize.rs
+++ b/deep_causality_rand/src/extensions/uniform/uniform_usize.rs
@@ -5,7 +5,7 @@
 
 use crate::{Rng, SampleBorrow, SampleRange, SampleUniform, UniformSampler};
 use crate::{RngError, UniformDistributionError};
-use std::ops::Range;
+use core::ops::Range;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct UniformUsize {

--- a/deep_causality_rand/src/lib.rs
+++ b/deep_causality_rand/src/lib.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod errors;
 mod extensions;
 mod traits;
@@ -42,18 +46,18 @@ pub use crate::types::map::Map;
 pub use crate::types::qmc::sobol::{MAX_SOBOL_DIM, SobolSequence};
 pub use crate::types::range::{Open01, OpenClosed01};
 
-#[cfg(not(feature = "os-random"))]
-use std::cell::RefCell;
+#[cfg(all(feature = "std", not(feature = "os-random")))]
+use core::cell::RefCell;
 
-#[cfg(not(feature = "os-random"))]
+#[cfg(all(feature = "std", not(feature = "os-random")))]
 thread_local! {
     static THREAD_RNG: RefCell<Xoshiro256> = RefCell::new(Xoshiro256::new());
 }
 
-#[cfg(not(feature = "os-random"))]
+#[cfg(all(feature = "std", not(feature = "os-random")))]
 pub struct ThreadRng;
 
-#[cfg(not(feature = "os-random"))]
+#[cfg(all(feature = "std", not(feature = "os-random")))]
 impl RngCore for ThreadRng {
     fn next_u32(&mut self) -> u32 {
         THREAD_RNG.with(|rng| rng.borrow_mut().next_u32())
@@ -66,7 +70,7 @@ impl RngCore for ThreadRng {
     }
 }
 
-#[cfg(not(feature = "os-random"))]
+#[cfg(all(feature = "std", not(feature = "os-random")))]
 impl Rng for ThreadRng {}
 
 /// Returns a new random number generator.
@@ -85,8 +89,15 @@ pub fn rng() -> impl Rng {
 
         OsRandomRng::new().expect("Failed to create OsRandomRng")
     }
-    #[cfg(not(feature = "os-random"))]
+    #[cfg(all(feature = "std", not(feature = "os-random")))]
     {
         ThreadRng
+    }
+    // Bare metal: no threads, so no thread-local generator. Hand back an
+    // owned `Xoshiro256`; the caller keeps it rather than reaching for a
+    // process-wide one.
+    #[cfg(all(not(feature = "std"), not(feature = "os-random")))]
+    {
+        Xoshiro256::new()
     }
 }

--- a/deep_causality_rand/src/lib.rs
+++ b/deep_causality_rand/src/lib.rs
@@ -73,14 +73,21 @@ impl RngCore for ThreadRng {
 #[cfg(all(feature = "std", not(feature = "os-random")))]
 impl Rng for ThreadRng {}
 
-/// Returns a new random number generator.
+/// Returns a new random number generator. Which one depends on the enabled
+/// features:
 ///
-/// By default, this returns a `ThreadRng` backed by `Xoshiro256` PRNG, with each
-/// thread getting a unique seed derived from the thread ID.
-/// If the `os-random` feature is enabled, it returns an `OsRandomRng` that
-/// sources entropy from the operating system.
-/// If the `aead-random` feature is enabled, it returns a `ChaCha20Rng` seeded from
-/// the OS CSPRNG. This is the preferred secure option.
+/// * With `os-random`: an `OsRandomRng` that sources every draw from the
+///   operating system. This is the option to use in production.
+/// * With `std` and without `os-random` (the default): a `ThreadRng` handle to
+///   a thread-local [`Xoshiro256`]. Each thread seeds its generator once, from
+///   a fresh `RandomState` mixed with the thread id, so threads of one process
+///   run distinct streams.
+/// * Without `std` and without `os-random` (bare metal): an owned
+///   [`Xoshiro256`] that the caller keeps, since there are no threads to hang a
+///   thread-local on. Its seed comes from a per-call counter rather than
+///   ambient entropy, so the sequence of streams repeats identically after
+///   every reset. When the stream has to differ per boot, build the generator
+///   with [`Xoshiro256::from_seed`] and a seed drawn from the board.
 pub fn rng() -> impl Rng {
     #[cfg(feature = "os-random")]
     {

--- a/deep_causality_rand/src/traits/rng_core.rs
+++ b/deep_causality_rand/src/traits/rng_core.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::ops::DerefMut;
+use core::ops::DerefMut;
 
 pub trait RngCore {
     fn next_u32(&mut self) -> u32 {

--- a/deep_causality_rand/src/traits/sample_range.rs
+++ b/deep_causality_rand/src/traits/sample_range.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::string::ToString;
 use crate::{Rng, RngError};
+use alloc::string::ToString;
 use core::ops::Range;
 
 pub trait SampleRange<T> {

--- a/deep_causality_rand/src/traits/sample_range.rs
+++ b/deep_causality_rand/src/traits/sample_range.rs
@@ -2,8 +2,10 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::string::ToString;
 use crate::{Rng, RngError};
-use std::ops::Range;
+use core::ops::Range;
 
 pub trait SampleRange<T> {
     fn sample_single<R: Rng + ?Sized>(self, rng: &mut R) -> Result<T, RngError>;

--- a/deep_causality_rand/src/types/distr/normal/standard_normal.rs
+++ b/deep_causality_rand/src/types/distr/normal/standard_normal.rs
@@ -3,6 +3,12 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+// On `std` the inherent `f64::exp`/`ln` win method resolution. Without it they
+// do not exist, and the `Float` impl in `deep_causality_num` supplies them
+// (routed to libm), so the trait only needs to be in scope on `no_std`.
+#[cfg(not(feature = "std"))]
+use deep_causality_num::Float;
+
 use crate::Open01;
 use crate::utils::{ziggurat_sampler, ziggurat_tables};
 use crate::{Distribution, Rng};

--- a/deep_causality_rand/src/types/distr/uniform/mod.rs
+++ b/deep_causality_rand/src/types/distr/uniform/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     Distribution, Rng, SampleBorrow, SampleUniform, UniformDistributionError, UniformSampler,
 };
 use deep_causality_algebra::RealField;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Uniform<X: SampleUniform>(X::Sampler);

--- a/deep_causality_rand/src/types/distr/uniform/mod.rs
+++ b/deep_causality_rand/src/types/distr/uniform/mod.rs
@@ -8,8 +8,8 @@ pub mod standard_uniform;
 use crate::{
     Distribution, Rng, SampleBorrow, SampleUniform, UniformDistributionError, UniformSampler,
 };
-use deep_causality_algebra::RealField;
 use core::fmt::Debug;
+use deep_causality_algebra::RealField;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Uniform<X: SampleUniform>(X::Sampler);

--- a/deep_causality_rand/src/types/qmc/sobol.rs
+++ b/deep_causality_rand/src/types/qmc/sobol.rs
@@ -14,6 +14,7 @@
 //! unscrambled), which uses the Joe–Kuo `new-joe-kuo-6.21201` set — so the generated points
 //! match a widely used reference implementation bit-for-bit.
 
+use alloc::format;
 use crate::{RngCore, RngError, Xoshiro256};
 
 /// Maximum dimension supported by the embedded direction-number table.

--- a/deep_causality_rand/src/types/qmc/sobol.rs
+++ b/deep_causality_rand/src/types/qmc/sobol.rs
@@ -14,8 +14,8 @@
 //! unscrambled), which uses the Joe–Kuo `new-joe-kuo-6.21201` set — so the generated points
 //! match a widely used reference implementation bit-for-bit.
 
-use alloc::format;
 use crate::{RngCore, RngError, Xoshiro256};
+use alloc::format;
 
 /// Maximum dimension supported by the embedded direction-number table.
 pub const MAX_SOBOL_DIM: usize = 16;

--- a/deep_causality_rand/src/types/rand/std_rng.rs
+++ b/deep_causality_rand/src/types/rand/std_rng.rs
@@ -17,20 +17,53 @@ impl Default for Xoshiro256 {
     }
 }
 
+/// Base seed shared by both seeding paths.
+const BASE_SEED: u64 = 0x736f_6d65_7073_6575;
+
+/// Ambient entropy from the host: a fresh `RandomState` mixed with the thread
+/// id, so each thread of a process draws a distinct stream.
+#[cfg(feature = "std")]
+fn entropy_seed() -> u64 {
+    use core::hash::BuildHasher;
+    use std::collections::hash_map::RandomState;
+    use std::thread;
+
+    let hash_builder = RandomState::new();
+    BASE_SEED.wrapping_add(hash_builder.hash_one(thread::current().id()))
+}
+
+/// Bare metal has neither ambient entropy nor a thread identity, so there is
+/// nothing honest to draw from. A counter is mixed into the base seed instead:
+/// successive `new()` calls within one run yield distinct streams, and the
+/// sequence repeats identically after every reset.
+///
+/// When the stream has to differ per boot, seed explicitly with
+/// [`Xoshiro256::from_seed`]. On an embedded target the entropy belongs to the
+/// board — a hardware RNG peripheral, ADC noise, a timer capture — not to this
+/// crate, which cannot know what the board offers.
+///
+/// Uses a 32-bit atomic, so targets without atomic compare-and-swap must use
+/// [`Xoshiro256::from_seed`] directly.
+#[cfg(not(feature = "std"))]
+fn entropy_seed() -> u64 {
+    use core::sync::atomic::{AtomicU32, Ordering};
+
+    /// Golden-ratio odd stride: walks the whole 32-bit range before repeating.
+    const GOLDEN: u32 = 0x9E37_79B9;
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    let n = COUNTER.fetch_add(GOLDEN, Ordering::Relaxed);
+    BASE_SEED.wrapping_add(u64::from(n))
+}
+
 impl Xoshiro256 {
+    /// Creates a generator seeded from whatever ambient entropy the target
+    /// offers. See [`entropy_seed`] for what that means on each: on `std` a
+    /// per-thread draw, on `no_std` a per-call counter that repeats across
+    /// resets. Use [`from_seed`](Self::from_seed) when the seed must be known
+    /// or must vary per boot.
     pub fn new() -> Self {
-        use std::collections::hash_map::RandomState;
-        use std::hash::BuildHasher;
-        use std::thread;
-
-        // Base seed for deterministic behavior within a single thread
-        let base_seed = 0x736f6d6570736575u64;
-
-        // Combine base seed with thread ID to ensure each thread gets a unique seed
-        let hash_builder = RandomState::new();
-        let thread_component = hash_builder.hash_one(thread::current().id());
-
-        Self::from_seed(base_seed.wrapping_add(thread_component))
+        Self::from_seed(entropy_seed())
     }
 
     /// Creates a generator from an explicit 64-bit seed.

--- a/deep_causality_rand/src/types/rand/std_rng.rs
+++ b/deep_causality_rand/src/types/rand/std_rng.rs
@@ -58,10 +58,17 @@ fn entropy_seed() -> u64 {
 
 impl Xoshiro256 {
     /// Creates a generator seeded from whatever ambient entropy the target
-    /// offers. See [`entropy_seed`] for what that means on each: on `std` a
-    /// per-thread draw, on `no_std` a per-call counter that repeats across
-    /// resets. Use [`from_seed`](Self::from_seed) when the seed must be known
-    /// or must vary per boot.
+    /// offers.
+    ///
+    /// On `std` that is a per-thread draw: a fresh `RandomState` mixed with the
+    /// current thread id, so two threads of one process run distinct streams.
+    /// On `no_std` there is neither ambient entropy nor a thread identity, so
+    /// the seed comes from a per-call counter instead: successive calls within
+    /// one run yield distinct streams, and the sequence repeats identically
+    /// after every reset.
+    ///
+    /// Use [`from_seed`](Self::from_seed) when the seed must be known, must be
+    /// reproducible, or must vary per boot on a bare-metal target.
     pub fn new() -> Self {
         Self::from_seed(entropy_seed())
     }

--- a/deep_causality_sparse/Cargo.toml
+++ b/deep_causality_sparse/Cargo.toml
@@ -26,7 +26,9 @@ exclude = [
 
 [features]
 default = ["std"]
-std = ["deep_causality_num/default", "deep_causality_algebra/default"]
+std = ["alloc", "deep_causality_num/std", "deep_causality_algebra/std", "deep_causality_haft/std", "deep_causality_tensor?/std"]
+alloc = []
+no-std = ["alloc", "deep_causality_num/no-std", "deep_causality_algebra/no-std", "deep_causality_haft/no-std", "deep_causality_tensor?/no-std"]
 # Opt-in: enables CausalTensor <-> CsrMatrix iso (forward `From`,
 # reverse Tier 2 `Iso`, inherent `to_dense()` alias). Pulls in
 # `deep_causality_tensor` as a transitive dependency. Off by default
@@ -47,6 +49,7 @@ default-features = false
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"

--- a/deep_causality_sparse/src/errors/sparse_matrix_error.rs
+++ b/deep_causality_sparse/src/errors/sparse_matrix_error.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::fmt;
+use core::fmt;
 
 /// Represents errors that can occur during sparse matrix operations.
 #[derive(Debug, Clone, PartialEq, Eq)] // Added Clone, PartialEq, Eq for completeness
@@ -45,4 +45,4 @@ impl fmt::Display for SparseMatrixError {
     }
 }
 
-impl std::error::Error for SparseMatrixError {}
+impl core::error::Error for SparseMatrixError {}

--- a/deep_causality_sparse/src/extensions/ext_hkt.rs
+++ b/deep_causality_sparse/src/extensions/ext_hkt.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_haft::{
     Adjunction, Applicative, CoMonad, Foldable, Functor, HKT, Monad, Pure, Satisfies,

--- a/deep_causality_sparse/src/extensions/ext_iso.rs
+++ b/deep_causality_sparse/src/extensions/ext_iso.rs
@@ -39,9 +39,9 @@
 //! `RingIso`, etc. would not type-check. The base `Iso<S, T>` is the
 //! right surface.
 
+use crate::CsrMatrix;
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::CsrMatrix;
 use core::fmt;
 use deep_causality_algebra::iso::witness::Iso;
 use deep_causality_num::Zero;

--- a/deep_causality_sparse/src/extensions/ext_iso.rs
+++ b/deep_causality_sparse/src/extensions/ext_iso.rs
@@ -70,7 +70,6 @@ impl fmt::Display for CsrFromTensorError {
     }
 }
 
-#[cfg(feature = "std")]
 impl core::error::Error for CsrFromTensorError {}
 
 // =============================================================================

--- a/deep_causality_sparse/src/extensions/ext_iso.rs
+++ b/deep_causality_sparse/src/extensions/ext_iso.rs
@@ -39,6 +39,8 @@
 //! `RingIso`, etc. would not type-check. The base `Iso<S, T>` is the
 //! right surface.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::CsrMatrix;
 use core::fmt;
 use deep_causality_algebra::iso::witness::Iso;
@@ -69,7 +71,7 @@ impl fmt::Display for CsrFromTensorError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CsrFromTensorError {}
+impl core::error::Error for CsrFromTensorError {}
 
 // =============================================================================
 // Forward (Tier 1): CausalTensor<F> -> CsrMatrix<F> via TryFrom

--- a/deep_causality_sparse/src/lib.rs
+++ b/deep_causality_sparse/src/lib.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 mod errors;
 mod extensions;
 mod solver;

--- a/deep_causality_sparse/src/solver/cg.rs
+++ b/deep_causality_sparse/src/solver/cg.rs
@@ -19,6 +19,8 @@
 //! The solver is generic over any [`RealField`] precision (`f32`, `f64`,
 //! `Float106`, …) and adds no external numeric dependency.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 

--- a/deep_causality_sparse/src/types/sparse_matrix/algebra/group.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/algebra/group.rs
@@ -3,14 +3,17 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_algebra::AbelianGroup;
-use std::ops::Sub;
+use core::ops::Sub;
 
 // AbelianGroup for CsrMatrix
 impl<T> AbelianGroup for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq,
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq,
 {
     // Marker trait, no methods needed here.
 }
@@ -62,7 +65,7 @@ where
 
 impl<T> CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T>,
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T>,
 {
     /// Element-wise negation.
     pub fn neg(&self) -> Self {

--- a/deep_causality_sparse/src/types/sparse_matrix/algebra/group.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/algebra/group.rs
@@ -7,8 +7,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::CsrMatrix;
-use deep_causality_algebra::AbelianGroup;
 use core::ops::Sub;
+use deep_causality_algebra::AbelianGroup;
 
 // AbelianGroup for CsrMatrix
 impl<T> AbelianGroup for CsrMatrix<T>

--- a/deep_causality_sparse/src/types/sparse_matrix/algebra/module.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/algebra/module.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_algebra::{Module, Ring};
 

--- a/deep_causality_sparse/src/types/sparse_matrix/algebra/ring.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/algebra/ring.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_algebra::Ring;
 use deep_causality_num::One;

--- a/deep_causality_sparse/src/types/sparse_matrix/api/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/api/mod.rs
@@ -3,10 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{CsrMatrix, SparseMatrixError};
-use deep_causality_num::{One, Zero};
+use alloc::vec::Vec;
 use core::ops::{Mul, Sub};
+use deep_causality_num::{One, Zero};
 
 impl<T> CsrMatrix<T>
 where

--- a/deep_causality_sparse/src/types/sparse_matrix/api/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/api/mod.rs
@@ -2,9 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{CsrMatrix, SparseMatrixError};
 use deep_causality_num::{One, Zero};
-use std::ops::{Mul, Sub};
+use core::ops::{Mul, Sub};
 
 impl<T> CsrMatrix<T>
 where

--- a/deep_causality_sparse/src/types/sparse_matrix/arithmetic/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/arithmetic/mod.rs
@@ -6,8 +6,8 @@
 use alloc::vec::Vec;
 
 use crate::CsrMatrix;
-use deep_causality_algebra::{AbelianGroup, Ring};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use deep_causality_algebra::{AbelianGroup, Ring};
 
 // ============================================================================
 // Add Implementations (4 variants for all ownership combinations)

--- a/deep_causality_sparse/src/types/sparse_matrix/arithmetic/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/arithmetic/mod.rs
@@ -3,9 +3,11 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_algebra::{AbelianGroup, Ring};
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 // ============================================================================
 // Add Implementations (4 variants for all ownership combinations)
@@ -14,7 +16,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 // owned + owned
 impl<T> Add for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
@@ -25,7 +27,7 @@ where
 // ref + ref
 impl<T> Add for &CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = CsrMatrix<T>;
     fn add(self, rhs: Self) -> CsrMatrix<T> {
@@ -36,7 +38,7 @@ where
 // owned + ref
 impl<T> Add<&CsrMatrix<T>> for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = Self;
     fn add(self, rhs: &Self) -> Self {
@@ -47,7 +49,7 @@ where
 // ref + owned
 impl<T> Add<CsrMatrix<T>> for &CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = CsrMatrix<T>;
     fn add(self, rhs: CsrMatrix<T>) -> CsrMatrix<T> {
@@ -61,7 +63,7 @@ where
 
 impl<T> AddAssign for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq,
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq,
 {
     fn add_assign(&mut self, rhs: Self) {
         *self = CsrMatrix::add(self, &rhs);
@@ -70,7 +72,7 @@ where
 
 impl<T> AddAssign<&CsrMatrix<T>> for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq,
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq,
 {
     fn add_assign(&mut self, rhs: &Self) {
         *self = CsrMatrix::add(self, rhs);
@@ -86,8 +88,8 @@ impl<T> Sub for CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq, // Added Default + PartialEq
 {
@@ -102,8 +104,8 @@ impl<T> Sub for &CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq, // Added Default + PartialEq
 {
@@ -118,8 +120,8 @@ impl<T> Sub<&CsrMatrix<T>> for CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq, // Added Default + PartialEq
 {
@@ -134,8 +136,8 @@ impl<T> Sub<CsrMatrix<T>> for &CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq, // Added Default + PartialEq
 {
@@ -153,8 +155,8 @@ impl<T> SubAssign for CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq,
 {
@@ -167,8 +169,8 @@ impl<T> SubAssign<&CsrMatrix<T>> for CsrMatrix<T>
 where
     T: AbelianGroup
         + Copy
-        + std::ops::Sub<Output = T>
-        + std::ops::Neg<Output = T>
+        + core::ops::Sub<Output = T>
+        + core::ops::Neg<Output = T>
         + Default
         + PartialEq,
 {
@@ -184,7 +186,7 @@ where
 // owned
 impl<T> Neg for CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = Self;
     fn neg(self) -> Self {
@@ -195,7 +197,7 @@ where
 // borrowed
 impl<T> Neg for &CsrMatrix<T>
 where
-    T: AbelianGroup + Copy + std::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
+    T: AbelianGroup + Copy + core::ops::Neg<Output = T> + Default + PartialEq, // Added Default + PartialEq
 {
     type Output = CsrMatrix<T>;
     fn neg(self) -> CsrMatrix<T> {
@@ -210,7 +212,7 @@ where
 // owned + owned
 impl<T> Mul for CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign, // Added Default + PartialEq and AddAssign
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign, // Added Default + PartialEq and AddAssign
 {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
@@ -221,7 +223,7 @@ where
 // ref + ref
 impl<T> Mul for &CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign, // Added Default + PartialEq and AddAssign
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign, // Added Default + PartialEq and AddAssign
 {
     type Output = CsrMatrix<T>;
     fn mul(self, rhs: Self) -> CsrMatrix<T> {
@@ -232,7 +234,7 @@ where
 // owned + ref
 impl<T> Mul<&CsrMatrix<T>> for CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign, // Added Default + PartialEq and AddAssign
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign, // Added Default + PartialEq and AddAssign
 {
     type Output = Self;
     fn mul(self, rhs: &Self) -> Self {
@@ -243,7 +245,7 @@ where
 // ref + owned
 impl<T> Mul<CsrMatrix<T>> for &CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign, // Added Default + PartialEq and AddAssign
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign, // Added Default + PartialEq and AddAssign
 {
     type Output = CsrMatrix<T>;
     fn mul(self, rhs: CsrMatrix<T>) -> CsrMatrix<T> {
@@ -257,7 +259,7 @@ where
 
 impl<T> MulAssign for CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign,
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign,
 {
     fn mul_assign(&mut self, rhs: Self) {
         *self = CsrMatrix::mul(self, &rhs);
@@ -266,7 +268,7 @@ where
 
 impl<T> MulAssign<&CsrMatrix<T>> for CsrMatrix<T>
 where
-    T: Ring + Copy + Default + PartialEq + std::ops::AddAssign,
+    T: Ring + Copy + Default + PartialEq + core::ops::AddAssign,
 {
     fn mul_assign(&mut self, rhs: &Self) {
         *self = CsrMatrix::mul(self, rhs);

--- a/deep_causality_sparse/src/types/sparse_matrix/display/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/display/mod.rs
@@ -5,13 +5,13 @@
 
 use crate::CsrMatrix;
 use deep_causality_num::Zero;
-use std::fmt::Display;
+use core::fmt::Display;
 
 impl<T> Display for CsrMatrix<T>
 where
     T: Display + Copy + Zero + PartialEq, // Added Zero and PartialEq for get_value_at
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let (rows, cols) = self.shape;
         if rows == 0 || cols == 0 {
             return write!(f, "CsrMatrix ({}x{}) [Empty]", rows, cols);

--- a/deep_causality_sparse/src/types/sparse_matrix/display/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/display/mod.rs
@@ -4,8 +4,8 @@
  */
 
 use crate::CsrMatrix;
-use deep_causality_num::Zero;
 use core::fmt::Display;
+use deep_causality_num::Zero;
 
 impl<T> Display for CsrMatrix<T>
 where

--- a/deep_causality_sparse/src/types/sparse_matrix/getters/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/getters/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::CsrMatrix;
+use alloc::vec::Vec;
 use deep_causality_num::Zero;
 
 impl<T> CsrMatrix<T> {

--- a/deep_causality_sparse/src/types/sparse_matrix/getters/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/getters/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::CsrMatrix;
 use deep_causality_num::Zero;
 

--- a/deep_causality_sparse/src/types/sparse_matrix/identity/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/identity/mod.rs
@@ -7,9 +7,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::CsrMatrix;
+use core::ops::Neg;
 use deep_causality_algebra::{AbelianGroup, Ring};
 use deep_causality_num::{One, Zero};
-use core::ops::Neg;
 
 // Implements Zero trait for CsrMatrix.
 // Returns an empty (0,0) matrix, representing a scalar zero.

--- a/deep_causality_sparse/src/types/sparse_matrix/identity/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/identity/mod.rs
@@ -3,10 +3,13 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
 use deep_causality_algebra::{AbelianGroup, Ring};
 use deep_causality_num::{One, Zero};
-use std::ops::Neg;
+use core::ops::Neg;
 
 // Implements Zero trait for CsrMatrix.
 // Returns an empty (0,0) matrix, representing a scalar zero.
@@ -38,7 +41,7 @@ impl<T> One for CsrMatrix<T>
 where
     // These bounds are needed for CsrMatrix<T> to satisfy Mul<Self> required by One.
     // T itself needs to be Ring for CsrMatrix's Mul impl.
-    T: One + Copy + Default + PartialEq + Ring + std::ops::AddAssign,
+    T: One + Copy + Default + PartialEq + Ring + core::ops::AddAssign,
 {
     fn one() -> Self {
         // Scalar one matrix is a 1x1 identity matrix

--- a/deep_causality_sparse/src/types/sparse_matrix/mod.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod algebra;
 mod api;
 mod arithmetic;
@@ -250,7 +253,7 @@ where
 
 impl<T> CsrMatrix<T>
 where
-    T: Clone + PartialEq + std::ops::Add<Output = T>,
+    T: Clone + PartialEq + core::ops::Add<Output = T>,
 {
     /// Creates a new `CsrMatrix` from a list of `(row, col, value)` triplets, using an explicit zero value.
     ///
@@ -349,7 +352,7 @@ where
     /// * `zero` - The value to treat as zero.
     pub fn add_with_zero(&self, other: &Self, zero: T) -> Result<Self, SparseMatrixError>
     where
-        T: std::ops::Add<Output = T>,
+        T: core::ops::Add<Output = T>,
     {
         self.add_matrix_with_zero_impl(other, zero)
     }

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/add_matrix_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/add_matrix_impl.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{CsrMatrix, SparseMatrixError};
 use deep_causality_num::Zero;
 
@@ -47,7 +49,7 @@ impl<T> CsrMatrix<T> {
     /// ```
     pub(crate) fn add_matrix_impl(&self, other: &Self) -> Result<Self, SparseMatrixError>
     where
-        T: Clone + Zero + std::ops::Add<Output = T> + PartialEq,
+        T: Clone + Zero + core::ops::Add<Output = T> + PartialEq,
     {
         self.add_matrix_with_zero_impl(other, T::zero())
     }
@@ -58,7 +60,7 @@ impl<T> CsrMatrix<T> {
         zero: T,
     ) -> Result<Self, SparseMatrixError>
     where
-        T: Clone + std::ops::Add<Output = T> + PartialEq,
+        T: Clone + core::ops::Add<Output = T> + PartialEq,
     {
         if self.shape != other.shape {
             return Err(SparseMatrixError::ShapeMismatch(self.shape, other.shape));

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/mat_mult_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/mat_mult_impl.rs
@@ -3,11 +3,11 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CsrMatrix, SparseMatrixError};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CsrMatrix, SparseMatrixError};
-use deep_causality_num::Zero;
 use core::ops::Mul;
+use deep_causality_num::Zero;
 
 impl<T> CsrMatrix<T> {
     /// Performs matrix multiplication: \( C = A \cdot B \).

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/mat_mult_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/mat_mult_impl.rs
@@ -2,9 +2,12 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CsrMatrix, SparseMatrixError};
 use deep_causality_num::Zero;
-use std::ops::Mul;
+use core::ops::Mul;
 
 impl<T> CsrMatrix<T> {
     /// Performs matrix multiplication: \( C = A \cdot B \).

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/scalar_mult_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/scalar_mult_impl.rs
@@ -3,8 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::CsrMatrix;
-use std::ops::Mul;
+use core::ops::Mul;
 
 impl<T> CsrMatrix<T> {
     /// Performs scalar multiplication: \( B = s \cdot A \).

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/sub_matrix_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/sub_matrix_impl.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{CsrMatrix, SparseMatrixError};
 use deep_causality_num::Zero;
 
@@ -47,7 +49,7 @@ impl<T> CsrMatrix<T> {
     /// ```
     pub(crate) fn sub_matrix_impl(&self, other: &Self) -> Result<Self, SparseMatrixError>
     where
-        T: Copy + Zero + std::ops::Sub<Output = T> + PartialEq,
+        T: Copy + Zero + core::ops::Sub<Output = T> + PartialEq,
     {
         if self.shape != other.shape {
             return Err(SparseMatrixError::ShapeMismatch(self.shape, other.shape));

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/transpose_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/transpose_impl.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
 use crate::CsrMatrix;
 use deep_causality_num::Zero;
 

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/transpose_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/transpose_impl.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
 use crate::CsrMatrix;
+use alloc::vec;
 use deep_causality_num::Zero;
 
 impl<T> CsrMatrix<T> {

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/vec_mult_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/vec_mult_impl.rs
@@ -3,10 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{CsrMatrix, SparseMatrixError};
-use deep_causality_num::Zero;
+use alloc::vec::Vec;
 use core::ops::Mul;
+use deep_causality_num::Zero;
 
 impl<T> CsrMatrix<T> {
     /// Performs matrix-vector multiplication: \( y = Ax \).

--- a/deep_causality_sparse/src/types/sparse_matrix/ops/vec_mult_impl.rs
+++ b/deep_causality_sparse/src/types/sparse_matrix/ops/vec_mult_impl.rs
@@ -2,9 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{CsrMatrix, SparseMatrixError};
 use deep_causality_num::Zero;
-use std::ops::Mul;
+use core::ops::Mul;
 
 impl<T> CsrMatrix<T> {
     /// Performs matrix-vector multiplication: \( y = Ax \).
@@ -46,7 +48,7 @@ impl<T> CsrMatrix<T> {
     /// ```
     pub(crate) fn vec_mult_impl(&self, x: &[T]) -> Result<Vec<T>, SparseMatrixError>
     where
-        T: Copy + Zero + std::ops::Add<Output = T> + Mul<Output = T>,
+        T: Copy + Zero + core::ops::Add<Output = T> + Mul<Output = T>,
     {
         if x.len() != self.shape.1 {
             return Err(SparseMatrixError::DimensionMismatch(self.shape.1, x.len()));

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -25,29 +25,41 @@ exclude = [
     "papers/*",
 ]
 
+[features]
+default = ["std"]
+std = ["alloc", "deep_causality_ast/std", "deep_causality_haft/std", "deep_causality_num/std", "deep_causality_algebra/std", "deep_causality_num_complex/std", "deep_causality_num_dual/std"]
+alloc = []
+no-std = ["alloc", "deep_causality_ast/no-std", "deep_causality_haft/no-std", "deep_causality_num/no-std", "deep_causality_algebra/no-std", "deep_causality_num_complex/no-std", "deep_causality_num_dual/no-std"]
+
 [dependencies.deep_causality_ast]
 path = "../deep_causality_ast"
 version = "0.1"
+default-features = false
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
 version = "0.4"
+default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 version = "0.2"
+default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
 version = "0.1"
+default-features = false
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
 version = "0.1"
+default-features = false
 
 [dev-dependencies]
 criterion = { version = "0.8" }

--- a/deep_causality_tensor/src/errors/causal_tensor_error.rs
+++ b/deep_causality_tensor/src/errors/causal_tensor_error.rs
@@ -3,8 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::string::String;
 use crate::EinSumValidationError;
+use alloc::string::String;
 use core::error::Error;
 
 /// Errors that can occur during tensor operations.

--- a/deep_causality_tensor/src/errors/causal_tensor_error.rs
+++ b/deep_causality_tensor/src/errors/causal_tensor_error.rs
@@ -2,8 +2,10 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::string::String;
 use crate::EinSumValidationError;
-use std::error::Error;
+use core::error::Error;
 
 /// Errors that can occur during tensor operations.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
@@ -34,8 +36,8 @@ pub enum CausalTensorError {
 
 impl Error for CausalTensorError {}
 
-impl std::fmt::Display for CausalTensorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for CausalTensorError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             CausalTensorError::ShapeMismatch => {
                 write!(f, "CausalTensorError: Shape mismatch error")

--- a/deep_causality_tensor/src/errors/ein_sum_validation_error.rs
+++ b/deep_causality_tensor/src/errors/ein_sum_validation_error.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
-use std::error::Error;
+
+use alloc::string::String;
+use core::error::Error;
 
 /// Specific errors that can occur during EinSum AST validation or execution.
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
@@ -19,8 +21,8 @@ pub enum EinSumValidationError {
     RankMismatch { expected: usize, found: usize },
 }
 
-impl std::fmt::Display for EinSumValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for EinSumValidationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             EinSumValidationError::InvalidNumberOfChildren { expected, found } => {
                 write!(

--- a/deep_causality_tensor/src/extensions/ext_hkt.rs
+++ b/deep_causality_tensor/src/extensions/ext_hkt.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensor;
 use crate::traits::tensor::Tensor;
 use deep_causality_haft::{

--- a/deep_causality_tensor/src/extensions/ext_hkt_strict.rs
+++ b/deep_causality_tensor/src/extensions/ext_hkt_strict.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensor;
 use deep_causality_haft::{Foldable, Functor, HKT, Pure, Satisfies};
 use deep_causality_num_complex::Complex;

--- a/deep_causality_tensor/src/extensions/ext_hkt_strict_tests.rs
+++ b/deep_causality_tensor/src/extensions/ext_hkt_strict_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensor;
 use crate::extensions::ext_hkt_strict::StrictCausalTensorWitness;
 use deep_causality_haft::{Foldable, Functor, Pure};

--- a/deep_causality_tensor/src/extensions/ext_hkt_tensor_train.rs
+++ b/deep_causality_tensor/src/extensions/ext_hkt_tensor_train.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensor;
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;
 use crate::types::causal_tensor_network::causal_tensor_train::CausalTensorTrain;

--- a/deep_causality_tensor/src/extensions/ext_math.rs
+++ b/deep_causality_tensor/src/extensions/ext_math.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::CausalTensor;
 use crate::CausalTensorError;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 
 pub trait CausalTensorMathExt<T> {

--- a/deep_causality_tensor/src/extensions/ext_math.rs
+++ b/deep_causality_tensor/src/extensions/ext_math.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::CausalTensor;
 use crate::CausalTensorError;
 use deep_causality_algebra::RealField;
@@ -23,10 +25,10 @@ pub trait CausalTensorMathExt<T> {
     /// ```
     /// use deep_causality_tensor::{CausalTensor, CausalTensorMathExt};
     ///
-    /// let tensor = CausalTensor::new(vec![1.0, std::f32::consts::E, 10.0], vec![3, 1]).unwrap();
+    /// let tensor = CausalTensor::new(vec![1.0, core::f32::consts::E, 10.0], vec![3, 1]).unwrap();
     /// let result = tensor.log_nat().unwrap();
     ///
-    /// assert_eq!(result.as_slice(), &[0.0, 0.99999994, std::f32::consts::LN_10]); // Approx. ln(10)
+    /// assert_eq!(result.as_slice(), &[0.0, 0.99999994, core::f32::consts::LN_10]); // Approx. ln(10)
     /// ```
     fn log_nat(&self) -> Result<CausalTensor<T>, CausalTensorError>;
 

--- a/deep_causality_tensor/src/extensions/ext_stats.rs
+++ b/deep_causality_tensor/src/extensions/ext_stats.rs
@@ -3,12 +3,12 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
-use alloc::vec::Vec;
-use alloc::format;
-use alloc::string::ToString;
 use crate::CausalTensor;
 use crate::CausalTensorError;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::RealField;
 use deep_causality_num::FromPrimitive;
 

--- a/deep_causality_tensor/src/extensions/ext_stats.rs
+++ b/deep_causality_tensor/src/extensions/ext_stats.rs
@@ -2,6 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::string::ToString;
 use crate::CausalTensor;
 use crate::CausalTensorError;
 use deep_causality_algebra::RealField;

--- a/deep_causality_tensor/src/lib.rs
+++ b/deep_causality_tensor/src/lib.rs
@@ -2,6 +2,10 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 mod errors;
 mod extensions;
 mod traits;

--- a/deep_causality_tensor/src/traits/tensor.rs
+++ b/deep_causality_tensor/src/traits/tensor.rs
@@ -2,11 +2,13 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumAST};
 use deep_causality_algebra::{RealField, Ring};
 use deep_causality_num::{One, Zero};
-use std::iter::Sum;
-use std::ops::{Add, Div, Mul};
+use core::iter::Sum;
+use core::ops::{Add, Div, Mul};
 
 pub trait Tensor<T> {
     /// Public API for Einstein summation.

--- a/deep_causality_tensor/src/traits/tensor.rs
+++ b/deep_causality_tensor/src/traits/tensor.rs
@@ -3,12 +3,12 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumAST};
-use deep_causality_algebra::{RealField, Ring};
-use deep_causality_num::{One, Zero};
+use alloc::vec::Vec;
 use core::iter::Sum;
 use core::ops::{Add, Div, Mul};
+use deep_causality_algebra::{RealField, Ring};
+use deep_causality_num::{One, Zero};
 
 pub trait Tensor<T> {
     /// Public API for Einstein summation.

--- a/deep_causality_tensor/src/types/causal_tensor/algebra/group.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/algebra/group.rs
@@ -3,13 +3,15 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensor;
 use deep_causality_algebra::{AbelianGroup, AddGroup};
 
 /// Marker trait for Abelian Group.
 /// CausalTensor addition is commutative if T's addition is commutative.
 impl<T> AbelianGroup for CausalTensor<T> where
-    T: AbelianGroup + Copy + Default + PartialOrd + std::ops::Neg<Output = T>
+    T: AbelianGroup + Copy + Default + PartialOrd + core::ops::Neg<Output = T>
 {
 }
 
@@ -18,7 +20,7 @@ impl<T> AbelianGroup for CausalTensor<T> where
 
 impl<T> CausalTensor<T>
 where
-    T: AddGroup + Copy + std::ops::Neg<Output = T>,
+    T: AddGroup + Copy + core::ops::Neg<Output = T>,
 {
     /// Creates a zero tensor with the specified shape.
     pub fn zero(shape: &[usize]) -> Self {

--- a/deep_causality_tensor/src/types/causal_tensor/algebra/ring.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/algebra/ring.rs
@@ -3,6 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensor;
 use deep_causality_algebra::{Associative, Distributive, Ring};
 

--- a/deep_causality_tensor/src/types/causal_tensor/api/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/api/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumAST, Tensor};
 use core::iter::Sum;
 use core::ops::{Add, Div, Mul};

--- a/deep_causality_tensor/src/types/causal_tensor/api/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/api/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumAST, Tensor};
+use alloc::vec::Vec;
 use core::iter::Sum;
 use core::ops::{Add, Div, Mul};
 use deep_causality_algebra::{RealField, Ring};

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/identity/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/identity/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
 use crate::CausalTensor;
 use deep_causality_num::{One, Zero};
 

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/identity/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/identity/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
 use crate::CausalTensor;
+use alloc::vec;
 use deep_causality_num::{One, Zero};
 
 /// Implements Zero trait for CausalTensor.

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/neg/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/neg/mod.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::CausalTensor;
-use std::ops::Neg;
+use core::ops::Neg;
 
 /// Implements Neg trait for CausalTensor.
 impl<T> Neg for CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_f32.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_f32.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // ############################################################################
 // ############################### ADDITION ###################################

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_f64.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_f64.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // ############################################################################
 // ############################### ADDITION ###################################

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i128.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i128.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- i128 ---
 impl<'a> Add<&'a CausalTensor<i128>> for i128

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i16.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i16.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- i16 ---
 impl<'a> Add<&'a CausalTensor<i16>> for i16

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i32.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i32.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- i32 ---
 impl<'a> Add<&'a CausalTensor<i32>> for i32

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i64.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i64.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- i64 ---
 impl<'a> Add<&'a CausalTensor<i64>> for i64

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i8.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_i8.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // ############################################################################
 // ############################### ADDITION ###################################

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u128.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u128.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- u128 ---
 impl<'a> Add<&'a CausalTensor<u128>> for u128

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u16.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u16.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- u16 ---
 impl<'a> Add<&'a CausalTensor<u16>> for u16

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u32.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u32.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- u32 ---
 impl<'a> Add<&'a CausalTensor<u32>> for u32

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u64.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u64.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- u64 ---
 impl<'a> Add<&'a CausalTensor<u64>> for u64

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u8.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/scalar_tensor/op_scalar_tensor_u8.rs
@@ -3,7 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 // --- u8 ---
 impl<'a> Add<&'a CausalTensor<u8>> for u8

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_scalar/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_scalar/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 use crate::types::causal_tensor::CausalTensor;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
-// Implemented via `std::ops` traits for ergonomic use (`+`, `-`, `*`, `/`).
+// Implemented via `core::ops` traits for ergonomic use (`+`, `-`, `*`, `/`).
 
 // --- ADDITION ---
 

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_tensor/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_tensor/mod.rs
@@ -5,7 +5,7 @@
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
 use deep_causality_num::Zero;
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 //
 // Implement Add trait for CausalTensor

--- a/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_tensor/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/arithmetic/tensor_tensor/mod.rs
@@ -4,8 +4,8 @@
  */
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
-use deep_causality_num::Zero;
 use core::ops::{Add, Div, Mul, Sub};
+use deep_causality_num::Zero;
 
 //
 // Implement Add trait for CausalTensor

--- a/deep_causality_tensor/src/types/causal_tensor/display/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/display/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::CausalTensor;
 
-impl<T: std::fmt::Display> std::fmt::Display for CausalTensor<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: core::fmt::Display> core::fmt::Display for CausalTensor<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CausalTensor {{ data: [")?;
         let max_items = 10;
         for (i, item) in self.data.iter().take(max_items).enumerate() {

--- a/deep_causality_tensor/src/types/causal_tensor/from/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/from/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensor;
 
 impl<T: Clone> From<T> for CausalTensor<T> {

--- a/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
@@ -3,6 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 // `get_ref` and `set` are crate-private helpers (used by `inverse_impl`), so
 // their error branches can only be exercised from within the crate.
 

--- a/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
@@ -3,7 +3,6 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-
 // `get_ref` and `set` are crate-private helpers (used by `inverse_impl`), so
 // their error branches can only be exercised from within the crate.
 

--- a/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/getters/get_ref_tests.rs
@@ -3,7 +3,6 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
 
 // `get_ref` and `set` are crate-private helpers (used by `inverse_impl`), so
 // their error branches can only be exercised from within the crate.

--- a/deep_causality_tensor/src/types/causal_tensor/getters/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/getters/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 mod get_ref;
 #[cfg(test)]
 mod get_ref_tests;

--- a/deep_causality_tensor/src/types/causal_tensor/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensorError;
 
 mod algebra;

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_broadcast/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_broadcast/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_dagger/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_dagger/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
 use deep_causality_algebra::ConjugateScalar;

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_eigen/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_eigen/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
 use deep_causality_algebra::{ConjugateScalar, Real};

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_execution.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_execution.rs
@@ -4,7 +4,7 @@
  */
 use crate::Tensor;
 use crate::{CausalTensor, CausalTensorError, EinSumAST, EinSumOp};
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl.rs
@@ -2,9 +2,14 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::string::ToString;
 use crate::Tensor;
 use crate::{CausalTensor, CausalTensorError, EinSumAST, EinSumValidationError};
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl.rs
@@ -3,12 +3,12 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
-use alloc::vec::Vec;
-use alloc::format;
-use alloc::string::ToString;
 use crate::Tensor;
 use crate::{CausalTensor, CausalTensorError, EinSumAST, EinSumValidationError};
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::ops::{Add, Mul};
 
 impl<T> CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl_tests.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl_tests.rs
@@ -3,7 +3,6 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-
 // The implementation is all module private thus tests can only be within the same module.
 
 mod tests {

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl_tests.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_impl_tests.rs
@@ -3,6 +3,7 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+
 // The implementation is all module private thus tests can only be within the same module.
 
 mod tests {

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_op.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_op.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::CausalTensor;
 use deep_causality_ast::ConstTree;
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_op.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_ein_sum/ein_sum_op.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::CausalTensor;
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::CausalTensor;
 use deep_causality_ast::ConstTree;
 
 // The core enum for the EinSum AST. T is the element type (e.g., Complex<f64>)

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_inverse/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_inverse/mod.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError};
 use deep_causality_algebra::RealField;
 use deep_causality_num::{One, Zero};

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_inverse/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_inverse/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CausalTensor, CausalTensorError};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CausalTensor, CausalTensorError};
 use deep_causality_algebra::RealField;
 use deep_causality_num::{One, Zero};
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_kronecker/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_kronecker/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::CausalTensorError;
 use crate::types::causal_tensor::CausalTensor;
 use deep_causality_algebra::ConjugateScalar;

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_product/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_product/mod.rs
@@ -3,10 +3,10 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumOp};
-use deep_causality_algebra::Ring;
+use alloc::vec::Vec;
 use core::ops::Mul;
+use deep_causality_algebra::Ring;
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_product/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_product/mod.rs
@@ -2,9 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError, EinSumOp};
 use deep_causality_algebra::Ring;
-use std::ops::Mul;
+use core::ops::Mul;
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qr/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qr/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+
 use crate::{CausalTensor, CausalTensorError};
 use deep_causality_algebra::{ConjugateScalar, Real};
 use deep_causality_num::{One, Zero};

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qtt/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qtt/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use alloc::format;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 
 use crate::{CausalTensor, CausalTensorError, Tensor};
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qtt/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_qtt/mod.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+use alloc::format;
+use alloc::string::ToString;
+
 use crate::{CausalTensor, CausalTensorError, Tensor};
 
 impl<T> CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_reduction/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_reduction/mod.rs
@@ -2,12 +2,15 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::Tensor;
 use crate::{CausalTensor, CausalTensorError};
 use deep_causality_algebra::RealField;
 use deep_causality_num::Zero;
-use std::iter::Sum;
-use std::ops::{Add, Div, Mul};
+use core::iter::Sum;
+use core::ops::{Add, Div, Mul};
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_reduction/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_reduction/mod.rs
@@ -3,14 +3,14 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
-use alloc::vec::Vec;
 use crate::Tensor;
 use crate::{CausalTensor, CausalTensorError};
-use deep_causality_algebra::RealField;
-use deep_causality_num::Zero;
+use alloc::vec;
+use alloc::vec::Vec;
 use core::iter::Sum;
 use core::ops::{Add, Div, Mul};
+use deep_causality_algebra::RealField;
+use deep_causality_num::Zero;
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_shape/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_shape/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::string::ToString;
 
 use crate::{CausalTensor, CausalTensorError};
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_shape/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_shape/mod.rs
@@ -3,6 +3,10 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::string::ToString;
+
 use crate::{CausalTensor, CausalTensorError};
 
 impl<T> CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_stack/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_stack/mod.rs
@@ -2,8 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError};
-use std::ops::{Add, Mul};
+use core::ops::{Add, Mul};
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_stack/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_stack/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CausalTensor, CausalTensorError};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CausalTensor, CausalTensorError};
 use core::ops::{Add, Mul};
 
 impl<T> CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
 use crate::{CausalTensor, CausalTensorError, Tensor};
+use alloc::vec;
 use deep_causality_algebra::RealField;
 use deep_causality_num::{One, Zero};
 

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
 use crate::{CausalTensor, CausalTensorError, Tensor};
 use deep_causality_algebra::RealField;
 use deep_causality_num::{One, Zero};

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_decomp/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_decomp/mod.rs
@@ -2,10 +2,13 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError};
 use deep_causality_algebra::RealField;
-use std::iter::Sum;
-use std::ops::Neg;
+use core::iter::Sum;
+use core::ops::Neg;
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_decomp/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_decomp/mod.rs
@@ -3,12 +3,12 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CausalTensor, CausalTensorError};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CausalTensor, CausalTensorError};
-use deep_causality_algebra::RealField;
 use core::iter::Sum;
 use core::ops::Neg;
+use deep_causality_algebra::RealField;
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_truncated/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_svd_truncated/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::types::causal_tensor_network::causal_tensor_train::linalg::matmul;
 use crate::types::causal_tensor_network::rng::gaussian_vec;
 use crate::types::causal_tensor_network::truncation::{RoundStrategy, Truncation};

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_view/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_view/mod.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CausalTensor, CausalTensorError};
 
 impl<T> CausalTensor<T>

--- a/deep_causality_tensor/src/types/causal_tensor/ops/tensor_view/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/ops/tensor_view/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::{CausalTensor, CausalTensorError};
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::{CausalTensor, CausalTensorError};
 
 impl<T> CausalTensor<T>
 where

--- a/deep_causality_tensor/src/types/causal_tensor/to/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/to/mod.rs
@@ -3,8 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec::Vec;
 use crate::CausalTensor;
+use alloc::vec::Vec;
 
 impl<T> CausalTensor<T> {
     pub fn from_vec(data: Vec<T>, shape: &[usize]) -> Self {

--- a/deep_causality_tensor/src/types/causal_tensor/to/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor/to/mod.rs
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec::Vec;
 use crate::CausalTensor;
 
 impl<T> CausalTensor<T> {

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/api/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/api/mod.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::string::ToString;
+
 use crate::traits::tensor_train::TensorTrain;
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;
 use crate::types::causal_tensor_network::causal_tensor_train::construct::MAX_DENSE_ELEMS;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/api/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/api/mod.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::string::ToString;
 
 use crate::traits::tensor_train::TensorTrain;
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/construct/cross.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/construct/cross.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;
 use crate::types::causal_tensor_network::causal_tensor_train::CausalTensorTrain;
 use crate::types::causal_tensor_network::causal_tensor_train::linalg::matmul;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/construct/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/construct/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod cross;
 
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/getters/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/getters/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::CausalTensor;
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;
 use crate::types::causal_tensor_network::causal_tensor_train::CausalTensorTrain;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/linalg/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/linalg/mod.rs
@@ -9,6 +9,8 @@
 //! (no `Default`), so they stay valid for the dual-number scalar — unlike `CausalTensor::matmul`,
 //! which requires `Default`.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::ConjugateScalar;
 
 /// Row-major matrix product: `a` (`m × k`) times `b` (`k × n`) into an `m × n` buffer.

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod algebra;
 mod api;
 mod construct;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/round_rand/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/round_rand/mod.rs
@@ -12,13 +12,13 @@
 //! (`ℓ` columns) left-to-right. No QR ever touches a full bond-`r` unfolding, so the cost is
 //! `O(d·n·r²·ℓ)` with `ℓ ≈ target rank + oversample`.
 
-use alloc::vec;
-use alloc::vec::Vec;
 use crate::types::causal_tensor_network::causal_tensor_train::CausalTensorTrain;
 use crate::types::causal_tensor_network::causal_tensor_train::linalg::matmul;
 use crate::types::causal_tensor_network::rng::gaussian_vec;
 use crate::types::causal_tensor_network::truncation::Truncation;
 use crate::{CausalTensor, CausalTensorError, Tensor, TensorTrain};
+use alloc::vec;
+use alloc::vec::Vec;
 use deep_causality_algebra::ConjugateScalar;
 
 type Re<T> = <T as ConjugateScalar>::Real;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/round_rand/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train/round_rand/mod.rs
@@ -12,6 +12,8 @@
 //! (`ℓ` columns) left-to-right. No QR ever touches a full bond-`r` unfolding, so the cost is
 //! `O(d·n·r²·ℓ)` with `ℓ ≈ target rank + oversample`.
 
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::types::causal_tensor_network::causal_tensor_train::CausalTensorTrain;
 use crate::types::causal_tensor_network::causal_tensor_train::linalg::matmul;
 use crate::types::causal_tensor_network::rng::gaussian_vec;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/api/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/api/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::traits::tensor_train::TensorTrain;
 use crate::traits::tensor_train_operator::TensorTrainOperator;
 use crate::types::causal_tensor_network::canonical_form::CanonicalForm;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/getters/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/getters/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::CausalTensor;
 use crate::types::causal_tensor_network::causal_tensor_train_operator::CausalTensorTrainOperator;
 use crate::types::causal_tensor_network::truncation::Truncation;

--- a/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/causal_tensor_train_operator/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod api;
 mod arrow;
 mod getters;

--- a/deep_causality_tensor/src/types/causal_tensor_network/cross_config/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/cross_config/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
+
 use crate::CausalTensorError;
 use deep_causality_algebra::Real;
 

--- a/deep_causality_tensor/src/types/causal_tensor_network/rng/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/rng/mod.rs
@@ -20,6 +20,7 @@
 //! previous `(z >> 11) / 2^53` mapping — the change is transparent at `f64` and only *adds* precision
 //! at higher-precision scalars.
 
+use alloc::vec::Vec;
 use deep_causality_algebra::{ConjugateScalar, Real, Scalar};
 use deep_causality_num::{FromPrimitive, One, Zero};
 

--- a/deep_causality_tensor/src/types/causal_tensor_network/solve/local.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/solve/local.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::string::ToString;
+
 use crate::TensorTrain;
 use crate::traits::tensor_train_operator::TensorTrainOperator;
 use crate::types::causal_tensor::sym_eig;

--- a/deep_causality_tensor/src/types/causal_tensor_network/solve/local.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/solve/local.rs
@@ -3,9 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::string::ToString;
 
 use crate::TensorTrain;
 use crate::traits::tensor_train_operator::TensorTrainOperator;

--- a/deep_causality_tensor/src/types/causal_tensor_network/solve_config/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/solve_config/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
+
 use crate::CausalTensorError;
 use deep_causality_algebra::Real;
 

--- a/deep_causality_tensor/src/types/causal_tensor_network/truncation/mod.rs
+++ b/deep_causality_tensor/src/types/causal_tensor_network/truncation/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::string::ToString;
+
 use crate::CausalTensorError;
 use deep_causality_algebra::Real;
 

--- a/deep_causality_tensor/src/utils/utils_tests.rs
+++ b/deep_causality_tensor/src/utils/utils_tests.rs
@@ -2,6 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::CausalTensor;
 
 // Helper function to create a simple scalar tensor for testing

--- a/deep_causality_tensor/src/utils/utils_tests.rs
+++ b/deep_causality_tensor/src/utils/utils_tests.rs
@@ -3,9 +3,9 @@
  * Copyright (c) "2025" . The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use crate::CausalTensor;
 use alloc::vec;
 use alloc::vec::Vec;
-use crate::CausalTensor;
 
 // Helper function to create a simple scalar tensor for testing
 pub fn scalar_tensor(value: f64) -> CausalTensor<f64> {

--- a/deep_causality_topology/src/types/cup_product/mod.rs
+++ b/deep_causality_topology/src/types/cup_product/mod.rs
@@ -27,6 +27,16 @@
 //! adds what quantum error correction needs and that surface cannot express:
 //! the cubical case, genericity over [`ChainComplex`], and the `n`-fold form.
 //!
+//! # Scalars
+//!
+//! The bound is [`CommutativeRing`] plus `Copy`, not `RealField`. The product
+//! adds, subtracts and multiplies coefficients and needs a zero; it never
+//! divides, never orders, and never calls an analytic function. Bounding at the
+//! weakest structure that carries the operation is what the algebra tower is
+//! for, and it leaves the door open to coefficient rings a cohomology
+//! computation may actually want, `Z_N` among them, without a second
+//! implementation.
+//!
 //! # Cochain representation
 //!
 //! A `k`-cochain is a flat slice indexed by cell index within the complex's
@@ -46,7 +56,7 @@
 use crate::errors::topology_error::{TopologyError, TopologyErrorEnum};
 use crate::traits::cell_splitting::SplittableCell;
 use crate::traits::chain_complex::ChainComplex;
-use deep_causality_algebra::RealField;
+use deep_causality_algebra::CommutativeRing;
 use std::collections::HashMap;
 
 /// Rejects a cochain whose length does not match the cell count of its degree.
@@ -92,7 +102,7 @@ pub fn cup_product<K, R>(
 where
     K: ChainComplex,
     K::CellType: SplittableCell,
-    R: RealField,
+    R: CommutativeRing + Copy,
 {
     // `checked_add` rather than `+`: the degrees are caller-supplied, and an
     // overflowing sum would panic in debug and wrap in release, the wrapped
@@ -144,9 +154,9 @@ where
             };
             let term = alpha[l] * beta[r];
             if split.sign() >= 0 {
-                acc += term;
+                acc = acc + term;
             } else {
-                acc -= term;
+                acc = acc - term;
             }
         }
         out[i] = acc;
@@ -171,7 +181,7 @@ pub fn cup_product_n<K, R>(complex: &K, factors: &[(&[R], usize)]) -> Result<Vec
 where
     K: ChainComplex,
     K::CellType: SplittableCell,
-    R: RealField,
+    R: CommutativeRing + Copy,
 {
     let Some(((first, first_degree), rest)) = factors.split_first() else {
         return Err(TopologyError(TopologyErrorEnum::InvalidInput(

--- a/openspec/notes/quantum/example-crosstalk-attribution.md
+++ b/openspec/notes/quantum/example-crosstalk-attribution.md
@@ -83,11 +83,28 @@ shutdown**, a spatial asymmetry metric, a **swap into a second refrigerator**, a
 measurements. Eighteen authors. The shutdown and the refrigerator swap are interventions, and the
 campaign is a hypothesis set against a family of experiments with wildly different costs.
 
-One honest correction, because it changes what may be claimed. A search summary reported that the
-process-tensor literature already frames this in the vocabulary of common cause and direct cause,
-citing White's thesis (arXiv:2405.05416). Reading the source did not confirm that vocabulary. So the
-causal framing is this project's contribution rather than an idiom borrowed from the target
-community, which is a weaker claim than the search suggested and the one that survives checking.
+Two corrections, because they change what may be claimed.
+
+The first is narrow. A search summary reported that the process-tensor literature already frames this
+in the vocabulary of common cause and direct cause, citing White's thesis (arXiv:2405.05416). Reading
+the source did not confirm that vocabulary.
+
+The second is not narrow, and it retires an earlier draft of this section. **Statistical causal
+inference was applied to crosstalk in quantum processors six years ago.** Sarovar, Proctor, Rudinger,
+Young, Nielsen & Blume-Kohout, *Detecting crosstalk errors in quantum information processors*
+(Quantum **4**, 321, 2020) adapts the PC algorithm, tests conditional independence under the Markov
+condition, and resolves direction as well as existence, at O(n²) to O(n³) experiments, demonstrated
+on 2- and 6-qubit processors. The causal framing for crosstalk belongs to that paper and this example
+must cite it rather than present the framing as new.
+
+What the example adds sits inside that framing, and it is narrower than the earlier draft implied.
+The Sandia protocol runs a **fixed experiment set**. It does not enumerate named hypotheses, so an
+inadmissible structure is never considered and never rejected; it does not screen for admissibility
+before device time is spent; and it does not select experiments against a cost budget. This example
+enumerates four structures including a cyclic one, rejects that one as a `C₃` before any shots, and
+then buys the cheapest experiment subset that separates the survivors by a stated number of bits.
+That conjunction — discrete structural hypotheses, admissibility screening, cost-bounded design — is
+the contribution. The causal vocabulary is not.
 
 ---
 
@@ -334,7 +351,8 @@ examples/quantum_examples/crosstalk_attribution/
 1. **Does this displace the calibration example or accompany it?** They share a shape: hypotheses,
    degenerate observation, designed experiment. *Recommendation: both, in this order.* Calibration
    discriminates parameter faults on one system and is the gentler introduction; this discriminates
-   causal structures across systems and is the one only this crate can pose.
+   causal structures across systems, which is the harder question and the one the design
+   stage is built for.
 2. **Is H₄ worth including given it is rejected?** *Recommendation: yes.* A validation gate that
    never rejects anything reads as decoration. H₄ is physically reasonable, and its rejection is the
    only demonstration in the repository of the C₃ criterion refusing a model an engineer might
@@ -350,6 +368,13 @@ examples/quantum_examples/crosstalk_attribution/
 
 ## 12. Sources
 
+- Sarovar, M., Proctor, T., Rudinger, K., Young, K., Nielsen, E. & Blume-Kohout, R. (2020).
+  *Detecting crosstalk errors in quantum information processors.* Quantum **4**, 321.
+  DOI 10.22331/q-2020-09-11-321. The prior work §3 defers to: PC algorithm, conditional independence
+  under the Markov condition, direction and existence, fixed experiment set.
+- Ferrie, C., Granade, C.E. & Cory, D.G. (2012). *Adaptive Hamiltonian Estimation Using Bayesian
+  Experimental Design.* arXiv:1111.0935. Adaptive design over continuous parameters; the `design`
+  stage here selects over discrete structures under a cost budget instead.
 - Allen, J.-M. et al. (2017). Complete common cause as factorization into commuting Choi factors,
   the theorem the freeze gate tests.
 - van der Lugt, T. & Lorenz, R. (2025). *Unitary causal decompositions.* arXiv:2508.11762. The

--- a/openspec/notes/quantum/example-geometric-qec.md
+++ b/openspec/notes/quantum/example-geometric-qec.md
@@ -302,7 +302,7 @@ looked larger is that the ladder was written against a specification rather than
 code and a `CCZ` on a 3-torus can be constructed from it, and their homology-class invariance
 checked. The crate delivers the *operation*, not the gate: `deep_causality_quantum` does not depend
 on `deep_causality_topology`, so the example itself is where the two meet, and no fault-tolerance
-claim attaches either way (§10 items 1 and 5).
+claim attaches either way (§11 items 1 and 5).
 
 The gate **catalogue** still lies out of reach, and with it the code search that consumes it. Counting
 independently addressable `C^{n−q−1}Z` generators from the Betti vector needs the higher products of
@@ -331,7 +331,118 @@ storage detail but the representation in which the defining property of a qLDPC 
 
 ---
 
-## 8. Sketch of the output
+## 8. DEM interop: the ecosystem's format is already a causal model
+
+Stim's Detector Error Model is the practical interchange standard across the QEC simulation
+ecosystem. Reading and writing it puts this example upstream of Stim and PyMatching rather than
+beside them.
+
+### 8.1 The format
+
+Five instructions, UTF-8, double-precision coordinates:
+
+```
+error(0.001) D0 D1 L0                 # probability, then symptoms and frame changes
+error(0.02) D2 L0 ^ D5 D6             # ^ suggests a decomposition into edge-like parts
+detector(2.5, 3.5, 6) D7              # coordinates, relative to the running offset
+logical_observable L1 L2              # assert the frame change exists
+shift_detectors(0, 0.5) 2             # advance detector index by 2, y by 0.5
+repeat 9 { ... }                      # a time-homogeneous block
+error[tag_name](0.1) D0               # optional tag
+```
+
+A DEM is a list of **independent** error mechanisms. Each carries a probability, the set of detectors
+it flips, and the set of logical observables it flips. Sampling keeps each mechanism independently
+and XORs the results, so symptoms appearing an odd number of times survive.
+
+Three details decide whether an importer is correct:
+
+1. **`D#` is relative, `L#` is absolute.** Detector indices are adjusted by the running offset;
+   observable indices are not. Treating them alike mis-wires every `repeat` block.
+2. **`repeat` with `shift_detectors` encodes time.** A repeat block is a time-homogeneous causal
+   process and the shift is the temporal stride. Preserve it; expanding it discards the stationarity
+   that makes the model compact.
+3. **`^` is a decoder hint.** It records a suggested decomposition for matching decoders and carries
+   no causal content. Drop it on import, regenerate it on export.
+
+### 8.2 The correspondence is exact
+
+A DEM is a bipartite graph from latent mechanisms to observed symptoms, with independent mechanisms
+and known marginals. `error(0.001) D0 D1 L0` reads directly as a hypothesis: a mechanism with effect
+set `{D0, D1, L0}` at `p = 0.001`. No translation layer is required.
+
+### 8.3 A DEM imports into two different configs
+
+This is where the subject-keyed config of [`qcl-design-note.md`](qcl-design-note.md) §4.2 earns its
+keep. A DEM carries a code **and** a noise model, and the two answer different questions.
+
+**Structural questions — `over_code`.** No device, exact evaluation.
+
+```rust
+let cfg = QclBuilder::config::<FloatType>()
+    .over_code(Code::from_dem_file("surface_d5.dem")?)
+    .build()?;
+
+QclBuilder::validate(&cfg)
+    .check_degeneracy()
+    .check_ldpc_weights()
+    .finalize().print_results();
+```
+
+**Diagnostic questions — `over_plant`.** The DEM supplies the hypothesis structure; the device
+supplies the evidence.
+
+```rust
+let dem = Dem::from_file("surface_d5.dem")?;
+
+let cfg = QclBuilder::config::<FloatType>()
+    .over_plant(device)
+    .evidence(Evidence::shots(4096).seed(20260821))
+    .baseline(Experiment::probe("syndrome", detector_readout, 1, cost = 1))
+    .probes(&targeted_experiments)
+    .candidates(&dem.mechanisms())          // each error(p) line becomes a hypothesis
+    .build()?;
+```
+
+### 8.4 The check that does not exist today
+
+Group error mechanisms by identical target set. Any group with more than one member is a
+**Markov-equivalence class: indistinguishable from syndrome data alone**.
+
+Stim combines such mechanisms by design, and for decoding they are the same — the correction depends
+on the symptom pattern, not on which fault produced it. For diagnosis they are different physical
+faults with different repairs, and the merge removes the only signal that would separate them. This
+is the failure class the calibration example opens on: a confident answer with nothing marking it as
+uninformative.
+
+`check_degeneracy` reports the class and names the experiment that breaks it. That is `validate`
+applied to a DEM, and it is the most defensible thing this line of work adds at the QEC tier.
+
+### 8.5 Export
+
+The derived code plus a noise model emits DEM text, which Stim samples and PyMatching decodes:
+
+```rust
+QclBuilder::validate(&cfg)
+    .derive_code()
+    .check_class_invariance()
+    .finalize()
+    .to_dem(&noise)?;
+```
+
+### 8.6 What this must not claim
+
+The example does not decode. Stim and PyMatching decode, and they are fast and correct at it. The
+contribution is upstream — deriving the code from a complex, checking that logical gates act on
+homology classes rather than representatives, and reporting which error mechanisms syndrome data
+cannot separate. Two recent lines of work sit nearby and should be cited rather than ignored: DEM
+reconstruction from syndrome data (arXiv 2606.16288, 2601.22286), which estimates parameters over a
+known structure, and quasilinear DEM equivalence checking (arXiv 2606.14677), which verifies rather
+than attributes.
+
+---
+
+## 9. Sketch of the output
 
 ```
 === Geometric quantum error correction: codes from shapes ===
@@ -371,7 +482,7 @@ until the example runs.
 
 ---
 
-## 9. Layout and build
+## 10. Layout and build
 
 ```
 examples/quantum_examples/geometric_qec/
@@ -384,7 +495,7 @@ multivector, num_complex and core in `deps`, and a row in the package README tab
 
 ---
 
-## 10. What the example must not claim
+## 11. What the example must not claim
 
 1. **The gates are not fault-tolerant.** Haruna states his focus "is not on fault tolerance such as
    constant depth or locality." The constant-depth line is Hsin–Kobayashi–Zhu and is not
@@ -404,7 +515,7 @@ multivector, num_complex and core in `deps`, and a row in the package README tab
 
 ---
 
-## 11. Open questions
+## 12. Open questions
 
 1. **Which complex family?** The 2-torus is the clearest. Adding the 3-torus shows the Betti vector
    generalising and costs a few lines. *Recommendation: both.*
@@ -429,13 +540,21 @@ multivector, num_complex and core in `deps`, and a row in the package README tab
 
 ---
 
-## 12. Sources
+## 13. Sources
 
 - Haruna, J. (2025). *Note on Logical Gates by Gauge Field Formalism of Quantum Error Correction.*
   arXiv:2511.15224. The gate construction and the homology-class invariance theorem the validate
   gate checks. Bundled in `deep_causality_quantum/papers/`.
 - Hsin, P.-S., Kobayashi, R. & Zhu, G. (2024). arXiv:2411.15848. The fault-tolerant constant-depth
   line, cited as the boundary of what is implemented, not as what is implemented.
+- Gidney, C. (2021). *Stim: a fast stabilizer circuit simulator.* Quantum **5**, 497. And
+  `doc/file_format_dem_detector_error_model.md` in `quantumlib/Stim`, the Detector Error Model
+  specification §8.1 follows: five instructions, relative `D#` against absolute `L#`, `repeat` with
+  `shift_detectors` for time-homogeneous blocks, `^` as a decoder hint.
+- DEM reconstruction from syndrome data, arXiv:2606.16288 and arXiv:2601.22286. Parameter estimation
+  over a known structure, adjacent to §8.4.
+- *Quasilinear Equivalence Checking for Detector Error Models*, arXiv:2606.14677. Verification, not
+  causal attribution.
 - `dynamic-qcm.md` §3, for the QEC-as-topology identification and the `SPEC-T1` through `SPEC-T6`
   ladder this example stops against.
 

--- a/openspec/notes/quantum/positioning.md
+++ b/openspec/notes/quantum/positioning.md
@@ -120,7 +120,7 @@ benchmark does not move them; a stated boundary does. Three consequences for the
 
 ## 3. The challenges
 
-Each current challenge below is backed by published work, cited in §10. Three papers carry most of
+Each current challenge below is backed by published work, cited in §12. Three papers carry most of
 the weight, and they are recent and from inside the field rather than from its commentary.
 
 ### 3.1 Current
@@ -404,7 +404,231 @@ rested on, and the compiler enforces the split.
 
 ---
 
-## 5. What ships today, measured
+## 5. The value chain, and where QCL sits
+
+### 5.1 The eleven tiers
+
+| # | Layer | Representative tooling | Scarce resource | QCL |
+|---|---|---|---|---|
+| 1 | Materials, fabrication | foundries, in-house | yield | — |
+| 2 | QPU / chip | IBM, Google, Quantinuum, QuEra | coherence | — |
+| 3 | Cryogenics, wiring, amplifiers | Bluefors, in-house | thermal budget, I/O lines | — |
+| 4 | Control electronics | Quantum Machines, QICK/RFSoC, Zurich | channel count | — |
+| 5 | **Quantum firmware** — calibration, tune-up, characterization, stabilization | Qiskit Experiments, Qibocal | **device time** | **primary** |
+| 6 | Real-time control and feedback | Guppy/Selene, `cudaq-realtime`, QUA | latency inside the coherence window | **reachable, unmeasured** |
+| 7 | QEC — code design, simulation, decoding | Stim, PyMatching, Qualtran | decoder throughput | **secondary** |
+| 8 | Compilation, transpilation | tket, BQSKit, Qiskit transpiler | circuit depth | — |
+| 9 | Circuit and algorithm frameworks | Qiskit, Cirq, PennyLane, Q# | developer attention | — |
+| 10 | Applications | domain libraries | problem fit | — |
+| 11 | Cloud orchestration | Braket, Azure Quantum, IBM Platform | access | — |
+
+Layer 5 is the recognised quantum-firmware tier: the layer that minimises hardware error through
+calibration, tune-up, characterization and automation. Its scarce resource is **device time**, and
+the chain above it optimises for circuit depth, developer attention and access instead. That is the
+economic argument for the position, and it stands without any claim about causality.
+
+### 5.2 Two loops, not one
+
+QCL runs a **slow loop**. Its unit of work is a shot budget: declare hypotheses, screen them, buy
+the cheapest experiment that separates the survivors by a stated number of bits, adjudicate. A
+thousand shots is the granularity, minutes is the cadence, and the output is a repair decision — 
+which knob, which coupler, which pulse.
+
+DeepCausality's substrate also runs a **fast loop**, and it ships today. The five programs in
+[`causal_correction_examples`](../../../examples/causal_correction_examples) are closed-loop control:
+a monitor inspects each tick, `alternate_value` replaces the in-flight value when it leaves the safe
+envelope, and the chain advances from the corrected state. `corrective_ddos_detector` is the closest
+in shape to a syndrome loop — a sliding-window baseline carried in `State`, five consecutive samples
+above 3σ declare the event, and the intervention engages within one tick.
+
+The two loops sit at different tiers and have different budgets. Conflating them understates the
+substrate and overstates QCL.
+
+### 5.3 What layer 6 would require, in numbers
+
+| Modality | Code cycle | Demonstrated feedback |
+|---|---|---|
+| Superconducting | 0.2–10 µs | sub-1 µs mean decode per round, 9.6 µs feedback latency |
+| Trapped ion, shuttling design | ~235 µs | — |
+
+The gap between the two is a factor of 25 to 1000, and it decides the question. Sustaining a decision
+per round at 0.2–10 µs is FPGA and ASIC territory; a general-purpose causal engine does not belong
+there. A ~235 µs code cycle is a different proposition, and it is the reason Guppy and Selene target
+that class of machine.
+
+**The loop shape is native and demonstrated. The port is verified. The latency budget is still
+unmeasured.**
+
+Measured on 2026-08-21:
+
+```
+rustup target add aarch64-unknown-none
+cargo build -p deep_causality_core --no-default-features --features no-std \
+      --target aarch64-unknown-none          →  Finished
+cargo clippy  … same flags                   →  clean
+cargo build -p deep_causality_core           →  Finished  (std path unaffected)
+cargo test   -p deep_causality_core          →  pass
+```
+
+`deep_causality_core` compiles for bare-metal ARM64. It is `no_std` **plus `alloc`**: building with
+no allocator at all fails with 17 errors, because `EffectLog` holds a `Vec<LogEntry>` and
+`CausalityError` holds an `alloc::string::String`. An allocator is available on the class of board
+that matters, so this is a constraint rather than an obstacle.
+
+Reaching that took a two-line fix. `deep_causality_haft`, `deep_causality_algebra` and
+`deep_causality_num` already declared `default-features = false` on their dependants and carried a
+`no-std` feature; `deep_causality_core` declared neither, so its `--no-default-features` build
+silently pulled `std` back in through `haft`. Core's own code was always `no_std`-clean — the
+dependency wiring was the gap, and the earlier host-side build that appeared to succeed had simply
+linked a `std` dependency chain underneath a `no_std` crate.
+
+What this changes: the relevant hardware is the **processing system**, not the fabric. Zynq
+UltraScale+ RFSoC boards — ZCU111, ZCU216, RFSoC 4x2, the class QICK targets — carry hard ARM A53
+application cores and R5F real-time cores on the same die as the converters, so the decision logic
+sits on-chip with no PCIe or network hop. Rust synthesised to fabric is not a path and is not
+proposed. The fabric generates pulses and streams converters; the cores sequence and decide.
+
+**One known obstacle remains, and it is the log.** `EffectLog::add_entry` performs
+`entries.push(LogEntry::new(ts, message.to_string()))` — a `String` allocation per entry, per stage,
+per tick. Allocation is not bounded-time, so as written the channel that makes a device-time decision
+defensible is the channel a hard deadline cannot tolerate. The resolution follows the two-loop split
+of §5.2: the fast loop writes fixed-capacity, preallocated event codes; the slow loop drains that
+ring and inflates it into the full provenance record. A design item with a clear shape, not a
+research question.
+
+What is still not measured is the tick cost itself. That is what the benchmark suite in
+[`qcl-design-note.md`](qcl-design-note.md) §7 exists to establish, against the 235 µs and 0.2–10 µs
+reference points above.
+
+### 5.4 The port surface above core
+
+`deep_causality_quantum` does not declare `no_std`, so whether it can reach bare metal was open.
+Surveyed on 2026-08-21, it can, and nothing in the way is architectural.
+
+| Crate | Status | What stands in the way |
+|---|---|---|
+| `deep_causality_num` | `no_std` ✓ | — (already carries `libm_math` for bare-metal float math) |
+| `deep_causality_algebra` | `no_std` ✓ | — |
+| `deep_causality_haft` | `no_std` ✓ | — |
+| `deep_causality_core` | `no_std` ✓ | — (wired 2026-08-21, §5.3) |
+| `deep_causality_num_complex` | `no_std` ✓ | — |
+| `deep_causality_num_dual` | `no_std` ✓ | — |
+| `deep_causality_metric` | `no_std` ✓ | — |
+| `deep_causality_ast` | std only | 11 sites / 9 files; `Arc` and `VecDeque` → `alloc` |
+| `deep_causality_tensor` | std only | 38 sites / 27 files |
+| `deep_causality_multivector` | std only | 54 sites / 17 files |
+| `deep_causality_quantum` | std only | 10 sites / 6 files |
+| `deep_causality` (graph) | std only | reached from 3 files, all under `types/qcm/` |
+| `deep_causality_uncertain` | std only | optional already, behind the `qpu` feature |
+| `deep_causality_rand` | std only | **dev-dependency** of tensor; does not affect the library build |
+
+**No genuine std blocker exists in the numeric stack.** `deep_causality_tensor` and
+`deep_causality_multivector` contain no `std::collections`, no `std::sync`, no threads and no IO.
+Their `std::` imports are `ops`, `iter::Sum`, `fmt` and `marker::PhantomData` — every one of them
+reachable as `core::`. Neither depends on `deep_causality_par` or rayon, which was the risk worth
+checking and is absent.
+
+The three items that are not a plain `core::` rewrite are all `alloc::` rewrites:
+
+- `std::error::Error`, twice in tensor. `core::error::Error` has been stable since Rust 1.81 and the
+  workspace MSRV is 1.93.0, so this is a rename.
+- `BTreeMap` and `BTreeSet`, seven sites in quantum. These live in `alloc::collections`; they were
+  never std-only.
+- `Arc` and `VecDeque` in `deep_causality_ast`. `alloc::sync::Arc` needs atomic pointers, which
+  aarch64 has.
+
+**The one dependency worth restructuring is the graph.** `deep_causality_quantum` reaches into
+`deep_causality` for `CausableGraph` and `CausalityGraphError` from exactly three files, all under
+`types/qcm/`. That pulls a large std-only crate in for a narrow surface. Feature-gating those three
+files keeps the QCM validation path off the bare-metal build without touching the gate kernels,
+density matrices, or the QPU seam.
+
+**The feature scaffolding is most of the work, and it does not exist yet.** `deep_causality_ast`,
+`deep_causality_tensor` and `deep_causality_multivector` carry **no `[features]` section at all**.
+`deep_causality_quantum` has one, but only for the `qpu` seam, and it declares `default = []`, so
+giving it `default = ["std"]` changes what downstream consumers get by default. Across the four
+crates there are 22 dependency blocks and **not one** sets `default-features = false` — which is
+exactly the omission that made core's `--no-default-features` build silently link `std` underneath a
+`no_std` crate (§5.3).
+
+**Two naming conventions are already in the tree, and mixing them will produce confusing feature
+graphs.** `deep_causality_metric` uses `std` / `alloc`. The numeric chain — `num`, `algebra`, `haft`,
+`num_complex`, `num_dual` — uses `std` / `no-std`. `deep_causality_core` now carries all three,
+`std` / `alloc` / `no-std`, because it needs `alloc` as a distinct level and a `no-std` name to
+forward. Settle on core's three-level shape before porting anything above it; retrofitting a
+convention across four more crates costs more than choosing one now.
+
+**Per crate, the work is four mechanical steps:** add the `[features]` block; add
+`#![cfg_attr(not(feature = "std"), no_std)]` and `extern crate alloc` to `lib.rs`; add
+`default-features = false` to every dependency block; rewrite the `std::` imports.
+
+**Ordering.** `ast` → `tensor` → `multivector` → `quantum`, bottom-up, each verified with a
+cross-compile before the next begins. About 113 import sites across 59 files, plus 22 dependency
+blocks and four feature sections.
+
+The estimate is a survey, not a build. The claim that survives without one is narrow: nothing found
+requires std, and the work is feature wiring plus import rewriting. Only a green cross-compile
+settles it.
+
+---
+
+### 5.5 Five gaps, ranked
+
+**A — diagnosis is projected out at the 5↔7 seam.** Stim's documentation states the design directly:
+the detector error model "focuses on the relationship between error mechanisms and their detector
+signatures rather than tracking individual fault types." That is correct for decoding, where the
+likely error *pattern* is what a correction needs. It means the ecosystem's standard artifact
+structurally cannot answer which coupler to recalibrate. A decoder repairs the state; nothing
+attributes the cause.
+
+**B — no experiment design under a cost budget.** Layer 5 runs known protocols and fits them.
+Bayesian adaptive design exists and is mature, over *continuous parameters* — adaptive tomography,
+Hamiltonian learning. Selecting a **discrete** experiment subset under a cost budget against a stated
+separation floor is the open case, and device time is what it spends.
+
+**C — no admissibility screening before device time.** Nothing checks that a proposed explanation is
+a valid causal model before shots are spent. A supporting feature rather than a product.
+
+**D — code design upstream of Stim.** Real, contested, and distant. qLDPC construction is an active
+field.
+
+**E — drift attribution over time.** Optimus solved calibration *scheduling*; the attribution inside
+it is a human reading plots.
+
+**A and B are the target.** They are one capability seen from two tiers: attribute a symptom to a
+mechanism, then buy the cheapest evidence that confirms it.
+
+---
+
+## 6. Related work
+
+Three lines of published work sit close enough that the delta has to be stated rather than implied.
+
+**Causal inference for crosstalk.** Rudinger et al., *Detecting crosstalk errors in quantum
+information processors* (Quantum 4, 321, 2020) adapts the PC algorithm to crosstalk, uses conditional
+independence tests under the Markov condition, and determines direction as well as existence, at
+O(n²) to O(n³) experiments on 2- and 6-qubit processors. The causal framing for crosstalk is six
+years old and belongs to that paper. The delta is that the protocol runs a **fixed experiment set**:
+it does not enumerate named hypotheses, does not reject inadmissible ones before spending device
+time, and does not select experiments under a cost budget.
+
+**Bayesian adaptive experiment design.** Adaptive Hamiltonian estimation, adaptive tomography, and
+transmon-qutrit identifiability all select the next experiment to maximise information. They target
+continuous parameter estimation. Discrete discrimination among named causal structures under a cost
+budget is the case that remains.
+
+**DEM reconstruction and equivalence.** Recent work learns detector error models from syndrome data
+(arXiv 2606.16288, 2601.22286) and checks DEM equivalence in quasilinear time (arXiv 2606.14677). The
+first is parameter estimation over a known structure; the second is verification. Neither closes gap
+A, and both are close enough that any claim in this area should cite them.
+
+**Calibration frameworks.** Qiskit Experiments and Qibocal fit a model to data from a chosen
+experiment. QCL chooses the experiment by what it would discriminate. These compose: QCL decides,
+layer 5 executes and fits, layer 6 runs it against the device.
+
+---
+
+## 7. What ships today, measured
 
 On the reference machine (Apple M3 Max, 16 cores, 128 GB):
 
@@ -435,7 +659,7 @@ On the reference machine (Apple M3 Max, 16 cores, 128 GB):
 
 ---
 
-## 6. The boundaries
+## 8. The boundaries
 
 These go on their own page, phrased as situations rather than as feature gaps. The CFD site's
 boundaries page is the model.
@@ -466,7 +690,7 @@ boundaries page is the model.
 
 ---
 
-## 7. Why "dynamic" earns its place
+## 9. Why "dynamic" earns its place
 
 Quantum causal models are written as static objects: a fixed graph, a fixed factorization, a theorem
 about it. A control loop is the opposite kind of object. The word *dynamic* claims three specific
@@ -487,7 +711,7 @@ quantum state is an ordinary use of the monad, not an extension to it.
 
 ---
 
-## 8. What the site should therefore be
+## 10. What the site should therefore be
 
 Ten pages, grouped by the three avenues. Same discipline as the CFD site: a claim per page, evidence
 under it.
@@ -501,7 +725,7 @@ under it.
 | Formalization | The Lean table, the refuted theorem first, `THEOREM_MAP` traceability, and the shared verdict lattice of §4.5 |
 | Modalities | Verifiable against emergent, and why the split is a compile-time guarantee |
 | Examples | Every runnable one, with its field and its exact command |
-| Boundaries | Section 6, written as situations |
+| Boundaries | Section 8, written as situations |
 | Roadmap | Tracks Q, T, G and D with their gating assumptions, and what a failed gate kills |
 | Papers | The bundled PDFs and the evidence citations, all properly attributed |
 
@@ -511,7 +735,7 @@ material lives in `dynamic-qcm.md` and stays there.
 
 ---
 
-## 9. Decisions I need from you
+## 11. Decisions I need from you
 
 1. **Prime audience.** Set to the classical-quantum control engineer, with P1 error correction and
    logical-gate design and P2 characterization as the entry personas, and P3 as the review audience.
@@ -534,7 +758,35 @@ material lives in `dynamic-qcm.md` and stays there.
 
 ---
 
-## 10. Sources
+## 12. Sources
+
+### Ecosystem and related work (§5, §6)
+
+- Sarovar, M., Proctor, T., Rudinger, K., Young, K., Nielsen, E. & Blume-Kohout, R. (2020).
+  *Detecting crosstalk errors in quantum information processors.* Quantum **4**, 321.
+  DOI 10.22331/q-2020-09-11-321. The PC
+  algorithm adapted to crosstalk; conditional independence under the Markov condition; direction as
+  well as existence; a fixed experiment set at O(n²)–O(n³).
+- *Qiskit Experiments: A Python package to characterize and calibrate quantum computers.* JOSS
+  **8**(84), 5329 (2023). Layer 5: run a known protocol, fit, update calibration.
+- *Qibocal: an open-source framework for calibration of self-hosted quantum devices.*
+  arXiv:2410.00101 (2024). Layer 5, self-hosted platforms, live fitting.
+- Gidney, C. (2021). *Stim: a fast stabilizer circuit simulator.* Quantum **5**, 497. And the DEM
+  file-format specification, `doc/file_format_dem_detector_error_model.md` in `quantumlib/Stim`.
+  The source for gap A: the DEM tracks detector signatures rather than individual fault types.
+- Ferrie, C., Granade, C.E. & Cory, D.G. (2012). *Adaptive Hamiltonian Estimation Using Bayesian
+  Experimental Design.* arXiv:1111.0935. Adaptive design over continuous parameters, the closest
+  prior work to the `design` stage. See also *Identifiability and Characterization of Transmon
+  Qutrits Through Bayesian Experimental Design*, arXiv:2312.10233.
+- *Demonstrating real-time and low-latency quantum error correction with superconducting qubits.*
+  Nature Communications (2026). Sub-1 µs mean decode per round, 9.6 µs feedback latency — two of the
+  numbers behind §5.3. The 0.2–10 µs code-cycle range and the ~235 µs trapped-ion shuttling estimate
+  are from arXiv:2108.12371, *The Impact of Hardware Specifications on Reaching Quantum Advantage in
+  the Fault Tolerant Regime*.
+- DEM reconstruction from syndrome data, arXiv:2606.16288 and arXiv:2601.22286; quasilinear DEM
+  equivalence checking, arXiv:2606.14677. Parameter estimation and verification respectively,
+  adjacent to gap A without closing it.
+- *Quantum firmware and the quantum computing stack*, Physics Today. The layer-5 naming used in §5.1.
 
 ### Evidence for the challenges
 

--- a/openspec/notes/quantum/qcl-design-note.md
+++ b/openspec/notes/quantum/qcl-design-note.md
@@ -1,0 +1,645 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+-->
+
+# QCL: Design Note
+
+**What this is.** The design for a Quantum Causal Language in
+`deep_causality_quantum`, derived from building all three designed examples against the shipped
+crates and recording what hurt.
+
+**Method, and why it matters.** Each example was implemented twice: once in Rust using **only APIs
+that exist today**, and once in Python from published formulas. The two agree on all 16 checked
+quantities. That agreement is what licenses the rest of this note: the friction listed below is
+friction in *expressing correct physics*, not the residue of getting the physics wrong.
+
+The scratch implementations and the Python reference were deleted after the comparison. They were
+instruments, not deliverables. This note is what they produced.
+
+**Status.** Design, not a proposal. Supersedes the speculative sketch in
+[`qcl-dsl-liftback.md`](qcl-dsl-liftback.md) §4, which guessed at a pipeline before any of it had
+been written.
+
+---
+
+## 1. What was built, and what it agreed with
+
+| Example | Reference source | Checks | Result |
+|---|---|---|---|
+| Calibration counterfactual | generalised Rabi formula; depolarising channel | 7 | exact |
+| Crosstalk attribution | Markov equivalence (Verma & Pearl 1990) | 5 | exact |
+| Geometric QEC | Kitaev (2003); Betti of `Tᵈ`; intersection form | 4 | exact |
+
+Concretely: the three faults read `0.980147 / 0.980159 / 0.980150` at one pulse and
+`0.086460 / 0.961136 / 0.847242` at nine, purity `0.741154`; the three causal structures all fit
+`P(e₁)=P(e₂)=0.10, P(e₁,e₂)=0.04` and the cyclic fourth is rejected as a `C₃`; the toric family
+comes out `[[8,2,2]]` to `[[50,2,5]]` with Betti `[1,4,6,4,1]` on `T⁴`, pairings `±L²` and triple
+products `8, 27, 64`.
+
+Two independent routes reaching the same numbers, one through `DensityMatrix`/`apply_kraus`/Born and
+one through closed-form Rabi, is the strongest evidence available that the substrate is sound. **The
+problem QCL solves is not correctness. It is that correct code is unreasonably hard to write.**
+
+---
+
+## 2. The friction, as observed
+
+Each item below is something the scratch code actually had to do.
+
+### F1. Operators are hand-packed tensors
+
+Every gate, projector and Kraus operator was built as a flat `CausalTensor` with a manually supplied
+shape. Building the rotation for a detuned pulse meant writing the four complex entries of
+`cos(θ/2)I − i sin(θ/2)(nₓX + n_zZ)` by hand.
+
+> There is no rotation, no Pauli, no standard-basis projector reachable as a value.
+
+### F2. Unitary evolution has to masquerade as a channel
+
+The only way to conjugate a state by a unitary is `apply_kraus(&[u], rho)`. It works and it is
+correct, but the reader sees a channel where the physics is evolution, and the CPTP machinery runs
+on every step to re-establish what a unitary guarantees by construction.
+
+### F3. The validated type is abandoned to compute
+
+The loop is `DensityMatrix::from_ket(..).matrix().clone()` → raw tensor arithmetic → re-wrap in
+`DensityMatrix::new`. The type validates Hermiticity, positivity and trace, then hands out its
+interior so the caller can work, then re-validates. Validation happens `n` times for a state that
+was valid throughout.
+
+### F4. Every stage of a causal flow costs four lines of ceremony
+
+```rust
+.bind(|_: CausalEffect<()>, st: Diag, cx: Option<()>| {
+    let mut st = st;
+    /* one line of actual work */
+    let next = CausalEffectPropagationProcess::pure(true);
+    CausalEffectPropagationProcess::with_state(next, st, cx)
+})
+```
+
+The turbofished closure signature and the `with_state` re-wrap appear at every stage, and the value
+channel carried `true` in both stages because nothing needed it.
+
+### F5. Shot noise is absent, so decisions are float comparisons
+
+Both discriminating examples adjudicate with `min_by(|a, b| (a - measured).abs().cmp(..))`. That is a
+nearest-neighbour test on exact reals. Turning it into the statistical decision it should be requires
+hand-building a `CountHistogram`, filling it, and bridging to `Uncertain` — so the scratch code, like
+anyone in a hurry, simply did not.
+
+### F6. A declared causal structure cannot be evaluated
+
+This is the largest gap. `CausalStructure` validates: it found the `C₃` in the cyclic hypothesis and
+rejected it with the offending inputs and outputs named. But nothing turns a structure into an
+interventional prediction, so `predict(hypothesis, experiment)` was a **hand-written lookup table**.
+The crate screens hypotheses it cannot evaluate.
+
+### F7. The experiment designer does not exist
+
+Bhattacharyya scoring and the minimum-cost cover were written by hand in the example, including an
+exhaustive bitmask over experiment subsets. Both are general; neither is in the crate.
+
+### F8. The topology-to-gate seam is unchecked, and silently wrong
+
+The decisive finding. A logical operator is a cochain: `Vec<f64>` indexed by edge. A Haruna gate
+wants a `CausalMultiVector` gauge field. **There is no conversion**, so the scratch code packed the
+cochain's sum into a multivector of unrelated dimension and called `logical_z`. The result:
+
+```
+logical_z failed: Haruna gate exp Taylor series did not converge within the
+64-term budget to tolerance 1e-12; the exponent norm is too large
+```
+
+The failure is a *numerical* complaint about magnitude. Nothing checked that the multivector was the
+gauge field of that cochain, that its metric matched the complex, or that its grading meant anything.
+A caller who normalised the value to make the series converge would have got a confident, meaningless
+answer.
+
+---
+
+## 3. What QCL is
+
+QCL is the layer that makes the above unnecessary. Three groups, in dependency order.
+
+### 3.1 Carriers — close F1, F2, F3, F8
+
+| Type | Replaces | Contract |
+|---|---|---|
+| `QubitOperator` | hand-packed 2×2 tensors | named constructors: `pauli_x`, `rotation(axis, angle)`, `phase(θ)` |
+| `Channel` | a bare Kraus slice | CPTP checked **once**, at construction |
+| `QuantumPlant` | state + channel juggling | a validated state that evolves in place; `step`, `evolve(n)` |
+| `Observable` | ket → `Projection` → Born | a named projector carrying its own read-out |
+| `GaugeField` | the unchecked F8 seam | built **from a cochain and its complex**, so degree and metric are checked at the boundary |
+
+Each carrier is generic over its scalar under the bound §3.4 assigns it.
+
+`GaugeField` is the one that matters most. It must be constructible only as
+`GaugeField::from_cochain(&complex, &cochain, degree)`, so the conversion that silently succeeded in
+the scratch code becomes the only conversion available, and it validates.
+
+### 3.2 Evidence — closes F5
+
+`ShotBudget { shots, seed }` with `sample(&Observable, &QuantumPlant) -> Uncertain<FloatType>`. One
+call, histogram built internally.
+
+This is not a convenience. `Uncertain<f64>` already implements `Verdict`, so a sampled reading is a
+lawful lattice carrier the moment it exists, and every downstream decision becomes statistical rather
+than a float comparison. F5 exists purely because the ergonomic path today is the wrong one.
+
+### 3.3 Reasoning — closes F6, F7
+
+- **`Hypothesis`** — a named candidate binding a `CausalStructure` to the plant modification it
+  implies. This is the missing link: today the validated structure and the thing being discriminated
+  are separate universes joined by an enum.
+- **`intervene(&Hypothesis, &Intervention) -> QuantumPlant`** — the operation F6 wants. A structure
+  plus a `do(...)` yields a plant whose predictions can be *computed* rather than tabulated.
+- **`design(&[Experiment], objective) -> DesignPlan`** — Bhattacharyya scoring and minimum-cost
+  cover, returning a plan rather than an experiment (established by the crosstalk example, where no
+  single cheap experiment separates all three hypotheses and `{E1, E2}` at cost 2 beats tomography at
+  200).
+- **`adjudicate(...) -> Adjudication`** — `Abduced` / `Ambiguous` / `NoneAdmissible`. `Ambiguous`
+  carries the binding pair and the shots that would resolve it.
+
+---
+
+### 3.4 Scalars: precision as a parameter, bounds as documentation
+
+QCL inherits the project's standing commitment that
+[numerical precision is a parameter, not an assumption](../../../website/docs/src/content/docs/concepts/uniform-math.md).
+Every QCL type is generic over its scalar, a program fixes one alias, and the
+whole pipeline instantiates at that precision:
+
+```rust
+pub type FloatType = Float106;   // or f64, or f32
+```
+
+That is the easy half. The half worth designing is **which bound each surface
+carries**, because `deep_causality_algebra` ships a tower precisely so that a
+signature can say what an operation actually needs.
+
+#### The bound each QCL surface should carry
+
+| Surface | Operations it performs | Bound | Why not tighter or looser |
+|---|---|---|---|
+| Cochains, cup product | `+`, `−`, `×`, `0` | `CommutativeRing + Copy` | No division, no ordering, no analytic call. `RealField` would exclude coefficient rings a cohomology computation may want |
+| Gauge field, operators | complex arithmetic | `ComplexField<R>`, `R: RealField` | Operator entries are genuinely complex; the real parameter carries the precision |
+| Rotations, gate synthesis | `sin`, `cos`, `sqrt`, `π`, normalisation | `RealField` | Needs the analytic surface of `Real` **and** division from `Field`; this is the one place the full bound is honest |
+| Born read-out, purity | real output compared to a spec | `Real` | Ordering yes, division no. `Real` is exactly "ordered and analytic" without field structure |
+| Verdicts | bounded lattice on `[0,1]` | `Prob` | Already an MV-algebra `Verdict`; QCL adds nothing |
+| Shot statistics, Bhattacharyya | `sqrt`, `log2`, ratios | `RealField` | Genuinely needs both halves |
+| Costs, shot counts, cover search | integer arithmetic | none | `usize`. A scalar bound here would be noise |
+
+The discipline is one line: **bound at the weakest structure that carries the
+operation.** A signature is the cheapest documentation in the crate, and an
+over-tight bound is a false statement about what the code does.
+
+#### The worked example, verified
+
+The cup product that shipped in `add-cup-product` was bound on `RealField`. It
+adds, subtracts, multiplies and needs a zero. It never divides, never orders and
+never calls an analytic function, so the bound was three levels too tight
+(`RealField → Field → CommutativeRing`) and additionally dragged in the whole
+`Real` analytic surface.
+
+Relaxing it to `CommutativeRing + Copy` was tried rather than argued: the crate
+compiles, the workspace compiles, and all 1471 tests pass unchanged. The
+relaxation is non-breaking, since every type that satisfied the old bound
+satisfies the new one, and it admits coefficient rings the old bound refused.
+
+That is what "as appropriate" means in practice, and it is the pattern QCL
+should follow from the start rather than tighten-then-discover.
+
+#### Precision as a functor, not only as an alias
+
+An alias makes precision a **compile-time** choice: edit the line, rebuild, and
+the program runs at the new scalar. `deep_causality_haft` makes a stronger form
+available.
+
+`CausalTensor` implements `fmap<A, B>`, which maps `CausalTensor<A>` to
+`CausalTensor<B>`. The map changes the *scalar type*, not merely the values. Any
+QCL carrier built on tensors inherits that, so a plant, an operator or a cochain
+can be lifted from one precision to another as an **operation**:
+
+```rust
+let plant_f64: QuantumPlant<f64> = ...;
+let plant_hi: QuantumPlant<Float106> = plant_f64.to_precision();
+```
+
+This turns the precision ladder from a rebuild into a computation. The same
+program can carry both, run a discrimination at each, and report the difference,
+which is exactly the experiment the capstone spinor example runs to show `f64`
+drift at `1.1e-16` against `Float106` at `1.7e-31`.
+
+For QCL that is not a curiosity. Every example in §1 makes a decision by
+comparing numbers: a spec threshold, a Bhattacharyya separation, a homology-class
+invariance residual. Whether such a comparison is precision-limited is a question
+the pipeline should be able to **answer about itself**, by running the same
+adjudication at two scalars and reporting whether the verdict moved. A verdict
+that changes with the scalar was never a verdict about the physics.
+
+#### What this does not license
+
+Genericity has a cost and the tower makes it easy to overpay:
+
+1. **No bound wider than the operation.** A function taking `CommutativeRing`
+   must not later reach for `sqrt` and force every caller up to `RealField`.
+2. **No scalar parameter where there is no scalar.** Cover search, shot counts
+   and cell indices are integers. `QclConfig<R>` should not thread `R` into them.
+3. **`Real` and `RealField` are not synonyms.** `Real` is ordered and analytic;
+   `RealField` adds division. Reaching for the latter by habit is how the cup
+   product ended up over-constrained.
+4. **Complex is not a precision.** `ComplexField<R>` carries its precision in
+   `R`. The alias a program fixes is the real scalar; complex structure is a
+   separate axis.
+
+---
+
+### 3.5 The ledger — cost and shot accounting in the State channel
+
+Device time is layer 5's scarce resource, so the run has to meter it. The carrier decides where:
+Context is read-only and cannot accumulate, `EffectLog` is a record rather than a running total, and
+Value is the answer rather than the meter. **State is the only channel that is both writable and
+threaded**, so the ledger goes there by elimination.
+
+That also explains a split reached by iteration in §4.3: the budget accumulates, so it is State; the
+floor is fixed, so it is a stage parameter. `design(MinCostCover { floor_bits })` reads spend from
+State and compares it against a constant from the call site.
+
+```rust
+use deep_causality_algebra::{Real, RealField};
+use deep_causality_num::Zero;
+
+/// Cost and shot accounting, threaded in the State channel.
+///
+/// Counts are integers: `deep_causality_algebra` deliberately excludes the integers from the
+/// trait tower, and counting shots in floating point would be wrong regardless. The continuous
+/// quantities carry the scalar parameter.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ledger<R> {
+    shots: u64,        // taken on the device
+    experiments: u32,  // executed on hardware
+    predictions: u32,  // model evaluations — tracked, never billed
+    device_time: R,    // accumulated, measured
+    cost: R,           // what MinCostCover minimises
+    bits: R,           // separation achieved so far
+}
+```
+
+`Real` is `Copy`, so `Ledger<R>` is `Copy` for every admissible `R`. It holds no `Vec` and no
+`String`, so it survives the bare-metal path of `positioning.md` §5.3 unchanged — the ledger is not
+what blocks the fast loop; the log is.
+
+**`Default` is hand-written, not derived.** `CausalMonad::pure` requires `State: Default`, and
+`#[derive(Default)]` would impose a spurious `R: Default` bound. `Real` reaches `Zero` through
+`CommutativeRing → Ring`, so the zero ledger is written from `R::zero()` and the bound stays `Real`.
+
+**The bound split follows the trait tower.** Accumulating, comparing against a budget, and computing
+a remainder need `+`, `-` and ordering, all of which `Real` provides:
+
+```rust
+impl<R: Real> Ledger<R> {
+    pub fn zero() -> Self { /* R::zero() in each continuous field */ }
+    pub fn record_shots(&mut self, n: u64, elapsed: R, cost: R) { /* += */ }
+    pub fn record_prediction(&mut self) { self.predictions += 1; }
+    pub fn within(&self, budget: R) -> bool { self.cost < budget }
+    pub fn remaining(&self, budget: R) -> R { budget - self.cost }
+}
+```
+
+Derived ratios divide, so they need field invertibility and sit on a separate block:
+
+```rust
+impl<R: RealField> Ledger<R> {
+    pub fn cost_per_bit(&self) -> R { self.cost / self.bits }
+    pub fn bits_per_shot(&self) -> R { /* … */ }
+}
+```
+
+Bounding accumulation on `Real` rather than `RealField` is not pedantry. `Real` admits analytic
+non-field types — the dual numbers used for forward-mode differentiation — so a cost model can be
+differentiated with respect to its parameters while still threading through the same ledger. Binding
+the whole struct on `RealField` would forfeit that for the sake of two ratio methods.
+
+#### Three invariants
+
+**Increment only at the device boundary.** Example 1 forks into three hypothesis worlds, but one
+experiment runs on hardware and the other two are model predictions. A ledger incremented in every
+world reports three times the true device time. `observe` is the only stage that touches `shots`,
+`experiments` and `device_time`; `predict`, `design`, `fork` and `adjudicate` touch at most
+`predictions`.
+
+**Forking is QCL's, not core's.** `branch`, `branch_with` and `either` route to *one* arm and move
+the state; the flow stays linear, and `alternate_value` is value substitution rather than Pearl's
+`do(...)`, which `intervene.rs` states directly — at the value level there is no graph to cut. So
+`fork` is built above core by cloning the carrier. `State: Clone` is deliberately not required (the
+sliding-window state in `corrective_ddos_detector` is not `Clone`), and a `Copy` ledger sidesteps
+that, but a plant state pairing ρ with the ledger needs ρ to be `Clone` for forking to work.
+
+**Do not merge forked ledgers with ∇.** `Ledger<R>` under field-wise addition is a commutative
+monoid, so `SymMonoidal::merge` will typecheck and give the wrong answer. Summation is correct for
+*sequential* composition, which `bind` already performs by threading. At a *counterfactual* fork
+exactly one branch was factual, and the merged ledger is that branch's. If the monoid instance
+exists it should be named for sequential accumulation, so nobody reaches for it at a fork.
+
+---
+
+## 4. Configuration and the pipeline
+
+### 4.1 One origin for configuration
+
+Every configuration in QCL comes from `QclBuilder::config()`. There is no other constructor, no
+free-standing struct literal, and no stage that accepts loose parameters standing in for a config.
+The builder is also the single site where the scalar type is named:
+
+```rust
+QclBuilder::config::<FloatType>()
+```
+
+Every bound in §3.4 — `Real`, `RealField`, `ComplexField<R>`, `CommutativeRing` — is discharged from
+that one parameter. Swapping `FloatType` for `Float106` re-types the whole run, and no second site
+can disagree with the first.
+
+### 4.2 The config branches on the subject
+
+A config is built *over* what the model is about, and that choice decides which pipelines are
+reachable:
+
+| Constructor | Subject | Candidates are | Reachable pipelines |
+|---|---|---|---|
+| `.over_plant(p)` | a system that evolves and is measured | `Hypothesis` | `validate`, `control` |
+| `.over_code(c)` | a complex, evaluated exactly | candidate complexes | `validate` |
+
+The split is observed, not imposed: the geometric-QEC example never measures anything, and the two
+device examples never evaluate a chain complex. Because the candidate type follows the subject,
+"hypothesis" keeps one meaning instead of two.
+
+`build()` returns a `Result`. It is where cross-field validation lives: a probe naming an observable
+the plant does not expose, a zero shot count, an empty candidate set.
+
+### 4.3 What the config holds, and what it does not
+
+**The config holds what several stages share**, or what must be validated together: the subject, the
+evidence policy, the baseline experiment, the probe family, the candidates.
+
+**A stage's parameter belongs to the stage.** `spec` goes to `.gate(spec)`, the selection objective
+to `.design(objective)`, the depth to `.evolve(n)`. This is not cosmetic. When `spec` was a required
+config field, the crosstalk example had to invent one to satisfy the builder — a field existing only
+to keep the type honest, which is the same defect as an all-optional config wearing a better
+disguise. Parameters are now written once, where they are read.
+
+### 4.4 The hand-off is a type
+
+`validate` terminates in `Screened<R>`, which carries the config together with the admitted subset.
+`control` accepts either a plant config or a `Screened<R>`. A config carrying **structural**
+candidates therefore has no path into `control` that skips validation, while a config carrying only
+mechanism candidates — which declare no structure, so there is nothing to screen — needs no extra
+step. The ordering is a fact about the types rather than a convention in the prose.
+
+### 4.5 The three examples
+
+**Calibration counterfactual.** Mechanism candidates, so `control` directly.
+
+```rust
+let cfg = QclBuilder::config::<FloatType>()
+    .over_plant(transmon)
+    .evidence(Evidence::shots(1024).seed(20260821))
+    .baseline(Experiment::probe("check", excited_population, 1, cost = 1))
+    .probes(&amplification_family)                      // depths 1..40
+    .candidates(&[
+        Hypothesis::mechanism("amplitude",   amp_drift),
+        Hypothesis::mechanism("detuning",    det_drift),
+        Hypothesis::mechanism("decoherence", depolarising),
+    ])
+    .build()?;
+
+QclBuilder::control(&cfg)
+    .observe()                                          // runs the baseline -> Uncertain
+    .gate(Spec::at_least(ft(0.999)))                    // 0.9801 fails, loop proceeds
+    .fork()                                             // one world per fault
+    .design(MinCostCover { floor_bits: ft(5.0) })       // picks depth 9
+    .predict()
+    .adjudicate()
+    .finalize().print_results();
+```
+
+**Crosstalk attribution.** Structural candidates, so validation is unavoidable.
+
+```rust
+let cfg = QclBuilder::config::<FloatType>()
+    .over_plant(two_qubit)
+    .evidence(Evidence::shots(1024).seed(20260821))
+    .baseline(Experiment::probe("passive", joint_error, 1, cost = 1))
+    .probes(&[do_q1, do_q2, echo_both, process_tomography])
+    .candidates(&[
+        Hypothesis::structural("Q1->Q2", s_d12, ext_d12),
+        Hypothesis::structural("Q2->Q1", s_d21, ext_d21),
+        Hypothesis::structural("common", s_com, ext_com),
+        Hypothesis::structural("cyclic", s_cyc, ext_cyc),
+    ])
+    .build()?;
+
+let screened = QclBuilder::validate(&cfg)
+    .check_markov()
+    .check_faithfulness()                               // rejects the cyclic C3
+    .finalize();                                        // -> Screened<FloatType>
+
+QclBuilder::control(screened)                           // unreachable unscreened
+    .observe()
+    .gate(Spec::uncorrelated())
+    .fork()
+    .design(MinCostCover { floor_bits: ft(5.0) })
+    .predict()
+    .adjudicate()
+    .finalize().print_results();
+```
+
+**Geometric QEC.** A code subject, so `validate` only, and the config is short because there is
+little to validate across fields.
+
+```rust
+let cfg = QclBuilder::config::<FloatType>()
+    .over_code(LatticeComplex::<2, FloatType>::square_torus(4))
+    .build()?;
+
+QclBuilder::validate(&cfg)
+    .derive_code()                                      // [[32,2,4]]
+    .check_ldpc_weights()
+    .check_class_invariance()                           // closes F8
+    .finalize().print_results();
+```
+
+The code pipeline has no probe family. Its selection over candidate complexes is scored against
+requirements, not against evidence, so it is a different computation that merely shares a shape with
+`design` (established in [`qcl-dsl-liftback.md`](qcl-dsl-liftback.md) §8.9). v1 does not unify them.
+
+### 4.6 Why this shape and not the three that preceded it
+
+Four config designs were written and each was scored against §2. `Cfg-sens` marks whether the config
+shape can move the score at all — F1–F3 are settled by the carriers however the config is spelled.
+
+Scale: 0 not addressed, 1 partly, 2 addressed, 3 settled at the type level.
+
+| Friction | Cfg-sens | One config, all optional | Three shapes | Subject-keyed | **This design** |
+|---|---|---|---|---|---|
+| F1 operators hand-packed | no | 2 | 2 | 2 | 2 |
+| F2 unitary as channel | no | 2 | 2 | 2 | 2 |
+| F3 validated type abandoned | no | 2 | 2 | 2 | 2 |
+| F4 stage ceremony | yes | 1 | 2 | 2 | **3** |
+| F5 shot noise absent | yes | 1 | 2 | 2 | **3** |
+| F6 structure not evaluable | yes | 1 | 1 | 1 | **3** |
+| F7 designer missing | yes | 1 | 1 | 1 | **3** |
+| F8 topology-to-gate seam | yes | 0 | 1 | 2 | 2 |
+| **friction subtotal / 24** | | 10 | 13 | 14 | **20** |
+| precision as a parameter / 3 | yes | 1 | 2 | 3 | **3** |
+| **total / 27** | | 11 | 15 | 17 | **23** |
+
+Where the movement comes from:
+
+- **F4** rises on the last step not through line count — the last two designs are within a line of
+  each other — but because no line exists solely to satisfy the builder.
+- **F5** is skippable while evidence is optional, which is exactly how the friction arose in the
+  scratch code. Making `Evidence` the sole source of shot counts on every plant config closes it.
+- **F6 and F7** are the two that the first three designs all failed. `Screened<R>` settles the
+  screening half of F6; splitting the probe family (shared) from the objective (per stage) settles
+  F7, since one family is scored under several objectives.
+- **F8** caps at 2 rather than 3. `over_code` makes the code checks reachable and the plant checks
+  unreachable, but the gauge-field conversion is a carrier obligation under §3.1, so no config shape
+  can settle it outright.
+- **Precision** reaches 3 once the scalar is named at exactly one site. The first design named it at
+  each of three entry points, where two of them can drift.
+
+**The DSL adds ordering and naming, not a monad.** `PropagatingEffect` already short-circuits and
+carries an `EffectLog`; every stage returns one. If a `QclEffect` type appears, something has gone
+wrong. F4 is solved by the stage methods hiding the closure ceremony, not by a new effect system.
+
+---
+
+## 5. What QCL must not do
+
+1. **Own graph traversal.** That is `deep_causality`'s `CausaloidGraph` and `ultragraph`.
+2. **Own topology.** Chain complexes, Betti numbers and the cup product are
+   `deep_causality_topology`'s. QCL names their QEC meaning and calls them.
+3. **Own the verdict lattice.** `Verdict` is `deep_causality_algebra`'s.
+4. **Model devices.** The rotation-with-detuning plant belongs to an example.
+5. **Claim fault tolerance.** QCL computes logical actions. Constant-depth fault-tolerant circuits
+   are a compiler, and a separate change.
+
+---
+
+## 6. Sequencing
+
+0. **Fix the scalar bounds before writing carriers** (§3.4). It costs nothing, it is the cheapest
+   documentation in the crate, and every layer below inherits whatever the carriers declare. The
+   cup-product relaxation shows the cost of the other order: tighten by habit, discover later.
+1. **Carriers next** (§3.1). They close five of the eight frictions and need nothing else. Start
+   with `GaugeField::from_cochain`, because F8 is the one that produces confident wrong answers
+   rather than merely verbose code.
+2. **`ShotBudget`** (§3.2). Small, and it changes every decision downstream from a float comparison
+   into a statistical one.
+3. **`Hypothesis` and `intervene`** (§3.3). The largest piece, and the one that makes the crate able
+   to evaluate what it already validates.
+4. **`design` and `adjudicate`.** Both general, both currently hand-rolled in examples.
+5. **`QclBuilder::config`** (§4.1–§4.3), then the stages (§4.5), last — once at least two
+   examples run against the layers beneath. Config comes first within this step because it is
+   the sole origin of configuration and the single site naming the scalar; stages read it.
+
+The failure mode to avoid is unchanged from `qcl-dsl-liftback.md` §7: writing the pipeline first and
+shaping examples to justify it. The ordering above is the reverse, and it is now grounded in three
+programs that compiled and produced verified numbers.
+
+---
+
+## 7. Benchmarks: what "normal" means, and how far off we are
+
+QCL makes two performance claims that nothing currently measures: that a tick is cheap enough for a
+control loop, and that precision is a parameter. Neither should be stated without numbers, and both
+have published reference points to be measured against. `criterion` with `harness = false` is the
+repo's existing convention.
+
+Every figure carries the machine. The workspace reference is **M3 Max, 16 cores, 128 GB**; bare-metal
+figures carry the board instead.
+
+### 7.1 Reference points
+
+| Quantity | Published value | Source |
+|---|---|---|
+| Superconducting code cycle | 0.2–10 µs | arXiv:2108.12371 |
+| Real-time decode, per round | sub-1 µs mean | Nature Comms (2026) |
+| Feedback latency, superconducting | 9.6 µs | Nature Comms (2026) |
+| Trapped-ion shuttling code cycle | ~235 µs | arXiv:2108.12371 |
+| Crosstalk detection, experiment count | O(n²)–O(n³) | Sarovar et al. (2020) |
+
+### 7.2 Tier 1 — tick latency, the layer-6 question
+
+| Benchmark | Measures |
+|---|---|
+| `bind` on `PropagatingEffect<FloatType>` | the floor: one stage, unit state, no context |
+| `bind` on `PropagatingProcess<Rho, Ledger<FloatType>, Config>` | a realistic carrier |
+| the same, log enabled vs bounded vs off | isolates the per-tick `String` allocation of §5.3 |
+| a full monitor→gate→`alternate_value` tick | the `corrective_ddos_detector` shape |
+
+Read against 235 µs and against 0.2–10 µs. These are the two numbers that decide whether the layer-6
+position in `positioning.md` §5.1 is a position or a footnote.
+
+**Allocations per tick matter more than wall clock here.** A bounded-time claim needs
+allocations/tick = 0, which a timing harness does not show. Count them separately with a counting
+allocator; a fast mean with an unbounded tail is the failure mode this is looking for.
+
+### 7.3 Tier 2 — stage cost, the layer-5 question
+
+`validate`, `design`, `predict` and `adjudicate` run once per calibration decision, so the budget is
+seconds, not microseconds. What matters is that nothing explodes.
+
+| Benchmark | Watch for |
+|---|---|
+| `check_markov` + `check_faithfulness` per hypothesis | scaling in qubit count against Sarovar's O(n²)–O(n³) |
+| `design` — min-cost cover, k experiments × n hypotheses | **exponential in k**: exhaustive bitmask over subsets |
+| `predict` — interventional evaluation per hypothesis | linear, and small |
+| `adjudicate` — Bhattacharyya plus decision | linear in hypothesis count |
+
+`design` is the one with a cliff. Sweep k from 4 to 20 and publish where exhaustive enumeration stops
+being usable; that number decides whether a heuristic cover is needed and when.
+
+### 7.4 Tier 3 — the price of precision
+
+Every Tier 1 and Tier 2 benchmark, repeated at `f32`, `f64` and `Float106`. Precision as a parameter
+(§3.4) is a claim about what a caller may choose; it is honest only if the cost of each choice is
+published. `Float106` in particular is expected to be expensive, and the number belongs next to the
+claim rather than in a reader's assumptions.
+
+### 7.5 Tier 4 — the bare-metal figure
+
+Once the port of `positioning.md` §5.4 lands, Tier 1 repeated on an aarch64 board with a bounded log,
+reported against the same reference points. Until then Tier 1 runs host-side and is an upper bound on
+what the hardware would do, not a substitute for it.
+
+### 7.6 What these benchmarks must not do
+
+They do not compare QCL against Qiskit Experiments, Qibocal or Stim on shared work — the pipelines
+compute different things, and a same-axis comparison would be measuring the difference in task.
+Stim's decoding throughput is the right reference for Stim's job and is not QCL's job. What is being
+measured is distance from a published physical budget, not a ranking.
+
+---
+
+## 8. Sources
+
+- `website/docs/src/content/docs/concepts/uniform-math.md` — the project's standing position on
+  precision as a parameter, the algebraic trait floor, and the witness pattern §3.4 builds on.
+- Nielsen, M. & Chuang, I. *Quantum Computation and Quantum Information* — generalised Rabi
+  formula and the depolarising channel, behind example 1.
+- Verma, T. & Pearl, J. (1990). *Equivalence and synthesis of causal models*; Pearl, *Causality*,
+  2nd ed., ch. 1 — Markov equivalence, behind example 2's structural degeneracy.
+- Kitaev, A. (2003). *Fault-tolerant quantum computation by anyons*, Ann. Phys. **303**, 2–30 — the
+  toric code parameters in example 3.
+- Chen, Y.-A. & Tata, S. (2023). arXiv:2106.05274 — the cup product the pairings run through, in
+  `deep_causality_topology/papers/`.
+- Haruna, J. (2025). arXiv:2511.15224 — the logical gates example 3 reaches for, in
+  `deep_causality_quantum/papers/`.
+
+Example designs: [`example-quantum-control-loop.md`](example-quantum-control-loop.md),
+[`example-crosstalk-attribution.md`](example-crosstalk-attribution.md),
+[`example-geometric-qec.md`](example-geometric-qec.md). Prior sketch:
+[`qcl-dsl-liftback.md`](qcl-dsl-liftback.md).

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -28,6 +28,12 @@ exclude = [
     "papers/*",
 ]
 
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+no-std = ["alloc"]
+
 [dev-dependencies]
 criterion = {  version = "0.8" }
 deep_causality_rand = { path = "../deep_causality_rand" }

--- a/ultragraph/src/errors/graph_error.rs
+++ b/ultragraph/src/errors/graph_error.rs
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use std::fmt;
+use core::fmt;
 
 /// A lightweight, copyable, stack-allocated error type for the next_graph library
 /// that provides context about the failure.
@@ -79,4 +79,4 @@ impl fmt::Display for GraphError {
 }
 
 // This makes GraphError a fully-fledged error type compatible with the Rust ecosystem.
-impl std::error::Error for GraphError {}
+impl core::error::Error for GraphError {}

--- a/ultragraph/src/errors/mod.rs
+++ b/ultragraph/src/errors/mod.rs
@@ -5,8 +5,10 @@
 
 #![forbid(unsafe_code)]
 
-use std::error::Error;
-use std::fmt;
+use alloc::string::String;
+
+use core::error::Error;
+use core::fmt;
 
 pub mod graph_error;
 

--- a/ultragraph/src/lib.rs
+++ b/ultragraph/src/lib.rs
@@ -3,6 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 pub mod errors;
 
 mod traits;

--- a/ultragraph/src/traits/graph_algo_centrality.rs
+++ b/ultragraph/src/traits/graph_algo_centrality.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{GraphError, GraphView};
+use alloc::vec::Vec;
 
 pub trait CentralityGraphAlgorithms<N, W>: GraphView<N, W> {
     /// Calculates the betweenness centrality of each node in the graph.

--- a/ultragraph/src/traits/graph_algo_pathfinder.rs
+++ b/ultragraph/src/traits/graph_algo_pathfinder.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{GraphError, GraphView};
+use alloc::vec::Vec;
 
 pub trait PathfindingGraphAlgorithms<N, W>: GraphView<N, W> {
     /// Checks if a path of any length exists from a start to a stop index.
@@ -29,5 +31,5 @@ pub trait PathfindingGraphAlgorithms<N, W>: GraphView<N, W> {
         stop_index: usize,
     ) -> Result<Option<(Vec<usize>, W)>, GraphError>
     where
-        W: Copy + Ord + Default + std::ops::Add<Output = W>;
+        W: Copy + Ord + Default + core::ops::Add<Output = W>;
 }

--- a/ultragraph/src/traits/graph_algo_structural.rs
+++ b/ultragraph/src/traits/graph_algo_structural.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{GraphError, GraphView};
+use alloc::vec::Vec;
 
 pub trait StructuralGraphAlgorithms<N, W>: GraphView<N, W> {
     /// Finds all Strongly Connected Components in the graph.

--- a/ultragraph/src/traits/graph_algo_topological.rs
+++ b/ultragraph/src/traits/graph_algo_topological.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{GraphError, GraphView};
+use alloc::vec::Vec;
 
 pub trait TopologicalGraphAlgorithms<N, W>: GraphView<N, W> {
     /// Finds a single cycle in the graph and returns the path of nodes that form it.

--- a/ultragraph/src/traits/graph_view.rs
+++ b/ultragraph/src/traits/graph_view.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 pub trait GraphView<N, W> {
     // State Inspection
     fn is_frozen(&self) -> bool;

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_articulation_points.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_articulation_points.rs
@@ -12,6 +12,8 @@
 
 use crate::types::storage::graph_csm::graph_csm_biconnectivity_common::build_symmetric_adjacency;
 use crate::{CsmGraph, GraphError, GraphView};
+use alloc::vec;
+use alloc::vec::Vec;
 
 const NO_PARENT_EDGE: usize = usize::MAX;
 

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_biconnected_components.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_biconnected_components.rs
@@ -11,6 +11,8 @@
 
 use crate::types::storage::graph_csm::graph_csm_biconnectivity_common::build_symmetric_adjacency;
 use crate::{CsmGraph, GraphError, GraphView};
+use alloc::vec;
+use alloc::vec::Vec;
 
 const NO_PARENT_EDGE: usize = usize::MAX;
 

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_bridges.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_bridges.rs
@@ -8,6 +8,8 @@
 
 use crate::types::storage::graph_csm::graph_csm_biconnectivity_common::build_symmetric_adjacency;
 use crate::{CsmGraph, GraphError, GraphView};
+use alloc::vec;
+use alloc::vec::Vec;
 
 const NO_PARENT_EDGE: usize = usize::MAX;
 

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_centrality.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_centrality.rs
@@ -2,9 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CentralityGraphAlgorithms, CsmGraph, GraphError, GraphView};
-use std::collections::HashSet;
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
 
 impl<N, W> CentralityGraphAlgorithms<N, W> for CsmGraph<N, W>
 where
@@ -195,9 +197,12 @@ where
                 for &neighbor in &self.backward_edges.targets[start_bwd..end_bwd] {
                     neighbors_to_process.push(neighbor);
                 }
-                // Use HashSet for efficient deduplication
-                let unique_neighbors: HashSet<usize> = neighbors_to_process.drain(..).collect();
-                neighbors_to_process.extend(unique_neighbors);
+                // Deduplicate in place. Sorting first makes the neighbour order
+                // deterministic; the previous `HashSet` round-trip inherited
+                // `RandomState`'s per-process seed, so the traversal order varied
+                // between runs.
+                neighbors_to_process.sort_unstable();
+                neighbors_to_process.dedup();
             }
 
             for &w in &neighbors_to_process {

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_centrality.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_centrality.rs
@@ -3,10 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
-use alloc::vec;
-use alloc::vec::Vec;
 use crate::{CentralityGraphAlgorithms, CsmGraph, GraphError, GraphView};
 use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
 
 impl<N, W> CentralityGraphAlgorithms<N, W> for CsmGraph<N, W>
 where

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_pathfinder.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_pathfinder.rs
@@ -2,9 +2,12 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{CsmGraph, GraphError, GraphView, PathfindingGraphAlgorithms};
-use std::cmp::Reverse;
-use std::collections::{BinaryHeap, VecDeque};
+use alloc::collections::{BinaryHeap, VecDeque};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp::Reverse;
 
 impl<N, W> PathfindingGraphAlgorithms<N, W> for CsmGraph<N, W>
 where
@@ -116,7 +119,7 @@ where
         stop_index: usize,
     ) -> Result<Option<(Vec<usize>, W)>, GraphError>
     where
-        W: Copy + Ord + Default + std::ops::Add<Output = W>,
+        W: Copy + Ord + Default + core::ops::Add<Output = W>,
     {
         if !self.contains_node(start_index) || !self.contains_node(stop_index) {
             return Ok(None);

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_structural.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_structural.rs
@@ -2,8 +2,11 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{CsmGraph, GraphError, GraphView, StructuralGraphAlgorithms};
-use std::slice;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::slice;
 
 impl<N, W> StructuralGraphAlgorithms<N, W> for CsmGraph<N, W>
 where

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_algo_topological.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_algo_topological.rs
@@ -2,9 +2,12 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{CsmGraph, GraphError, GraphView, TopologicalGraphAlgorithms};
-use std::collections::VecDeque;
-use std::slice;
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::slice;
 
 /// Private enum representing the state of a node during a DFS traversal.
 /// It is not part of the public API.

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
@@ -84,6 +84,13 @@ where
             canonical.push((a, b));
         }
     }
+    // TEMP-PROBE: was canonical already sorted before the sort call?
+    {
+        let already = canonical.is_sorted();
+        if !already {
+            panic!("PROBE: canonical NOT already sorted, len={}", canonical.len());
+        }
+    }
     // Sort to make edge_id assignment deterministic regardless of CSR layout.
     canonical.sort_unstable();
 

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
@@ -84,13 +84,6 @@ where
             canonical.push((a, b));
         }
     }
-    // TEMP-PROBE: was canonical already sorted before the sort call?
-    {
-        let already = canonical.is_sorted();
-        if !already {
-            panic!("PROBE: canonical NOT already sorted, len={}", canonical.len());
-        }
-    }
     // Sort to make edge_id assignment deterministic regardless of CSR layout.
     canonical.sort_unstable();
 

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
@@ -21,8 +21,10 @@
 //! components (e.g., two parallel edges between `u` and `v` are not a bridge,
 //! but a collapsed single edge would be).
 
+use alloc::vec;
+use alloc::vec::Vec;
 use crate::{CsmGraph, GraphView};
-use std::collections::HashMap;
+use alloc::collections::BTreeMap;
 
 /// Symmetric CSR adjacency over the undirected view of a `CsmGraph`.
 ///
@@ -53,7 +55,7 @@ where
     // are genuine parallel multi-edges. This rule is consistent with
     // `parallel_directed_edges_canonicalized_to_min_max` (anti-parallel pair
     // -> one undirected edge) and preserves multigraph semantics.
-    let mut counts: HashMap<(usize, usize), (usize, usize)> = HashMap::new();
+    let mut counts: BTreeMap<(usize, usize), (usize, usize)> = BTreeMap::new();
     for u in 0..n {
         let start = g.forward_edges.offsets[u];
         let end = g.forward_edges.offsets[u + 1];

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
@@ -21,10 +21,10 @@
 //! components (e.g., two parallel edges between `u` and `v` are not a bridge,
 //! but a collapsed single edge would be).
 
-use alloc::vec;
-use alloc::vec::Vec;
 use crate::{CsmGraph, GraphView};
 use alloc::collections::BTreeMap;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// Symmetric CSR adjacency over the undirected view of a `CsmGraph`.
 ///

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_biconnectivity_common.rs
@@ -84,8 +84,9 @@ where
             canonical.push((a, b));
         }
     }
-    // Sort to make edge_id assignment deterministic regardless of CSR layout.
-    canonical.sort_unstable();
+    // `counts` is a BTreeMap, so the loop above already pushed `canonical` in
+    // ascending (a, b) order with runs of parallel edges contiguous. Edge-id
+    // assignment is deterministic without an explicit sort.
 
     let mut degree: Vec<usize> = vec![0; n];
     for &(a, b) in &canonical {

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_unfreeze.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_unfreeze.rs
@@ -3,8 +3,10 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{CsmGraph, DynamicGraph, Unfreezable};
-use std::mem;
+use core::mem;
 
 /// This implementation provides the logic for the "unfreeze" part of the graph's
 /// evolutionary lifecycle. It allows a static, high-performance `CsmGraph` to be

--- a/ultragraph/src/types/storage/graph_csm/graph_csm_view.rs
+++ b/ultragraph/src/types/storage/graph_csm/graph_csm_view.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{CsmGraph, GraphView};
 
 // A constant defined for the adaptive `contains_edge` algorithm.

--- a/ultragraph/src/types/storage/graph_csm/mod.rs
+++ b/ultragraph/src/types/storage/graph_csm/mod.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 mod default;
 mod graph_csm_algo;
 mod graph_csm_algo_articulation_points;

--- a/ultragraph/src/types/storage/graph_dynamic/graph_freeze.rs
+++ b/ultragraph/src/types/storage/graph_dynamic/graph_freeze.rs
@@ -3,6 +3,9 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::types::storage::graph_csm::CsrAdjacency;
 use crate::{CsmGraph, DynamicGraph, Freezable, GraphView};
 
@@ -265,7 +268,7 @@ where
     let mut next_weights = &mut weights_buffer[..];
 
     // Process the `usize` keys 8 bits (1 byte) at a time.
-    for i in 0..std::mem::size_of::<usize>() {
+    for i in 0..core::mem::size_of::<usize>() {
         let shift = i * 8;
 
         // 1. Counting pass: Count occurrences of each byte value in the current data.
@@ -289,14 +292,14 @@ where
 
             next_targets[write_pos] = target;
             // Use mem::take to move the weight without cloning, preserving data.
-            next_weights[write_pos] = std::mem::take(&mut current_weights[j]);
+            next_weights[write_pos] = core::mem::take(&mut current_weights[j]);
 
             offsets[key] += 1;
         }
 
         // 4. Swap buffers: The `next` buffer is now the `current` for the next pass.
-        std::mem::swap(&mut current_targets, &mut next_targets);
-        std::mem::swap(&mut current_weights, &mut next_weights);
+        core::mem::swap(&mut current_targets, &mut next_targets);
+        core::mem::swap(&mut current_weights, &mut next_weights);
     }
 
     // After all passes, the data is fully sorted. Because we swap an even number

--- a/ultragraph/src/types/storage/graph_dynamic/graph_mut.rs
+++ b/ultragraph/src/types/storage/graph_dynamic/graph_mut.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{DynamicGraph, GraphError, GraphMut, GraphView};
 
 impl<N, W> GraphMut<N, W> for DynamicGraph<N, W> {

--- a/ultragraph/src/types/storage/graph_dynamic/graph_view.rs
+++ b/ultragraph/src/types/storage/graph_dynamic/graph_view.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{DynamicGraph, GraphView};
 
 impl<N, W> GraphView<N, W> for DynamicGraph<N, W> {

--- a/ultragraph/src/types/storage/graph_dynamic/mod.rs
+++ b/ultragraph/src/types/storage/graph_dynamic/mod.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 mod default;
 mod graph_freeze;
 mod graph_mut;

--- a/ultragraph/src/types/ultra_graph/graph_algo.rs
+++ b/ultragraph/src/types/ultra_graph/graph_algo.rs
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
 
+use alloc::vec::Vec;
+
 use crate::{
     CentralityGraphAlgorithms, GraphAlgorithms, GraphError, GraphState, PathfindingGraphAlgorithms,
     StructuralGraphAlgorithms, TopologicalGraphAlgorithms, UltraGraphContainer,
@@ -175,7 +177,7 @@ where
     /// This high-performance operation is only available when the graph is in a `Static` (frozen) state.
     ///
     /// # Type Parameters
-    /// - `W`: The weight type, which must implement `Copy`, `Ord`, `Default`, and `std::ops::Add`.
+    /// - `W`: The weight type, which must implement `Copy`, `Ord`, `Default`, and `core::ops::Add`.
     ///
     /// # Errors
     ///
@@ -188,7 +190,7 @@ where
         stop_index: usize,
     ) -> Result<Option<(Vec<usize>, W)>, GraphError>
     where
-        W: Copy + Ord + Default + std::ops::Add<Output = W>,
+        W: Copy + Ord + Default + core::ops::Add<Output = W>,
     {
         match &self.state {
             GraphState::Static(g) => g.shortest_weighted_path(start_index, stop_index),

--- a/ultragraph/src/types/ultra_graph/graph_evolve.rs
+++ b/ultragraph/src/types/ultra_graph/graph_evolve.rs
@@ -18,7 +18,7 @@ where
     pub fn freeze(&mut self) {
         if !self.is_frozen() {
             // Safely take ownership of the state, leaving a default in its place.
-            let current_state = std::mem::take(&mut self.state);
+            let current_state = core::mem::take(&mut self.state);
 
             // We know this will be the `Dynamic` variant because of the check above.
             if let GraphState::Dynamic(dynamic_graph) = current_state {
@@ -38,7 +38,7 @@ where
     pub fn unfreeze(&mut self) {
         if self.is_frozen() {
             // Safely take ownership of the state.
-            let current_state = std::mem::take(&mut self.state);
+            let current_state = core::mem::take(&mut self.state);
 
             // We know this will be the `Static` variant because of the check above.
             if let GraphState::Static(static_graph) = current_state {

--- a/ultragraph/src/types/ultra_graph/graph_view.rs
+++ b/ultragraph/src/types/ultra_graph/graph_view.rs
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MIT
  * Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
  */
+
 use crate::{GraphState, GraphView, UltraGraphContainer};
+use alloc::vec::Vec;
 
 impl<N, W> GraphView<N, W> for UltraGraphContainer<N, W>
 where


### PR DESCRIPTION
## Describe your changes

Allocator-free (core only) non-std
- deep_causality_algebra
- deep_causality_num
- deep_causality_num_complex
- deep_causality_num_dual
- deep_causality_calculus

Allocator required  non-std:
- deep_causality_haft
- deep_causality_core
- deep_causality_metric
- deep_causality_ast
- deep_causality_data_structures
- deep_causality_tensor
- deep_causality_multivector
- deep_causality_sparse
- deep_causality_fft
- deep_causality_rand
- deep_causality_par
- deep_causality_quantum
- ultragraph 

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds consistent no-std support across 18 crates behind unified std/alloc/no-std features and blocks std leakage via `default-features = false`. Hosted behavior is unchanged; on no-std the `parallel` path is std-only and the quantum causal-model slice (`qcm`) is disabled.

- Adds/aligns no-std in `deep_causality_ast`, `deep_causality_calculus`, `deep_causality_core`, `deep_causality_data_structures`, `deep_causality_fft`, `deep_causality_metric`, `deep_causality_multivector`, `deep_causality_par`, `deep_causality_quantum` (and forwards in dependents) using `#![cfg_attr(not(feature = "std"), no_std)]` with `extern crate alloc`.
- Rejects alloc-only builds: `deep_causality_core` and `deep_causality_calculus` `compile_error!` unless you choose exactly one platform level, `std` or `no-std`.
- `deep_causality_par`: `std` is default; `parallel` now requires `std`. On bare metal, enabling `parallel` emits a targeted `compile_error!`; `scoped_map` runs inline on `no-std`.
- `deep_causality_fft`: `parallel = ["std", "rayon", "deep_causality_par/parallel"]` prevents Rayon under `no-std`; downstream `parallel` forwards to `deep_causality_par`.
- `deep_causality_quantum`: defaults to `["std","qcm"]`; `qcm` implies `std` and is off on `no-std`. Bazel docs/tests enable `qcm`; modules and tests are `#[cfg(feature = "qcm")]`.
- `deep_causality_cfd`: fixes `std` feature wiring and sets internal deps `default-features = false`; remains `std`-only.
- `deep_causality_rand`: no `ThreadRng` on `no-std`; `Xoshiro256::new()` seeds from a per-call counter (deterministic per boot). Use `from_seed` for per-boot uniqueness.
- Adds `README_NO_STD.md` with allocator guidance and a verified bare‑metal build matrix (aarch64-unknown-none).

**Review and rollout**
- Build bare metal: cargo build -p <crate> --no-default-features --features no-std --target <triple>. Provide a #[global_allocator] for crates using `alloc` (e.g., `deep_causality_core`, `deep_causality_tensor`, `deep_causality_multivector`, `deep_causality_fft`, `deep_causality_par`, `deep_causality_quantum`). Do not enable `parallel` on `no-std`.
- When depending on updated crates, set `default-features = false` to avoid re‑introducing `std`. Seed RNGs explicitly on embedded if uniqueness across boots is required.
- For quantum causal‑model validation on host builds, enable `deep_causality_quantum`’s `qcm` feature; it is unavailable on `no-std`.

<sup>Written for commit 6b741184d955aa6288eab58fbf5a09fae522094e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

