### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.1...deep_causality-v0.15.2) - 2026-08-25
+
+### Added
+
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(clippy)* silence chunks_exact_to_as_chunks and useless_format
+
+### Other
+
+- *(deep_causality)* Updated SBOM
+- Updated version requirmentes
+- Removed broken Test URL from README
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.15.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.0...deep_causality-v0.15.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -554,11 +554,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_cfd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -590,14 +590,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.16"
+version = "0.10.17"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "deep_causality_algebra",
 ]
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_metric"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "deep_causality_multivector"
@@ -719,11 +719,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2200,7 +2200,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.15.1"
+version = "0.15.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_algebra/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.3.0...deep_causality_algebra-v0.4.1) - 2026-08-25
+
+### Added
+
+- *(linear)* implement until the suite is green
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(algebra)* give morphisms a domain and a codomain
+- *(algebra)* [**breaking**] add IntegralDomain, connect Semiring, remove AssociativeRing
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- *(deep_causality_algebra)* Updated SBOM
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_algebra/Cargo.toml
@@ -32,7 +32,7 @@ no-std = ["deep_causality_num/no-std"]
 
 [dependencies.deep_causality_num]
 path = "../deep_causality_num"
-version = "0.4.2"
+version = "0.4.3"
 default-features = false
 
 [lints]

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.2...deep_causality_algorithms-v0.4.3) - 2026-08-25
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_algorithms)* Updated SBOM
+- Updated version requirmentes
+
 ## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.1...deep_causality_algorithms-v0.4.2) - 2026-08-12
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.9...deep_causality_ast-v0.1.10) - 2026-08-25
+
+### Added
+
+- *(deep_causality_ast)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_ast)* Updated SBOM
+- lints and minor code fixes
+
 ## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.3...deep_causality_calculus-v0.1.4) - 2026-08-25
+
+### Added
+
+- *(deep_causality_calculus)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_calculus)* Updated SBOM.
+- Updated version requirmentes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_cfd/CHANGELOG.md
+++ b/deep_causality_cfd/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.0...deep_causality_cfd-v0.1.1) - 2026-08-25
+
+### Added
+
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_cfd)* fixes std feat bug.
+- *(clippy)* silence chunks_exact_to_as_chunks and useless_format
+
+### Other
+
+- *(deep_causality_cfd)* Updated SBOM.
+- Updated version requirmentes
+- *(cfd)* run slow verification harnesses monthly, not nightly
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_cfd-v0.1.0) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_cfd"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.1...deep_causality_core-v0.11.2) - 2026-08-25
+
+### Added
+
+- *(deep_causality_core)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_core)* Added IntType type alias
+
+### Other
+
+- *(deep_causality_core)* Updated SBOM.
+- lints and minor code fixes
+
 ## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.17](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.16...deep_causality_data_structures-v0.10.17) - 2026-08-25
+
+### Added
+
+- *(deep_causality_data_structures)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_data_structures)* Updated SBOM.
+- lints and minor code fixes
+
 ## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
 
 ### Added

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.16"
+version = "0.10.17"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.1...deep_causality_discovery-v0.5.2) - 2026-08-25
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_discovery)* Updated SBOM.
+- Updated version requirmentes
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.10...deep_causality_ethos-v0.2.11) - 2026-08-25
+
+### Added
+
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(website)* rework the CFD landing page and re-sync every published number to its artifact
+
+### Other
+
+- *(deep_causality_ethos)* Updated SBOM.
+- Removed broken Test URL from README
+- Merge remote-tracking branch 'origin/main'
+
 ## [0.2.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.9...deep_causality_ethos-v0.2.10) - 2026-08-12
 
 ### Added

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.10"
+version = "0.2.11"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_fft/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.2...deep_causality_fft-v0.1.3) - 2026-08-25
+
+### Added
+
+- *(deep_causality_fft)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_fft)* Updated SBOM.
+- Updated version requirmentes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_fft/Cargo.toml
+++ b/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.3...deep_causality_file-v0.1.4) - 2026-08-25
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_file)* Updated SBOM.
+- Updated version requirmentes
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.2...deep_causality_haft-v0.4.3) - 2026-08-25
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_haft)* Updated SBOM.
+- Updated version requirmentes
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_haft/Cargo.toml
+++ b/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_linear/CHANGELOG.md
+++ b/deep_causality_linear/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_linear-v0.1.0) - 2026-08-25
+
+### Added
+
+- *(topology)* retire the duplicated linear algebra
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(linear)* implement until the suite is green
+- *(linear)* implement until the suite is green
+- *(linear)* declare the deep_causality_linear API, implement nothing
+
+### Other
+
+- *(linear)* close the mutation survivors in integer, elimination, solve, cholesky and QR
+- *(deep_causality_linear)* Improved test coverage.
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(ci)* Fixed various lints and minor issues.
+- *(deep_causality_linear)* Added SBOM.
+- *(deep_causality_linear)* remove tautological, compile-only and weak assertions
+- *(linear)* verify the suite against defects, and against an oracle
+- *(linear)* write the suite before the implementation

