### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-01
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(build)* [**breaking**] move build/scripts to the repository root
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.15.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.0...deep_causality-v0.15.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -533,14 +533,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algebra"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "deep_causality_num",
 ]
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -558,7 +558,7 @@ version = "0.1.11"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -590,14 +590,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.3.0"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_homology"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "deep_causality_linear",
  "deep_causality_num",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_linear"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -682,7 +682,7 @@ version = "0.2.6"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -696,14 +696,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_dual"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_rational"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -729,11 +729,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_tensor"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2205,7 +2205,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,32 +41,32 @@ license = "MIT"
 # `features` or `optional` where they differ.
 
 # Internal crates
-deep_causality = { path = "deep_causality", version = "0.15" }
+deep_causality = { path = "deep_causality", version = "0.16" }
 deep_causality_algebra = { path = "deep_causality_unified_math/deep_causality_algebra", version = "0.4", default-features = false }
-deep_causality_algorithms = { path = "deep_causality_algorithms", version = "0.4" }
+deep_causality_algorithms = { path = "deep_causality_algorithms", version = "0.5" }
 deep_causality_ast = { path = "deep_causality_unified_math/deep_causality_ast", version = "0.1", default-features = false }
 deep_causality_calculus = { path = "deep_causality_unified_math/deep_causality_calculus", version = "0.1", default-features = false }
-deep_causality_cfd = { path = "deep_causality_cfd", version = "0.1" }
-deep_causality_core = { path = "deep_causality_core", version = "0.11", default-features = false }
+deep_causality_cfd = { path = "deep_causality_cfd", version = "0.2" }
+deep_causality_core = { path = "deep_causality_core", version = "0.12", default-features = false }
 deep_causality_data_structures = { path = "deep_causality_data_structures", version = "0.10" }
-deep_causality_discovery = { path = "deep_causality_discovery", version = "0.5" }
-deep_causality_ethos = { path = "deep_causality_ethos", version = "0.2" }
+deep_causality_discovery = { path = "deep_causality_discovery", version = "0.6" }
+deep_causality_ethos = { path = "deep_causality_ethos", version = "0.3" }
 deep_causality_fft = { path = "deep_causality_unified_math/deep_causality_fft", version = "0.1", default-features = false }
 deep_causality_file = { path = "deep_causality_file", version = "0.1" }
 deep_causality_haft = { path = "deep_causality_unified_math/deep_causality_haft", version = "0.5", default-features = false }
-deep_causality_homology = { path = "deep_causality_unified_math/deep_causality_homology", version = "0.1", default-features = false }
-deep_causality_linear = { path = "deep_causality_unified_math/deep_causality_linear", version = "0.1", default-features = false }
+deep_causality_homology = { path = "deep_causality_unified_math/deep_causality_homology", version = "0.2", default-features = false }
+deep_causality_linear = { path = "deep_causality_unified_math/deep_causality_linear", version = "0.2", default-features = false }
 deep_causality_metric = { path = "deep_causality_unified_math/deep_causality_metric", version = "0.2", default-features = false }
-deep_causality_multivector = { path = "deep_causality_unified_math/deep_causality_multivector", version = "0.6", default-features = false }
+deep_causality_multivector = { path = "deep_causality_unified_math/deep_causality_multivector", version = "0.7", default-features = false }
 deep_causality_num = { path = "deep_causality_unified_math/deep_causality_num", version = "0.4", default-features = false }
-deep_causality_num_complex = { path = "deep_causality_unified_math/deep_causality_num_complex", version = "0.1", default-features = false }
-deep_causality_num_dual = { path = "deep_causality_unified_math/deep_causality_num_dual", version = "0.1", default-features = false }
+deep_causality_num_complex = { path = "deep_causality_unified_math/deep_causality_num_complex", version = "0.2", default-features = false }
+deep_causality_num_dual = { path = "deep_causality_unified_math/deep_causality_num_dual", version = "0.2", default-features = false }
 deep_causality_num_rational = { path = "deep_causality_unified_math/deep_causality_num_rational", version = "0.1", default-features = false }
 deep_causality_par = { path = "deep_causality_par", version = "0.1", default-features = false }
