### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.1...deep_causality-v0.15.2) - 2026-08-23
+
+### Added
+
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Fixed
+
+- *(clippy)* silence chunks_exact_to_as_chunks and useless_format
+
+### Other
+
+- Removed broken Test URL from README
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.15.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.0...deep_causality-v0.15.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -533,14 +533,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algebra"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "deep_causality_num",
 ]
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -554,11 +554,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_cfd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -590,14 +590,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "deep_causality_algebra",
 ]
@@ -663,11 +663,11 @@ version = "0.9.5"
 
 [[package]]
 name = "deep_causality_metric"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -680,14 +680,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_dual"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -711,11 +711,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_sparse"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_tensor"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2194,7 +2194,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.15.1"
+version = "0.15.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -43,7 +43,7 @@ os-random = ["deep_causality_uncertain/os-random"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"

--- a/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_algebra/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.2.0...deep_causality_algebra-v0.3.0) - 2026-08-23
+
+### Added
+
+- *(lean)* formalize the Euclidean domain and Q
+- *(deep_causality_algebra)* add the semiring level so N has an algebraic slot
+- *(deep_causality_algebra)* [**breaking**] admit the integers into the algebra tower
+
+### Fixed
+
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+- *(deep_causality_algebra)* [**breaking**] make the Euclidean contract honest at the edges
+- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub
+- *(deep_causality_algebra)* [**breaking**] normalize the Euclidean gcd and stop lcm overflowing
+
+### Other
+
+- More fixes and lints.
+- Improved test coverage
+- bring the algebra reference current and correct the CI claim
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algebra"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.2...deep_causality_algorithms-v0.4.3) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra, deep_causality_tensor
+
 ## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.1...deep_causality_algorithms-v0.4.2) - 2026-08-12
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -28,7 +28,7 @@ exclude = [
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
@@ -36,7 +36,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"

--- a/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.9...deep_causality_ast-v0.1.10) - 2026-08-23
+
+### Added
+
+- *(deep_causality_ast)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+
 ## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.3...deep_causality_calculus-v0.1.4) - 2026-08-23
+
+### Added
+
+- *(deep_causality_calculus)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -48,12 +48,12 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [lints]

--- a/deep_causality_cfd/CHANGELOG.md
+++ b/deep_causality_cfd/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.0...deep_causality_cfd-v0.1.1) - 2026-08-23
+
+### Added
+
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Fixed
+
+- *(deep_causality_cfd)* fixes std feat bug.
+- *(clippy)* silence chunks_exact_to_as_chunks and useless_format
+
+### Other
+
+- *(cfd)* run slow verification harnesses monthly, not nightly
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_cfd-v0.1.0) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_cfd"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -93,22 +93,22 @@ version = "0.4"
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 default-features = false
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
 default-features = false
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
 default-features = false
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
 default-features = false
-version = "0.5"
+version = "0.6"
 
 # Std-only: the uncertain-inflow zone consumes `MaybeUncertain<R>` and its global
 # sample cache. Gated behind `std` so the `alloc`-only build stays uncertain-free.

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.1...deep_causality_core-v0.11.2) - 2026-08-23
+
+### Added
+
+- *(deep_causality_core)* Configured no-std flag.
+
+### Fixed
+
+- *(deep_causality_core)* Added IntType type alias
+
+### Other
+
+- lints and minor code fixes
+
 ## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.17](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.16...deep_causality_data_structures-v0.10.17) - 2026-08-23
+
+### Added
+
+- *(deep_causality_data_structures)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+
 ## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
 
 ### Added

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.16"
+version = "0.10.17"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.1...deep_causality_discovery-v0.5.2) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra, deep_causality_tensor
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -38,7 +38,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
@@ -47,7 +47,7 @@ version = "0.4"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 
 
 [dependencies.deep_causality_topology]

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.10...deep_causality_ethos-v0.2.11) - 2026-08-23
+
+### Added
+
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Other
+
+- Removed broken Test URL from README
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.2.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.9...deep_causality_ethos-v0.2.10) - 2026-08-12
 
 ### Added

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.10"
+version = "0.2.11"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_fft/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.2...deep_causality_fft-v0.1.3) - 2026-08-23
+
+### Added
+
+- *(deep_causality_fft)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -58,12 +58,12 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_par]

--- a/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.3...deep_causality_file-v0.1.4) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -34,7 +34,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies]
 # External dependencies