--- a/deep_causality_metric/CHANGELOG.md
+++ b/deep_causality_metric/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.4...deep_causality_metric-v0.2.5) - 2026-08-25
+
+### Added
+
+- *(deep_causality_metric)* Configured no-std flag.
+
+### Other
+
+- *(deep_causality_metric)* Updated SBOM.
+
 ## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.3...deep_causality_metric-v0.2.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_metric/Cargo.toml
+++ b/deep_causality_metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_metric"
-version = "0.2.4"
+version = "0.2.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.4...deep_causality_multivector-v0.6.0) - 2026-08-25
+
+### Added
+
+- *(topology)* retire the duplicated linear algebra
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(deep_causality_multivector)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(deep_causality_multivector)* Updated SBOM.
+- Updated version requirmentes
+- lints and minor code fixes
+
 ## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.2...deep_causality_num-v0.4.3) - 2026-08-25
+
+### Added
+
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+
+### Other
+
+- *(deep_causality_num)* Updated SBOM.
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.4...deep_causality_num_complex-v0.1.6) - 2026-08-25
+
+### Added
+
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(algebra)* give morphisms a domain and a codomain
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+- *(deep_causality_num_complex)* Added default implementation for Invertible trait
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- *(deep_causality_num_complex)* Updated SBOM.
+- Updated version requirmentes
+- bring the algebra reference current and correct the CI claim
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.4...deep_causality_num_dual-v0.1.5) - 2026-08-25
+
+### Added
+
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- *(deep_causality_num_dual)* Updated SBOM.
+- Updated version requirmentes
+- bring the algebra reference current and correct the CI claim
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14
 
 ### Other

--- a/deep_causality_num_rational/CHANGELOG.md
+++ b/deep_causality_num_rational/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.0...deep_causality_num_rational-v0.1.2) - 2026-08-25
+
+### Added
+
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(algebra)* give morphisms a domain and a codomain
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- *(deep_causality_num_rational)* Updated SBOM.
+- Updated version requirmentes
+- *(sbom)* register deep_causality_num_rational

--- a/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.2...deep_causality_par-v0.1.3) - 2026-08-25
+
+### Added
+
+- *(deep_causality_par)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_par)* Updated SBOM.
+- *(deep_causality)* Updated non-std README.
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.2"
+version = "0.1.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.1...deep_causality_physics-v0.8.2) - 2026-08-25
+
+### Added
+
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(deep_causality_physics)* Updated SBOM.
+- Updated version requirmentes
+
 ## [0.8.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.0...deep_causality_physics-v0.8.1) - 2026-08-12
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.8.1"
+version = "0.8.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -53,7 +53,7 @@ version = "0.1"
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 
 [dependencies.deep_causality_haft]
 path = "../deep_causality_haft"