-deep_causality_physics = { path = "deep_causality_physics", version = "0.8", default-features = false }
+deep_causality_physics = { path = "deep_causality_physics", version = "0.9", default-features = false }
 deep_causality_quantum = { path = "deep_causality_quantum", version = "0.2" }
 deep_causality_rand = { path = "deep_causality_unified_math/deep_causality_rand", version = "0.2" }
-deep_causality_tensor = { path = "deep_causality_unified_math/deep_causality_tensor", version = "0.5", default-features = false }
+deep_causality_tensor = { path = "deep_causality_unified_math/deep_causality_tensor", version = "0.6", default-features = false }
 deep_causality_topology = { path = "deep_causality_unified_math/deep_causality_topology", version = "0.9" }
 deep_causality_uncertain = { path = "deep_causality_unified_math/deep_causality_uncertain", version = "0.5" }
 ultragraph = { path = "ultragraph", version = "0.9" }

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.5.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.1...deep_causality_algorithms-v0.4.2) - 2026-08-12
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.3"
+version = "0.5.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_cfd/CHANGELOG.md
+++ b/deep_causality_cfd/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology
+
+### Fixed
+
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_cfd-v0.1.0) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-01
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-01
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
 
 ### Added

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.3.0) - 2026-09-01
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(build)* [**breaking**] move build/scripts to the repository root
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.2.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.9...deep_causality_ethos-v0.2.10) - 2026-08-12
 
 ### Added

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.3.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-01
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_file/Cargo.toml
+++ b/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-01
+
+### Fixed
+
+- *(deep_causality_par)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_par/Cargo.toml
+++ b/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.9.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated inbound links to archived notes
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.8.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.0...deep_causality_physics-v0.8.1) - 2026-08-12
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.8.2"
+version = "0.9.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_quantum/CHANGELOG.md
+++ b/deep_causality_quantum/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.1.2...deep_causality_quantum-v0.2.0) - 2026-09-01
+
+### Added
+
+- *(deep_causality_quantum)* decide class invariance over the code space
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+- *(deep_causality_quantum)* [**breaking**] retype the Haruna gate layer onto Gf2Chain and close four QCL gaps
+- *(quantum,num,topology)* close the six low-effort QCL gaps
+
+### Fixed
+
+- *(CI)* fixed broken lean theorem.
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/

--- a/deep_causality_unified_math/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_algebra/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.4.2...deep_causality_algebra-v0.4.3) - 2026-09-01
+
+### Fixed
+
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algebra"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.4...deep_causality_calculus-v0.1.5) - 2026-09-01
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_fft/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.3...deep_causality_fft-v0.1.4) - 2026-09-01
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_fft/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.3...deep_causality_haft-v0.5.0) - 2026-09-01
+
+### Added
+
+- *(deep_causality_haft)* formalize the lax monoidal laws in Lean
+- *(haft)* add the lax monoidal structure on endofunctors
+- *(unified_math)* HKT witnesses for the Cayley-Dickson types
+
+### Fixed
+
+- *(deep_causality_haft)* bumped up version;
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- Applied lints and fixes.
+- *(bazel)* [**breaking**] rename build/ to bazel/
+- *(examples)* [**breaking**] move the haft examples into mathematics_examples
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- *(openspec)* Archived specs and notes on lax monoidal applicative
+- *(haft)* record why VecWitness has no Traversable, with the measurement
+- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- *(deep_causality_tensor)* delete the dead strict tensor witness
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_homology/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_homology/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.0...deep_causality_homology-v0.2.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes

--- a/deep_causality_unified_math/deep_causality_homology/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_homology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_homology"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_linear/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_linear/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_linear-v0.1.2...deep_causality_linear-v0.2.0) - 2026-09-01
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes

--- a/deep_causality_unified_math/deep_causality_linear/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_linear"
-version = "0.1.2"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.6.1...deep_causality_multivector-v0.7.0) - 2026-09-01
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
+- *(deep_causality_multivector)* [**breaking**] close an unsound HKT witness and remove the repo's last unsafe exemption
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.6.1"
+version = "0.7.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.4...deep_causality_num-v0.4.5) - 2026-09-01
+
+### Fixed
+
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.4.4"
+version = "0.4.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.7...deep_causality_num_complex-v0.2.0) - 2026-09-01
+
+### Added
+
+- *(deep_causality_num_complex)* close E1 — monoidal applicative on the Cayley-Dickson types
+- *(unified_math)* HKT witnesses for the Cayley-Dickson types
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- Applied lints and fixes.
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- *(openspec)* Archived specs and notes on lax monoidal applicative
+- *(haft)* record why VecWitness has no Traversable, with the measurement
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.7"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.6...deep_causality_num_dual-v0.2.0) - 2026-09-01
+
+### Added
+
+- *(num_dual)* close E2 — drop the Dual struct bound, add DualWitness
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- Applied lints and fixes.
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- *(openspec)* Archived specs and notes on lax monoidal applicative
+- *(haft)* record why VecWitness has no Traversable, with the measurement
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14
 
 ### Other

--- a/deep_causality_unified_math/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_dual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_dual"
-version = "0.1.6"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_rational/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_rational/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.3...deep_causality_num_rational-v0.1.4) - 2026-09-01
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/

--- a/deep_causality_unified_math/deep_causality_num_rational/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_rational/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_rational"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.2...deep_causality_rand-v0.2.3) - 2026-09-01
+
+### Fixed
+
+- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_rand/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.2"
+version = "0.2.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.3...deep_causality_tensor-v0.6.0) - 2026-09-01
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- Applied lints and fixes.
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
+- *(deep_causality_tensor)* delete the dead strict tensor witness
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_tensor/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_tensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_tensor"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_unified_math/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.8.0...deep_causality_topology-v0.9.0) - 2026-09-01
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
+- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
+- *(deep_causality_multivector)* [**breaking**] close an unsound HKT witness and remove the repo's last unsafe exemption
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
+- *(ci,scripts)* derive crate lists from the workspace manifest
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated paths in docs of relocated crates across the repo
+- *(openspec)* Updated inbound links to archived notes
+- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- *(deep_causality_tensor)* delete the dead strict tensor witness
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.1...deep_causality_uncertain-v0.5.2) - 2026-09-01
+
+### Other
+
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.5.1"
+version = "0.5.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.5](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.9.5) - 2026-09-01
+
+### Fixed
+
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
 
 ### Fixed

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.9.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.4.4 -> 0.4.5 (✓ API compatible changes)
* `deep_causality_algebra`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `deep_causality_haft`: 0.4.3 -> 0.5.0
* `deep_causality_core`: 0.11.2 -> 0.12.0 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.17 -> 0.10.18 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `deep_causality_uncertain`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `ultragraph`: 0.9.4 -> 0.9.5 (✓ API compatible changes)
* `deep_causality`: 0.15.2 -> 0.16.0 (✓ API compatible changes)
* `deep_causality_par`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_linear`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.7 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_num_dual`: 0.1.6 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_tensor`: 0.5.3 -> 0.6.0 (✓ API compatible changes)
* `deep_causality_fft`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_homology`: 0.1.0 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_multivector`: 0.6.1 -> 0.7.0 (✓ API compatible changes)
* `deep_causality_topology`: 0.8.0 -> 0.9.0
* `deep_causality_algorithms`: 0.4.3 -> 0.5.0 (✓ API compatible changes)
* `deep_causality_num_rational`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_calculus`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_file`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_physics`: 0.8.2 -> 0.9.0 (✓ API compatible changes)
* `deep_causality_cfd`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_discovery`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.11 -> 0.3.0 (✓ API compatible changes)
* `deep_causality_quantum`: 0.1.2 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.4.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.4...deep_causality_num-v0.4.5) - 2026-09-01

### Fixed

- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.4.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.4.2...deep_causality_algebra-v0.4.3) - 2026-09-01

### Fixed

- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.3...deep_causality_haft-v0.5.0) - 2026-09-01

### Added

- *(deep_causality_haft)* formalize the lax monoidal laws in Lean
- *(haft)* add the lax monoidal structure on endofunctors
- *(unified_math)* HKT witnesses for the Cayley-Dickson types

### Fixed

- *(deep_causality_haft)* bumped up version;
- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- Applied lints and fixes.
- *(bazel)* [**breaking**] rename build/ to bazel/
- *(examples)* [**breaking**] move the haft examples into mathematics_examples
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- *(openspec)* Archived specs and notes on lax monoidal applicative
- *(haft)* record why VecWitness has no Traversable, with the measurement
- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- *(deep_causality_tensor)* delete the dead strict tensor witness
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-01

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-01

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.2...deep_causality_rand-v0.2.3) - 2026-09-01

### Fixed

- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.1...deep_causality_uncertain-v0.5.2) - 2026-09-01

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
</blockquote>

## `ultragraph`

<blockquote>

## [0.9.5](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.9.5) - 2026-09-01

### Fixed

- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality`

