### PR TITLE
fix(release): bump algebra to 0.3.0 so the new traits are actually published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algebra"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "deep_causality_num",
 ]
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libm",
 ]

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -43,7 +43,7 @@ os-random = ["deep_causality_uncertain/os-random"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_uncertain]
 path = "../deep_causality_uncertain"

--- a/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algebra"
-version = "0.2.0"
+version = "0.3.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -32,7 +32,7 @@ no-std = ["deep_causality_num/no-std"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.4"
+version = "0.4.2"
 default-features = false
 
 [lints]

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_topology]
 path = "../deep_causality_topology"

--- a/deep_causality_algorithms/README.md
+++ b/deep_causality_algorithms/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -17,7 +17,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 A collection of computational causality algorithms used in
 the [DeepCausality](https://github.com/deepcausality-rs/deep_causality) project. This crate provides tools for analyzing

--- a/deep_causality_ast/README.md
+++ b/deep_causality_ast/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 [crates-url]: https://crates.io/crates/deep_causality_ast
@@ -14,7 +14,7 @@
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 
 A persistent, immutable, thread-safe tree data structure for the `deep_causality` project.

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -48,7 +48,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_dual]

--- a/deep_causality_calculus/README.md
+++ b/deep_causality_calculus/README.md
@@ -10,7 +10,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 [crates-url]: https://crates.io/crates/deep_causality_calculus
@@ -18,7 +18,7 @@
 [docs-url]: https://docs.rs/deep_causality_calculus/latest/deep_causality_calculus/
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 
 Arrow-native differentiation and integration operators for the DeepCausality stack:

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -93,7 +93,7 @@ version = "0.4"
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
 default-features = false
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"

--- a/deep_causality_core/README.md
+++ b/deep_causality_core/README.md
@@ -9,7 +9,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 [crates-url]: https://crates.io/crates/deep_causality_core
@@ -17,7 +17,7 @@
 [docs-url]: https://docs.rs/deep_causality_core/latest/deep_causality_core/
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 **Core types and abstractions for the [DeepCausality project](http://www.deepcausality.com).**
 

--- a/deep_causality_data_structures/README.md
+++ b/deep_causality_data_structures/README.md
@@ -9,7 +9,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -23,7 +23,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 High performance datastructures used in [DeepCausality](https://github.com/deepcausality-rs/deep_causality).
 

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -38,7 +38,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"

--- a/deep_causality_discovery/README.md
+++ b/deep_causality_discovery/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/crates/v/deep_causality_discovery.svg
 
@@ -17,7 +17,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 ## Introduction
 

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -58,7 +58,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -34,7 +34,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies]
 # External dependencies

--- a/deep_causality_file/README.md
+++ b/deep_causality_file/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/crates/v/deep_causality_file.svg
 
@@ -17,7 +17,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 ## Introduction
 

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -34,7 +34,7 @@ no-std = ["alloc", "deep_causality_algebra/no-std"]
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [[example]]

--- a/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_multivector/Cargo.toml
@@ -43,7 +43,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]

--- a/deep_causality_num/Cargo.toml
+++ b/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.4.1"
+version = "0.4.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_num/README.md
+++ b/deep_causality_num/README.md
@@ -5,11 +5,10 @@
 [//]: # (---)
 
 # DeepCausality NUM types and traits
-
+x
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -22,8 +21,6 @@
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
-
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
 
 ## Summary
 

--- a/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_num_complex/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
     "MODULE.bazel",
     ".bazelignore",
     ".bazelrc",
+    "tests/*",
     "tests/**/*",
     "papers/*",
 ]
@@ -36,7 +37,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_num_dual/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
     "MODULE.bazel",
     ".bazelignore",
     ".bazelrc",
+    "tests/*",
     "tests/**/*",
     "papers/*",
 ]
@@ -37,7 +38,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_num_rational/Cargo.toml
+++ b/deep_causality_num_rational/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
     "MODULE.bazel",
     ".bazelignore",
     ".bazelrc",
+    "tests/*",
     "tests/**/*",
     "papers/*",
 ]
@@ -37,7 +38,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [lints]