--- a/deep_causality_quantum/CHANGELOG.md
+++ b/deep_causality_quantum/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_quantum-v0.1.1) - 2026-08-25
+
+### Added
+
+- *(deep_causality_quantum)* Set quantum crate to publishable.
+- *(topology)* retire the duplicated linear algebra
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(deep_causality_quantum)* Configured no-std flag.
+- *(bazel)* build and run the library-crate examples under Bazel
+- *(deep_causality_physics)* add propulsion kernel family (SRP Stage 1)
+- feat(deep_causality_quantum); implemeted quantum crate.
+- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)
+- *(deep_causality_quantum)* new crate — quantum-information kernels move out of physics (Phase 1)
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_quantum)* Removed dead module
+- *(deep_causality_quantum)* Multiple fixes
+- *(deep_causality)* code formatting
+- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
+- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
+- *(deep_causality_quantum)* code formatting
+- *(deep_causality_quantum)* Multiple fixes
+- *(deep_causality_quantum)* Fixed LEAN prooves and moved them into a dedicate folder.
+- *(deep_causality_quantum)* Code formatting
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(ci)* Fixed various lints and minor issues.
+- *(deep_causality_quantum)* Updated SBOM.
+- Updated version requirmentes
+- *(deep_causality_num)* document all five number systems and where each lives
+- lints and minor code fixes
+- lints and minor code fixes
+- Added publications to quantum crate
+- *(deep_causality_quantum)* fix code formatting.
+- *(quantum)* fix rustdoc private-intra-doc-link warnings in Haruna gates
+- release
+- *(deep_causality_quantum)* Updated README
+- *(deep_causality_quantum)* code refactored to add correct error handling to haruna gates
+- *(deep_causality_quantum)* Improved code test coverage.
+- *(deep_causality_quantum)* internal source re organization.

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -53,7 +53,7 @@ default-features = false
 
 [dependencies.deep_causality_core]
 path = "../deep_causality_core"
-version = "0.11.1"
+version = "0.11.2"
 default-features = false
 
 [dependencies.deep_causality_haft]

--- a/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.1...deep_causality_rand-v0.2.2) - 2026-08-25
+
+### Added
+
+- *(deep_causality_rand)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_rand)* Updated SBOM.
+- Updated version requirmentes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_rand/Cargo.toml
+++ b/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_sparse/CHANGELOG.md
+++ b/deep_causality_sparse/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.2...deep_causality_sparse-v0.2.4) - 2026-08-25
+
+### Added
+
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+- *(deep_causality_sparse)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Updated version requirmentes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.1...deep_causality_sparse-v0.2.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.1...deep_causality_tensor-v0.5.2) - 2026-08-25
+
+### Added
+
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
+- *(deep_causality_tensor)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
+- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(deep_causality_tensor)* Updated SBOM.
+- Updated version requirmentes
+- More fixes and lints.
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.1...deep_causality_topology-v0.7.2) - 2026-08-25
+
+### Added
+
+- *(topology)* retire the duplicated linear algebra
+- *(linear)* migrate the workspace onto deep_causality_linear
+- *(algebra)* give the tower a finite field, and a guard for admitting it
+- *(topology)* add the cup product, generic over ChainComplex
+
+### Fixed
+
+- *(topology)* dimension-matched cut-face tolerance, and an analytic charge test
+- *(deep_causality_topology)* Fixed a number of incorrect tests.
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+- *(topology)* address review findings on the cup product changeset
+
+### Other
+
+- General QA: Bug fixes and code improvements.
+- Improved test coverage
+- *(ci)* Fixed various lints and minor issues.
+- *(deep_causality_topology)* Updated SBOM.
+- Updated version requirmentes
+- lints and minor code fixes
+- *(topology)* document the vertex and corner ordering contracts
+- *(deep_causality_topology)* added test suite for cup product
+
 ## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_topology/Cargo.toml