<blockquote>

## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-01

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(build)* [**breaking**] move build/scripts to the repository root
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-01

### Fixed

- *(deep_causality_par)* Applied a number of fixes and lint corrections.

### Other

- *(bazel)* merge test BUILD files and derive deps from Cargo
</blockquote>

## `deep_causality_linear`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_linear-v0.1.2...deep_causality_linear-v0.2.0) - 2026-09-01

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.7...deep_causality_num_complex-v0.2.0) - 2026-09-01

### Added

- *(deep_causality_num_complex)* close E1 — monoidal applicative on the Cayley-Dickson types
- *(unified_math)* HKT witnesses for the Cayley-Dickson types

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- Applied lints and fixes.
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- *(openspec)* Archived specs and notes on lax monoidal applicative
- *(haft)* record why VecWitness has no Traversable, with the measurement
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.6...deep_causality_num_dual-v0.2.0) - 2026-09-01

### Added

- *(num_dual)* close E2 — drop the Dual struct bound, add DualWitness

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- Applied lints and fixes.
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- *(openspec)* Archived specs and notes on lax monoidal applicative
- *(haft)* record why VecWitness has no Traversable, with the measurement
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.3...deep_causality_tensor-v0.6.0) - 2026-09-01

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- Applied lints and fixes.
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
- *(deep_causality_tensor)* delete the dead strict tensor witness
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_fft`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.3...deep_causality_fft-v0.1.4) - 2026-09-01

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_homology`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.0...deep_causality_homology-v0.2.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.7.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.6.1...deep_causality_multivector-v0.7.0) - 2026-09-01

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
- *(deep_causality_multivector)* [**breaking**] close an unsound HKT witness and remove the repo's last unsafe exemption
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_unified_math)* Applied a number of fixes and lint corrections.

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.8.0...deep_causality_topology-v0.9.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(unified_math)* [**breaking**] act on a review of the HKT law and constraint work
- *(unified_math)* [**breaking**] rectify the HKT law tests and correct the defects they exposed
- *(deep_causality_multivector)* [**breaking**] close an unsound HKT witness and remove the repo's last unsafe exemption
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
- *(ci,scripts)* derive crate lists from the workspace manifest

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- *(haft)* [**breaking**] drop the GAT where-clause from the HKT trait family
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- *(deep_causality_tensor)* delete the dead strict tensor witness
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.5.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_num_rational`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.3...deep_causality_num_rational-v0.1.4) - 2026-09-01

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated paths in docs of relocated crates across the repo
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_calculus`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.4...deep_causality_calculus-v0.1.5) - 2026-09-01

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-01

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.9.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated inbound links to archived notes
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_cfd`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology

### Fixed

- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-01

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.3.0) - 2026-09-01

### Other

- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(build)* [**breaking**] move build/scripts to the repository root
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_quantum`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.1.2...deep_causality_quantum-v0.2.0) - 2026-09-01

### Added

- *(deep_causality_quantum)* decide class invariance over the code space
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
- *(deep_causality_quantum)* [**breaking**] retype the Haruna gate layer onto Gf2Chain and close four QCL gaps
- *(quantum,num,topology)* close the six low-effort QCL gaps

### Fixed

- *(CI)* fixed broken lean theorem.

### Other

- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).