--- a/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.2...deep_causality_haft-v0.4.3) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -34,7 +34,7 @@ no-std = ["alloc", "deep_causality_algebra/no-std"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [[example]]

--- a/deep_causality_metric/CHANGELOG.md
+++ b/deep_causality_metric/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.4...deep_causality_metric-v0.2.5) - 2026-08-23
+
+### Added
+
+- *(deep_causality_metric)* Configured no-std flag.
+
 ## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.3...deep_causality_metric-v0.2.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_metric/Cargo.toml
+++ b/deep_causality_metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_metric"
-version = "0.2.4"
+version = "0.2.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.4...deep_causality_multivector-v0.5.5) - 2026-08-23
+
+### Added
+
+- *(deep_causality_multivector)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+
 ## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.5.4"
+version = "0.5.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -43,17 +43,17 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dependencies.deep_causality_metric]

--- a/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.1...deep_causality_num-v0.4.2) - 2026-08-23
+
+### Added
+
+- *(deep_causality_num)* add NaturalNumber, the set-named entry point for N
+
+### Fixed
+
+- *(deep_causality_num)* Added u64 and i64 default implementation to num trait
+- *(deep_causality_num)* fixed a non-std lint
+
+### Other
+
+- Fixed docstring
+- bring the algebra reference current and correct the CI claim
+- *(deep_causality_num)* document all five number systems and where each lives
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_num/Cargo.toml
+++ b/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.4.1"
+version = "0.4.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.4...deep_causality_num_complex-v0.2.0) - 2026-08-23
+
+### Fixed
+
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+- *(deep_causality_num_complex)* Added default implementation for Invertible trait
+
+### Other
+
+- bring the algebra reference current and correct the CI claim
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.4"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -36,7 +36,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.4...deep_causality_num_dual-v0.2.0) - 2026-08-23
+
+### Fixed
+
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+
+### Other
+
+- bring the algebra reference current and correct the CI claim
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14
 
 ### Other

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_dual"
-version = "0.1.4"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -37,7 +37,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_num_rational/CHANGELOG.md
+++ b/deep_causality_num_rational/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_num_rational-v0.1.0) - 2026-08-23
+
+### Added
+
+- *(deep_causality_num_rational)* add Q, the field of fractions
+
+### Fixed
+
+- *(deep_causality_num_rational)* [**breaking**] overflow defects in comparison, construction
+
+### Other
+
+- Improved test coverage
+- bring the algebra reference current and correct the CI claim

--- a/deep_causality_num_rational/Cargo.toml
+++ b/deep_causality_num_rational/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.2...deep_causality_par-v0.1.3) - 2026-08-23
+
+### Added
+
+- *(deep_causality_par)* Configured no-std flag.
+
+### Other
+
+- *(deep_causality)* Updated non-std README.
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.1...deep_causality_physics-v0.8.2) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra, deep_causality_core, deep_causality_num_complex, deep_causality_num_dual, deep_causality_tensor
+
 ## [0.8.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.0...deep_causality_physics-v0.8.1) - 2026-08-12
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.8.1"
+version = "0.8.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -53,7 +53,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"
@@ -73,15 +73,15 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
-version = "0.1"
+version = "0.2"
 
 [dependencies.deep_causality_rand]
 path = "../deep_causality_rand"
@@ -94,7 +94,7 @@ version = "0.2"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -51,12 +51,12 @@ optional = true
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 default-features = false
 
 [dependencies.deep_causality_haft]
@@ -81,12 +81,12 @@ default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 default-features = false
 
 [dependencies.deep_causality_uncertain]

--- a/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.1...deep_causality_rand-v0.2.2) - 2026-08-23
+
+### Added
+
+- *(deep_causality_rand)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -32,7 +32,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 

--- a/deep_causality_sparse/CHANGELOG.md
+++ b/deep_causality_sparse/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.2...deep_causality_sparse-v0.2.3) - 2026-08-23
+
+### Added
+
+- *(deep_causality_sparse)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.1...deep_causality_sparse-v0.2.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_sparse/Cargo.toml
+++ b/deep_causality_sparse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_sparse"
-version = "0.2.2"
+version = "0.2.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -43,7 +43,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_haft]
@@ -53,7 +53,7 @@ default-features = false
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 default-features = false
 optional = true
 

--- a/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.1...deep_causality_tensor-v0.6.0) - 2026-08-23
+
+### Added
+
+- *(deep_causality_tensor)* Configured no-std flag.
+
+### Fixed
+
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub
+
+### Other
+
+- More fixes and lints.
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_tensor"
-version = "0.5.1"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -48,17 +48,17 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_num_dual]
 path = "../deep_causality_num_dual"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dev-dependencies]