+++ b/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.7.1"
+version = "0.7.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.0...deep_causality_uncertain-v0.5.1) - 2026-08-25
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(deep_causality_uncertain)* Updated SBOM.
+- Updated version requirmentes
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.5.0"
+version = "0.5.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.3...ultragraph-v0.9.4) - 2026-08-25
+
+### Added
+
+- *(ultragraph)* Configured no-std flag.
+
+### Fixed
+
+- *(release)* bump algebra to 0.3.0 so the new traits are actually published
+
+### Other
+
+- *(ultragraph)* Updated SBOM.
+- lints and minor code fixes
+- lints and minor code fixes
+- lints and minor code fixes
+- lints and minor code fixes
+
 ## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
 
 ### Fixed

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.3"
+version = "0.9.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.4.2 -> 0.4.3
* `deep_causality_algebra`: 0.3.0 -> 0.4.1
* `deep_causality_ast`: 0.1.9 -> 0.1.10 (✓ API compatible changes)
* `deep_causality_haft`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `deep_causality_core`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.16 -> 0.10.17 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `deep_causality_uncertain`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `ultragraph`: 0.9.3 -> 0.9.4 (✓ API compatible changes)
* `deep_causality`: 0.15.1 -> 0.15.2 (✓ API compatible changes)
* `deep_causality_par`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_linear`: 0.1.0
* `deep_causality_num_complex`: 0.1.4 -> 0.1.6
* `deep_causality_num_dual`: 0.1.4 -> 0.1.5
* `deep_causality_tensor`: 0.5.1 -> 0.5.2
* `deep_causality_fft`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `deep_causality_metric`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `deep_causality_multivector`: 0.5.4 -> 0.6.0
* `deep_causality_topology`: 0.7.1 -> 0.7.2 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `deep_causality_num_rational`: 0.1.0 -> 0.1.2
* `deep_causality_calculus`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_file`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_physics`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `deep_causality_cfd`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `deep_causality_discovery`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `deep_causality_quantum`: 0.1.1
* `deep_causality_sparse`: 0.2.2 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.2...deep_causality_num-v0.4.3) - 2026-08-25

### Added

- *(algebra)* give the tower a finite field, and a guard for admitting it

### Other

- *(deep_causality_num)* Updated SBOM.
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.3.0...deep_causality_algebra-v0.4.1) - 2026-08-25

### Added

- *(linear)* implement until the suite is green
- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(algebra)* give morphisms a domain and a codomain
- *(algebra)* [**breaking**] add IntegralDomain, connect Semiring, remove AssociativeRing
- *(algebra)* [**breaking**] state each algebraic law about the operation it governs

### Other

- General QA: Bug fixes and code improvements.
- *(deep_causality_algebra)* Updated SBOM
</blockquote>

## `deep_causality_ast`

<blockquote>

## [0.1.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.9...deep_causality_ast-v0.1.10) - 2026-08-25

### Added

- *(deep_causality_ast)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_ast)* Updated SBOM
- lints and minor code fixes
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.2...deep_causality_haft-v0.4.3) - 2026-08-25

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_haft)* Updated SBOM.
- Updated version requirmentes
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.11.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.1...deep_causality_core-v0.11.2) - 2026-08-25

### Added

- *(deep_causality_core)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_core)* Added IntType type alias

### Other

- *(deep_causality_core)* Updated SBOM.
- lints and minor code fixes
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.17](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.16...deep_causality_data_structures-v0.10.17) - 2026-08-25

### Added

- *(deep_causality_data_structures)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_data_structures)* Updated SBOM.
- lints and minor code fixes
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.1...deep_causality_rand-v0.2.2) - 2026-08-25

### Added

- *(deep_causality_rand)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_rand)* Updated SBOM.
- Updated version requirmentes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.0...deep_causality_uncertain-v0.5.1) - 2026-08-25

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_uncertain)* Updated SBOM.
- Updated version requirmentes
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.4](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.3...ultragraph-v0.9.4) - 2026-08-25

### Added

- *(ultragraph)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(ultragraph)* Updated SBOM.
- lints and minor code fixes
- lints and minor code fixes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality`

<blockquote>

## [0.15.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.1...deep_causality-v0.15.2) - 2026-08-25

### Added

- *(linear)* migrate the workspace onto deep_causality_linear
- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(clippy)* silence chunks_exact_to_as_chunks and useless_format

### Other

- *(deep_causality)* Updated SBOM
- Updated version requirmentes
- Removed broken Test URL from README
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.2...deep_causality_par-v0.1.3) - 2026-08-25

### Added

- *(deep_causality_par)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_par)* Updated SBOM.
- *(deep_causality)* Updated non-std README.
</blockquote>

## `deep_causality_linear`

<blockquote>

## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_linear-v0.1.0) - 2026-08-25

### Added

