### PR TITLE
Fixing CI issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "deep_causality_calculus"

--- a/deep_causality_ast/Cargo.toml
+++ b/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.9"
+version = "0.1.10"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_quantum/README.md
+++ b/deep_causality_quantum/README.md
@@ -158,17 +158,16 @@ overflow and non-convergence as typed errors rather than a silent identity.
 
 ## Usage
 
-The crate is unpublished; add it as a git dependency:
 
 ```toml
 [dependencies]
-deep_causality_quantum = { git = "https://github.com/deepcausality-rs/deep_causality.git", branch = "main" }
+deep_causality_quantum = { version = "0.1.1" }
 ```
 
 Enable the emergent QPU seam with the `qpu` feature:
 
 ```toml
-deep_causality_quantum = { git = "…", branch = "main", features = ["qpu"] }
+deep_causality_quantum = { version = "0.1.1", features = ["qpu"] }
 ```
 
 ## Examples

--- a/website/quantum/wrangler.toml
+++ b/website/quantum/wrangler.toml
@@ -10,7 +10,7 @@
 # stays unchanged. Note that the sibling sites do not share one spelling
 # (`deepcausality-prod`, `deepcausality-docs`, `deep-causality-cfd-prod`), so
 # match the dashboard rather than the pattern.
-name = "deep-causality-quantum-prod"
+name = "quantum"
 # Same account as the other three sites; pinned explicitly because this
 # credential is linked to two Cloudflare accounts.
 account_id = "222139bff18ce0390d15f59a78d3d6b2"


### PR DESCRIPTION
## Describe your changes

fix(ci): raised version number for ast crate 
x(ci): Fixed auto-publishes of new quantum project site

## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI publishes and restores quantum site auto-deploys. Previously the pipeline stalled on an unpublished `deep_causality_ast` 0.1.9 and Cloudflare deploys failed due to a mismatched project name; now `deep_causality_ast` is 0.1.10 and the project name is `quantum`.

**Bug Fixes**
- Set `website/quantum/wrangler.toml` project `name` to `quantum` so Cloudflare auto-publishes succeed.

**Dependencies**
- Bumped `deep_causality_ast` to `0.1.10` to trigger publish and unblock downstream crates.
- Updated `deep_causality_quantum` README to use the published crate `0.1.1` instead of a git dependency.

<sup>Written for commit aea04122a7783e8addb5de3db4a20a931dc37140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