--- a/deep_causality_num_rational/README.md
+++ b/deep_causality_num_rational/README.md
@@ -9,7 +9,6 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -23,7 +22,6 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
 
 ## Summary
 

--- a/deep_causality_par/README.md
+++ b/deep_causality_par/README.md
@@ -9,7 +9,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -23,7 +23,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 Shared parallelism primitives for the DeepCausality workspace.
 

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -73,7 +73,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dependencies.deep_causality_num_complex]
 path = "../deep_causality_num_complex"

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -51,7 +51,7 @@ optional = true
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_core]

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -32,7 +32,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 

--- a/deep_causality_rand/README.md
+++ b/deep_causality_rand/README.md
@@ -9,7 +9,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [crates-badge]: https://img.shields.io/badge/Crates.io-Latest-blue
 
@@ -23,7 +23,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 ## Why?
 

--- a/deep_causality_sparse/Cargo.toml
+++ b/deep_causality_sparse/Cargo.toml
@@ -43,7 +43,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_haft]

--- a/deep_causality_sparse/README.md
+++ b/deep_causality_sparse/README.md
@@ -4,11 +4,11 @@
 [![Docs.rs](https://docs.rs/deep_causality_sparse/badge.svg)](https://docs.rs/deep_causality_sparse)
 
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 
 # CausalSparse - Efficient Sparse Matrix Operations

--- a/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_tensor/Cargo.toml
@@ -48,7 +48,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_num_complex]

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -62,7 +62,7 @@ default-features = false
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 default-features = false
 
 [dependencies.deep_causality_par]

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.4"
 
 [dependencies.deep_causality_algebra]
 path = "../deep_causality_algebra"
-version = "0.2"
+version = "0.3"
 
 [dev-dependencies]
 rusty-fork = "0.3"

--- a/deep_causality_uncertain/README.md
+++ b/deep_causality_uncertain/README.md
@@ -4,7 +4,7 @@
 [![Docs.rs](https://docs.rs/deep_causality_uncertain/badge.svg)](https://docs.rs/deep_causality_uncertain)
 
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg
 
@@ -12,7 +12,7 @@
 
 [audit-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/audit.yml/badge.svg
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 A Rust library for first-order uncertain data types, enabling robust computation and decision-making under uncertainty.
 

--- a/ultragraph/README.md
+++ b/ultragraph/README.md
@@ -3,7 +3,7 @@
 [![Crates.io][crates-badge]][crates-url]
 [![Docs.rs][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
-![Tests][test-url]
+ 
 
 [ossf-badge]: https://bestpractices.coreinfrastructure.org/projects/7568/badge
 
@@ -19,7 +19,7 @@
 
 [mit-url]: https://github.com/deepcausality-rs/deep_causality/blob/main/LICENSE
 
-[test-url]: https://github.com/deepcausality-rs/deep_causality/actions/workflows/run_tests.yml/badge.svg
+ 
 
 ## Goal
 


### PR DESCRIPTION


## Describe your changes

fix(release): bump algebra to 0.3.0 so the new traits are actually published


## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the new algebra traits by releasing `deep_causality_algebra` 0.3.0 and updating all dependents. This fixes crates.io publish failures where verification resolved `deep_causality_algebra` 0.2.0, causing unresolved imports for `Annihilating`, `EuclideanDomain`, and `Invertible`. Also bumps `deep_causality_num` to 0.4.2 to include integer implementations and align with `algebra` 0.3.

- Old behavior: local builds passed via path deps; crates.io verification failed against `algebra` 0.2.0.
- New behavior: all crates depend on published `algebra` 0.3.0 and `num` 0.4.2; publishing (e.g., `deep_causality_num_rational`) succeeds.
- Side effects: breaking under 0.x—`AddGroup` now requires `Neg`, `Ring` requires `Annihilating`, and law markers are no longer blanket-provided via `Num`. README badges for stale test SVGs removed only.

**Migration notes**
- Set `deep_causality_algebra = "0.3"` and `deep_causality_num = "0.4.2"` in dependents.
- Update implementations to meet new trait bounds and stop relying on blanket law markers from `Num`.

<sup>Written for commit 00ff0cb07beb5bbedce42cd08d82e141228964de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