- *(topology)* retire the duplicated linear algebra
- *(linear)* migrate the workspace onto deep_causality_linear
- *(linear)* implement until the suite is green
- *(linear)* implement until the suite is green
- *(linear)* declare the deep_causality_linear API, implement nothing

### Other

- *(linear)* close the mutation survivors in integer, elimination, solve, cholesky and QR
- *(deep_causality_linear)* Improved test coverage.
- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(ci)* Fixed various lints and minor issues.
- *(deep_causality_linear)* Added SBOM.
- *(deep_causality_linear)* remove tautological, compile-only and weak assertions
- *(linear)* verify the suite against defects, and against an oracle
- *(linear)* write the suite before the implementation
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.1.6](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.4...deep_causality_num_complex-v0.1.6) - 2026-08-25

### Added

- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(algebra)* give morphisms a domain and a codomain
- *(algebra)* [**breaking**] state each algebraic law about the operation it governs

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
- *(deep_causality_num_complex)* Added default implementation for Invertible trait

### Other

- General QA: Bug fixes and code improvements.
- *(deep_causality_num_complex)* Updated SBOM.
- Updated version requirmentes
- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.4...deep_causality_num_dual-v0.1.5) - 2026-08-25

### Added

- *(algebra)* [**breaking**] state each algebraic law about the operation it governs

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference

### Other

- General QA: Bug fixes and code improvements.
- *(deep_causality_num_dual)* Updated SBOM.
- Updated version requirmentes
- bring the algebra reference current and correct the CI claim
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.1...deep_causality_tensor-v0.5.2) - 2026-08-25

### Added

- *(linear)* migrate the workspace onto deep_causality_linear
- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
- *(deep_causality_tensor)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_algebra)* [**breaking**] stop handing out algebraic laws by inference
- *(deep_causality_algebra)* [**breaking**] AddGroup requires Neg, not merely Sub

### Other

- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(deep_causality_tensor)* Updated SBOM.
- Updated version requirmentes
- More fixes and lints.
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_fft`

<blockquote>

## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.2...deep_causality_fft-v0.1.3) - 2026-08-25

### Added

- *(deep_causality_fft)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_fft)* Updated SBOM.
- Updated version requirmentes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_metric`

<blockquote>

## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.4...deep_causality_metric-v0.2.5) - 2026-08-25

### Added

- *(deep_causality_metric)* Configured no-std flag.

### Other

- *(deep_causality_metric)* Updated SBOM.
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.4...deep_causality_multivector-v0.6.0) - 2026-08-25

### Added

- *(topology)* retire the duplicated linear algebra
- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(deep_causality_multivector)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(deep_causality_multivector)* Updated SBOM.
- Updated version requirmentes
- lints and minor code fixes
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.7.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.1...deep_causality_topology-v0.7.2) - 2026-08-25

### Added

- *(topology)* retire the duplicated linear algebra
- *(linear)* migrate the workspace onto deep_causality_linear
- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(topology)* add the cup product, generic over ChainComplex

### Fixed

- *(topology)* dimension-matched cut-face tolerance, and an analytic charge test
- *(deep_causality_topology)* Fixed a number of incorrect tests.
- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(topology)* address review findings on the cup product changeset

### Other

- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(ci)* Fixed various lints and minor issues.
- *(deep_causality_topology)* Updated SBOM.
- Updated version requirmentes
- lints and minor code fixes
- *(topology)* document the vertex and corner ordering contracts
- *(deep_causality_topology)* added test suite for cup product
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.2...deep_causality_algorithms-v0.4.3) - 2026-08-25

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_algorithms)* Updated SBOM
- Updated version requirmentes
</blockquote>

## `deep_causality_num_rational`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.0...deep_causality_num_rational-v0.1.2) - 2026-08-25

### Added

- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(algebra)* give morphisms a domain and a codomain
- *(algebra)* [**breaking**] state each algebraic law about the operation it governs

### Other

- General QA: Bug fixes and code improvements.
- *(deep_causality_num_rational)* Updated SBOM.
- Updated version requirmentes
- *(sbom)* register deep_causality_num_rational
</blockquote>

## `deep_causality_calculus`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.3...deep_causality_calculus-v0.1.4) - 2026-08-25

### Added