--- a/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.1...deep_causality_topology-v0.7.2) - 2026-08-23
+
+### Added
+
+- *(topology)* add the cup product, generic over ChainComplex
+
+### Fixed
+
+- *(topology)* address review findings on the cup product changeset
+
+### Other
+
+- lints and minor code fixes
+- *(topology)* document the vertex and corner ordering contracts
+- *(deep_causality_topology)* added test suite for cup product
+
 ## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.7.1"
+version = "0.7.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -57,12 +57,12 @@ default-features = false
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"
-version = "0.1"
+version = "0.2"
 default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_par]
@@ -89,7 +89,7 @@ version = "0.4"
 
 [dependencies.deep_causality_tensor]
 path = "../deep_causality_tensor"
-version = "0.5"
+version = "0.6"
 
 [dependencies.deep_causality_metric]
 path = "../deep_causality_metric"

--- a/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.0...deep_causality_uncertain-v0.5.1) - 2026-08-23
+
+### Other
+
+- updated the following local packages: deep_causality_algebra
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.5.0"
+version = "0.5.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -47,7 +47,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dev-dependencies]
 rusty-fork = "0.3"

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.3...ultragraph-v0.9.4) - 2026-08-23
+
+### Added
+
+- *(ultragraph)* Configured no-std flag.
+
+### Other
+
+- lints and minor code fixes
+- lints and minor code fixes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
 
 ### Fixed

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.3"
+version = "0.9.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `deep_causality_algebra`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `deep_causality_ast`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `deep_causality_core`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.16 -> 0.10.17 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `ultragraph`: 0.9.3 -> 0.9.4 (✓ API compatible changes)
* `deep_causality`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `deep_causality_par`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.4 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_num_dual`: 0.1.4 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_tensor`: 0.5.1 -> 0.6.0 (✓ API compatible changes)
* `deep_causality_fft`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_metric`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `deep_causality_multivector`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `deep_causality_sparse`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `deep_causality_topology`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `deep_causality_calculus`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_cfd`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `deep_causality_num_rational`: 0.1.0
* `deep_causality_haft`: 0.4.2 -> 0.4.3
* `deep_causality_uncertain`: 0.5.0 -> 0.5.1
* `deep_causality_algorithms`: 0.4.2 -> 0.4.3
* `deep_causality_file`: 0.1.3 -> 0.1.4
* `deep_causality_physics`: 0.8.1 -> 0.8.2
* `deep_causality_discovery`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.1...deep_causality_num-v0.4.2) - 2026-08-23

### Added

- *(deep_causality_num)* add NaturalNumber, the set-named entry point for N

### Fixed

- *(deep_causality_num)* Added u64 and i64 default implementation to num trait
- *(deep_causality_num)* fixed a non-std lint

### Other

- Fixed docstring
- bring the algebra reference current and correct the CI claim
- *(deep_causality_num)* document all five number systems and where each lives
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.2.0...deep_causality_algebra-v0.3.0) - 2026-08-23

### Added

- *(lean)* formalize the Euclidean domain and Q
- *(deep_causality_algebra)* add the semiring level so N has an algebraic slot
- *(deep_causality_algebra)* [**breaking**] admit the integers into the algebra tower

### Fixed

- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
- *(deep_causality_algebra)* [**breaking**] make the Euclidean contract honest at the edges
- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub
- *(deep_causality_algebra)* [**breaking**] normalize the Euclidean gcd and stop lcm overflowing

### Other

- More fixes and lints.
- Improved test coverage
- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_ast`

<blockquote>

## [0.1.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.9...deep_causality_ast-v0.1.10) - 2026-08-23

### Added

- *(deep_causality_ast)* Configured no-std flag.

### Other

- lints and minor code fixes
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.11.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.1...deep_causality_core-v0.11.2) - 2026-08-23

### Added

- *(deep_causality_core)* Configured no-std flag.

### Fixed

- *(deep_causality_core)* Added IntType type alias

### Other

- lints and minor code fixes
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.17](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.16...deep_causality_data_structures-v0.10.17) - 2026-08-23

### Added

- *(deep_causality_data_structures)* Configured no-std flag.

### Other

- lints and minor code fixes
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.1...deep_causality_rand-v0.2.2) - 2026-08-23

### Added

- *(deep_causality_rand)* Configured no-std flag.

### Other

- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.4](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.3...ultragraph-v0.9.4) - 2026-08-23

### Added

- *(ultragraph)* Configured no-std flag.

### Other

- lints and minor code fixes
- lints and minor code fixes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality`

<blockquote>

