### PR TITLE
ci(cfd): run slow verification harnesses monthly, not nightly

### DIFF
--- a/.github/workflows/cfd_verification.yml
+++ b/.github/workflows/cfd_verification.yml
@@ -8,7 +8,7 @@
 # verification/README.md was unenforced. Each harness self-verifies and exits non-zero on a broken
 # gate, so running it is the whole check — no extra assertions live here.
 #
-# Split by cost: the fast harnesses gate every pull request; the slow ones run nightly.
+# Split by cost: the fast harnesses gate every pull request; the slow ones run monthly.
 # `verification-suite-complete` fails if a harness is declared in Cargo.toml but listed in neither
 # set, so a newly added harness cannot silently never run.
 #
@@ -40,8 +40,13 @@ name: CFD Verification
 on:
   pull_request:
   schedule:
-    # 03:17 UTC daily. Off the hour to avoid the scheduler's peak-minute queue.
-    - cron: '17 3 * * *'
+    # 03:17 UTC on the 1st of each month. Off the hour to avoid the scheduler's peak-minute queue.
+    #
+    # Monthly, not nightly: the slow set re-verified an unchanged tree every night and was the single
+    # largest consumer of the repository's Actions minutes (~53 min/day, ~41% of all CI compute over
+    # August 2026) for a signal that changes only when the DEC solver does. Between scheduled runs,
+    # reach for `workflow_dispatch` after any change to the solver or to a slow harness's gates.
+    - cron: '17 3 1 * *'
   workflow_dispatch:
 
 permissions:
@@ -113,7 +118,7 @@ jobs:
 
   fast:
     name: Fast harnesses (pull request)
-    # Skipped on the nightly schedule: the PR run already covers these.
+    # Skipped on the monthly schedule: the PR run already covers these.
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -169,8 +174,8 @@ jobs:
           echo "All fast verification harnesses passed."
 
   slow:
-    name: Slow harnesses (nightly)
-    # Nightly and manual only — ~12 min, dominated by dec_cylinder. Never gates a pull request.
+    name: Slow harnesses (monthly)
+    # Monthly and manual only — ~12 min, dominated by dec_cylinder. Never gates a pull request.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/deep_causality_cfd/README.md
+++ b/deep_causality_cfd/README.md
@@ -309,10 +309,11 @@ whole program at another precision.
 
 ## Verification
 
-The crate ships its evidence, and CI runs it. `verification/` holds thirteen runnable programs gated
+The crate ships its evidence, and CI runs it. `verification/` holds fourteen runnable programs gated
 against analytic solutions, published references, or internal invariants;
-`.github/workflows/cfd_verification.yml` executes the fast nine on every pull request and the slow
-four nightly, failing the build on a non-zero exit. `studies/` holds the empirical probes that settled
+`.github/workflows/cfd_verification.yml` executes the fast ten on every pull request and the slow
+three monthly, failing the build on a non-zero exit. The fourteenth, `qtt_cylinder_verification`, is
+too slow for CI at the resolution its physics needs and is run by hand. `studies/` holds the empirical probes that settled
 design questions before they were committed to specs, findings encoded as gates so the conclusions
 stay reproducible. `benches/` pins performance in `PERFORMANCE.md`.
 

--- a/deep_causality_cfd/verification/README.md
+++ b/deep_causality_cfd/verification/README.md
@@ -17,7 +17,8 @@ reference check fails — so the suite is usable as a gate, not just a demo. Wha
 how it fails, is in the per-example sections below.
 
 **CI runs this suite.** `.github/workflows/cfd_verification.yml` executes the ten `FAST_HARNESSES` on
-every pull request and the three `SLOW_HARNESSES` nightly, failing the build on a non-zero exit. A
+every pull request and the three `SLOW_HARNESSES` on the first of each month (and on
+`workflow_dispatch`), failing the build on a non-zero exit. A
 fourteenth, `qtt_cylinder_verification`, sits in `OFFLINE_HARNESSES` and no job runs it. A completeness
 check asserts that every `[[example]]` declared under `verification/` in `Cargo.toml` appears in one of
 those three lists, so a newly added harness cannot silently never run. Until this workflow existed,
@@ -99,7 +100,7 @@ difference. Measured at `f64` on an Apple M3 Max (release).
 | `qtt_blunt_body_2d` | rank lever: bow-shock χ, fitted vs Cartesian capture | fitted 3→5; capture 16→61 | structural (fitted χ bounded, ≤ +1 per refinement) | fitted flat 3→5; capture ≈ side/2 (16, 32, 61), not ~√side | 2^5–2^7 | <1 s |
 | `qtt_reentry_3d` | rank lever: 3-D forebody χ (wake out-of-scope) | fitted 2→4; Cartesian 10→59; wake 41 | structural (`qtt_rank_3d` bound) | fitted plateau; capture grows | 2^3–2^5 | <1 s |
 
-> ⚠ **`qtt_cylinder_verification` is known-failing and runs nightly, not per-PR.** Its two parameter
+> ⚠ **`qtt_cylinder_verification` is known-failing and runs offline by hand, not in CI.** Its two parameter
 > ladders gate and both report `NOT CONVERGING`. This is a correct measurement, not a regression:
 >
 > - **η ladder** (0.128 → 0.008): `C_d` = 17.39, 24.02, 26.25, 23.76, 21.40 — it rises, peaks, then


### PR DESCRIPTION

## Describe your changes

The nightly schedule re-verified an unchanged tree every night and was
the single largest consumer of the repository's Actions minutes — 1,161
min over 2026-08-01..20, ~41% of all CI compute, ~53 min on days with no
other activity. The slow set only changes signal when the DEC solver
does, so daily cadence bought nothing.

Schedule moves to 03:17 UTC on the 1st of each month. PR behaviour is
unchanged: the fast ten still gate every pull request, the slow three
still never do. Use workflow_dispatch after solver changes or when
editing a slow harness's gates.

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run slow CFD verification harnesses monthly instead of nightly to cut wasted CI minutes without losing signal. Previously the slow set ran every night; now it runs at 03:17 UTC on the first of each month and on demand. PR behavior is unchanged.

- `slow` job schedule: monthly cron (`17 3 1 * *`) and `workflow_dispatch`; `fast` job still gates pull requests; slow harnesses never gate.
- Docs: update `deep_causality_cfd/README.md` and `deep_causality_cfd/verification/README.md` to reflect 14 harnesses (10 fast, 3 slow, 1 offline) and mark `qtt_cylinder_verification` as offline.
- Required action: after any DEC solver change or edits to a slow harness’s gates, manually run `CFD Verification` via `workflow_dispatch`.

<sup>Written for commit 8bbffd30bfd75db22dd0353390bf6bde1da3c537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