- *(deep_causality_calculus)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_calculus)* Updated SBOM.
- Updated version requirmentes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.3...deep_causality_file-v0.1.4) - 2026-08-25

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_file)* Updated SBOM.
- Updated version requirmentes
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.8.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.1...deep_causality_physics-v0.8.2) - 2026-08-25

### Added

- *(linear)* migrate the workspace onto deep_causality_linear
- *(algebra)* give the tower a finite field, and a guard for admitting it

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(deep_causality_physics)* Updated SBOM.
- Updated version requirmentes
</blockquote>

## `deep_causality_cfd`

<blockquote>

## [0.1.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.0...deep_causality_cfd-v0.1.1) - 2026-08-25

### Added

- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_cfd)* fixes std feat bug.
- *(clippy)* silence chunks_exact_to_as_chunks and useless_format

### Other

- *(deep_causality_cfd)* Updated SBOM.
- Updated version requirmentes
- *(cfd)* run slow verification harnesses monthly, not nightly
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.1...deep_causality_discovery-v0.5.2) - 2026-08-25

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- *(deep_causality_discovery)* Updated SBOM.
- Updated version requirmentes
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.11](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.10...deep_causality_ethos-v0.2.11) - 2026-08-25

### Added

- *(linear)* migrate the workspace onto deep_causality_linear
- *(website)* rework the CFD landing page and re-sync every published number to its artifact

### Other

- *(deep_causality_ethos)* Updated SBOM.
- Removed broken Test URL from README
- Merge remote-tracking branch 'origin/main'
</blockquote>

## `deep_causality_quantum`

<blockquote>

## [0.1.1](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_quantum-v0.1.1) - 2026-08-25

### Added

- *(deep_causality_quantum)* Set quantum crate to publishable.
- *(topology)* retire the duplicated linear algebra
- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(deep_causality_quantum)* Configured no-std flag.
- *(bazel)* build and run the library-crate examples under Bazel
- *(deep_causality_physics)* add propulsion kernel family (SRP Stage 1)
- feat(deep_causality_quantum); implemeted quantum crate.
- *(deep_causality_quantum)* the operator/channel layer on CausalTensor<Complex<R>> (Phase 2)
- *(deep_causality_quantum)* new crate — quantum-information kernels move out of physics (Phase 1)

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published
- *(deep_causality_quantum)* Removed dead module
- *(deep_causality_quantum)* Multiple fixes
- *(deep_causality)* code formatting
- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
- *(deep_causality_quantum)* Added NaN/overflow/bounds check to Haruna gates
- *(deep_causality_quantum)* code formatting
- *(deep_causality_quantum)* Multiple fixes
- *(deep_causality_quantum)* Fixed LEAN prooves and moved them into a dedicate folder.
- *(deep_causality_quantum)* Code formatting

### Other

- General QA: Bug fixes and code improvements.
- Improved test coverage
- *(ci)* Fixed various lints and minor issues.
- *(deep_causality_quantum)* Updated SBOM.
- Updated version requirmentes
- *(deep_causality_num)* document all five number systems and where each lives
- lints and minor code fixes
- lints and minor code fixes
- Added publications to quantum crate
- *(deep_causality_quantum)* fix code formatting.
- *(quantum)* fix rustdoc private-intra-doc-link warnings in Haruna gates
- release
- *(deep_causality_quantum)* Updated README
- *(deep_causality_quantum)* code refactored to add correct error handling to haruna gates
- *(deep_causality_quantum)* Improved code test coverage.
- *(deep_causality_quantum)* internal source re organization.
</blockquote>

## `deep_causality_sparse`

<blockquote>

## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_sparse-v0.2.2...deep_causality_sparse-v0.2.4) - 2026-08-25

### Added

- *(linear)* migrate the workspace onto deep_causality_linear
- *(algebra)* give the tower a finite field, and a guard for admitting it
- *(algebra)* [**breaking**] state each algebraic law about the operation it governs
- *(deep_causality_sparse)* Configured no-std flag.

### Fixed

- *(release)* bump algebra to 0.3.0 so the new traits are actually published

### Other

- General QA: Bug fixes and code improvements.
- Updated version requirmentes
- lints and minor code fixes
- lints and minor code fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).