## [0.15.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.1...deep_causality-v0.15.2) - 2026-08-23

### Added

- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Fixed

- *(clippy)* silence chunks_exact_to_as_chunks and useless_format

### Other

- Removed broken Test URL from README
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.2...deep_causality_par-v0.1.3) - 2026-08-23

### Added

- *(deep_causality_par)* Configured no-std flag.

### Other

- *(deep_causality)* Updated non-std README.
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.4...deep_causality_num_complex-v0.2.0) - 2026-08-23

### Fixed

- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
- *(deep_causality_num_complex)* Added default implementation for Invertible trait

### Other

- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.4...deep_causality_num_dual-v0.2.0) - 2026-08-23

### Fixed

- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference

### Other

- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.1...deep_causality_tensor-v0.6.0) - 2026-08-23

### Added

- *(deep_causality_tensor)* Configured no-std flag.

### Fixed

- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub

### Other

- More fixes and lints.
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_fft`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.2...deep_causality_fft-v0.1.3) - 2026-08-23

### Added

- *(deep_causality_fft)* Configured no-std flag.

### Other

- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_metric`

<blockquote>

## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.4...deep_causality_metric-v0.2.5) - 2026-08-23

### Added

- *(deep_causality_metric)* Configured no-std flag.
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.5.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.4...deep_causality_multivector-v0.5.5) - 2026-08-23

### Added

- *(deep_causality_multivector)* Configured no-std flag.

### Other

- lints and minor code fixes
</blockquote>

## `deep_causality_sparse`

<blockquote>

## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.2...deep_causality_sparse-v0.2.3) - 2026-08-23

### Added

- *(deep_causality_sparse)* Configured no-std flag.

### Other

- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.7.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.1...deep_causality_topology-v0.7.2) - 2026-08-23

### Added

- *(topology)* add the cup product, generic over ChainComplex

### Fixed

- *(topology)* address review findings on the cup product changeset

### Other

- lints and minor code fixes
- *(topology)* document the vertex and corner ordering contracts
- *(deep_causality_topology)* added test suite for cup product
</blockquote>

## `deep_causality_calculus`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.3...deep_causality_calculus-v0.1.4) - 2026-08-23

### Added

- *(deep_causality_calculus)* Configured no-std flag.

### Other

- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_cfd`

<blockquote>

## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.0...deep_causality_cfd-v0.1.1) - 2026-08-23

### Added

- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Fixed

- *(deep_causality_cfd)* fixes std feat bug.
- *(clippy)* silence chunks_exact_to_as_chunks and useless_format

### Other

- *(cfd)* run slow verification harnesses monthly, not nightly
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.11](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.10...deep_causality_ethos-v0.2.11) - 2026-08-23

### Added

- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Other

- Removed broken Test URL from README
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_num_rational`

<blockquote>

## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_num_rational-v0.1.0) - 2026-08-23

### Added

- *(deep_causality_num_rational)* add Q, the field of fractions

### Fixed

- *(deep_causality_num_rational)* [**breaking**] overflow defects in comparison, construction

### Other

- Improved test coverage
- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.2...deep_causality_haft-v0.4.3) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.0...deep_causality_uncertain-v0.5.1) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.2...deep_causality_algorithms-v0.4.3) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra, deep_causality_tensor
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.3...deep_causality_file-v0.1.4) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.8.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.1...deep_causality_physics-v0.8.2) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra, deep_causality_core, deep_causality_num_complex, deep_causality_num_dual, deep_causality_tensor
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.1...deep_causality_discovery-v0.5.2) - 2026-08-23

### Other

- updated the following local packages: deep_causality_algebra, deep_causality_tensor
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the workspace with `deep_causality_algebra` 0.3 and adds optional `no-std` across core crates. Publishes `deep_causality_num_rational` (Q) and updates dependents to the stricter algebra contracts (AddGroup now requires Neg; Euclidean gcd normalized and lcm overflow fixed).

- Migration
  - Add `core::ops::Neg` to any type implementing AddGroup; Sub-only implementations now fail under `deep_causality_algebra` 0.3.
  - Update dependencies to `deep_causality_algebra` 0.3 and aligned versions (`deep_causality_tensor` 0.6, `deep_causality_num_complex` 0.2, `deep_causality_num_dual` 0.2).
  - If you rely on gcd/lcm semantics, expect normalized gcd and non-overflowing lcm; update tests accordingly.
  - For `no-std` builds, enable `alloc` where needed and disable std-only features; defaults remain std.

<sup>Written for commit 2d96047fa289933e884075db197ba8818ae738d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

