### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-03
+
+### Other
+
+- Added CRA compliance notice to README.md and SECURITY.md
+- *(workspace)* move ast, file and par into deep_causality_utils
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(build)* [**breaking**] move build/scripts to the repository root
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.15.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.0...deep_causality-v0.15.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algorithms"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.12"
+version = "0.1.13"
 
 [[package]]
 name = "deep_causality_calculus"
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -592,14 +592,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.3.0"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_homology"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "deep_causality_linear",
  "deep_causality_num",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -731,11 +731,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "deep_causality_physics"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_calculus",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_uncertain"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -2211,7 +2211,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,16 +36,16 @@ license = "MIT"
 # picked up without touching this file. release-plz preserves whatever verion it finds in a crate.
 
 # Internal crates
-deep_causality = { path = "deep_causality", version = "0.15" }
+deep_causality = { path = "deep_causality", version = "0.16" }
 deep_causality_algebra = { path = "deep_causality_unified_math/deep_causality_algebra", version = "0.4", default-features = false }
-deep_causality_algorithms = { path = "deep_causality_algorithms", version = "0.4" }
+deep_causality_algorithms = { path = "deep_causality_algorithms", version = "0.5" }
 deep_causality_ast = { path = "deep_causality_utils/deep_causality_ast", version = "0.1", default-features = false }
 deep_causality_calculus = { path = "deep_causality_unified_math/deep_causality_calculus", version = "0.1", default-features = false }
-deep_causality_cfd = { path = "deep_causality_cfd", version = "0.1" }
-deep_causality_core = { path = "deep_causality_core", version = "0.11", default-features = false }
+deep_causality_cfd = { path = "deep_causality_cfd", version = "0.2" }
+deep_causality_core = { path = "deep_causality_core", version = "0.12", default-features = false }
 deep_causality_data_structures = { path = "deep_causality_data_structures", version = "0.10" }
-deep_causality_discovery = { path = "deep_causality_discovery", version = "0.5" }
-deep_causality_ethos = { path = "deep_causality_ethos", version = "0.2" }
+deep_causality_discovery = { path = "deep_causality_discovery", version = "0.6" }
+deep_causality_ethos = { path = "deep_causality_ethos", version = "0.3" }
 deep_causality_fft = { path = "deep_causality_unified_math/deep_causality_fft", version = "0.1", default-features = false }
 deep_causality_file = { path = "deep_causality_utils/deep_causality_file", version = "0.1" }
 deep_causality_haft = { path = "deep_causality_unified_math/deep_causality_haft", version = "0.5", default-features = false }
@@ -58,13 +58,13 @@ deep_causality_num_complex = { path = "deep_causality_unified_math/deep_causalit
 deep_causality_num_dual = { path = "deep_causality_unified_math/deep_causality_num_dual", version = "0.1", default-features = false }
 deep_causality_num_rational = { path = "deep_causality_unified_math/deep_causality_num_rational", version = "0.1", default-features = false }
 deep_causality_par = { path = "deep_causality_utils/deep_causality_par", version = "0.1", default-features = false }
-deep_causality_physics = { path = "deep_causality_physics", version = "0.8", default-features = false }
+deep_causality_physics = { path = "deep_causality_physics", version = "0.9", default-features = false }
 deep_causality_quantum = { path = "deep_causality_quantum", version = "0.3" }
 deep_causality_rand = { path = "deep_causality_unified_math/deep_causality_rand", version = "0.2" }
 deep_causality_tensor = { path = "deep_causality_unified_math/deep_causality_tensor", version = "0.5", default-features = false }
 deep_causality_topology = { path = "deep_causality_unified_math/deep_causality_topology", version = "0.9" }
 deep_causality_uncertain = { path = "deep_causality_unified_math/deep_causality_uncertain", version = "0.5" }
-ultragraph = { path = "ultragraph", version = "0.9" }
+ultragraph = { path = "ultragraph", version = "0.10" }
 
 # External crates
 candle-core = { version = "0.11" }

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.5.0) - 2026-09-03
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.1...deep_causality_algorithms-v0.4.2) - 2026-08-12
 
 ### Added

--- a/deep_causality_algorithms/Cargo.toml
+++ b/deep_causality_algorithms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algorithms"
-version = "0.4.3"
+version = "0.5.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_cfd/CHANGELOG.md
+++ b/deep_causality_cfd/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology
+
+### Fixed
+
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_cfd-v0.1.0) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-03
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-03
+
+### Other
+
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
 
 ### Added

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-03
+
+### Added
+
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.3.0) - 2026-09-03
+
+### Other
+
+- Added CRA compliance notice to README.md and SECURITY.md
+- *(workspace)* move ast, file and par into deep_causality_utils
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(build)* [**breaking**] move build/scripts to the repository root
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.2.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.9...deep_causality_ethos-v0.2.10) - 2026-08-12
 
 ### Added

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.3.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.9.0) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated inbound links to archived notes
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.8.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.0...deep_causality_physics-v0.8.1) - 2026-08-12
 
 ### Added

--- a/deep_causality_physics/Cargo.toml
+++ b/deep_causality_physics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_physics"
-version = "0.8.2"
+version = "0.9.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_quantum/CHANGELOG.md
+++ b/deep_causality_quantum/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.2.0...deep_causality_quantum-v0.3.0) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl
+- *(deep_causality_quantum)* add the QCL pipeline, from one config origin through validate, Screened and control
+- *(deep_causality_quantum)* add Hypothesis with the mechanism-level intervention, embedded prediction and warrant-gated marginalisation
+- *(deep_causality_quantum)* add the typed carriers, the shot budget and the default-build Born sampler
+- *(deep_causality_quantum)* [**breaking**] finish class invariance with the normalizer check, the Clifford tableau and the tuple cap
+
+### Fixed
+
+- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
+- *(deep_causality_quantum,openspec)* correct C₃ to Definition 3.1 and apply the QCL corrections register
+
+### Other
+
+- Fixed PR review issues.
+- *(deep_causality_quantum)* add design as an exact pair cover and adjudicate under the verdict law
+- Updated Rust depencies to the latest version.

--- a/deep_causality_unified_math/deep_causality_homology/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_homology/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.1...deep_causality_homology-v0.1.2) - 2026-09-03
+
+### Other
+
+- Updated Rust depencies to the latest version.

--- a/deep_causality_unified_math/deep_causality_homology/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_homology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_homology"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.5...deep_causality_num-v0.5.0) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl
+
+### Fixed
+
+- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
+
+### Other
+
+- Fixed PR review issues.
+- Update deep_causality_unified_math/deep_causality_num/tests/casts/to_primitive/to_primitive_float_tests.rs
+- Update deep_causality_unified_math/deep_causality_num/src/float_106/traits_num.rs
+- Fixed PR review issues.
+- *(workspace)* follow deep_causality_num to 0.5 in the dependency table
+- *(examples)* lift through deep_causality_num instead of hand-rolled helpers
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.5.0" # Update workspace Cargo.toml internal version dep for a major bump.
+version = "0.5.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.8...deep_causality_num_complex-v0.1.9) - 2026-09-03
+
+### Fixed
+
+- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.8"
+version = "0.1.9"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.3...deep_causality_rand-v0.2.4) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_rand/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.3"
+version = "0.2.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.2...deep_causality_uncertain-v0.5.3) - 2026-09-03
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_uncertain/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_uncertain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_uncertain"
-version = "0.5.2"
+version = "0.5.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_utils/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.12...deep_causality_ast-v0.1.13) - 2026-09-03
+
+### Other
+
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_utils/deep_causality_ast/Cargo.toml
+++ b/deep_causality_utils/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.12"
+version = "0.1.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/deep_causality_utils/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-03
+
+### Other
+
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_utils/deep_causality_file/Cargo.toml
+++ b/deep_causality_utils/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_utils/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-03
+
+### Other
+
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_utils/deep_causality_par/Cargo.toml
+++ b/deep_causality_utils/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.10.0) - 2026-09-03
+
+### Fixed
+
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
 
 ### Fixed

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.10.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.4.5 -> 0.5.0
* `deep_causality_ast`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `deep_causality_core`: 0.11.2 -> 0.12.0 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.17 -> 0.10.18 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `deep_causality_uncertain`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `ultragraph`: 0.9.4 -> 0.10.0 (⚠ API breaking changes)
* `deep_causality`: 0.15.2 -> 0.16.0 (✓ API compatible changes)
* `deep_causality_par`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `deep_causality_homology`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.4.3 -> 0.5.0 (✓ API compatible changes)
* `deep_causality_file`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_physics`: 0.8.2 -> 0.9.0 (✓ API compatible changes)
* `deep_causality_cfd`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_discovery`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.11 -> 0.3.0 (✓ API compatible changes)
* `deep_causality_quantum`: 0.2.0 -> 0.3.0

### ⚠ `ultragraph` breaking changes

```text
--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---

Description:
A pub function is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_now_doc_hidden.ron

Failed in:
  function get_acyclic_graph in file /tmp/.tmpnvg0mW/deep_causality/ultragraph/src/utils/utils_tests.rs:28
  function get_cyclic_graph in file /tmp/.tmpnvg0mW/deep_causality/ultragraph/src/utils/utils_tests.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.5...deep_causality_num-v0.5.0) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl

### Fixed

- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them

### Other

- Fixed PR review issues.
- Update deep_causality_unified_math/deep_causality_num/tests/casts/to_primitive/to_primitive_float_tests.rs
- Update deep_causality_unified_math/deep_causality_num/src/float_106/traits_num.rs
- Fixed PR review issues.
- *(workspace)* follow deep_causality_num to 0.5 in the dependency table
- *(examples)* lift through deep_causality_num instead of hand-rolled helpers
</blockquote>

## `deep_causality_ast`

<blockquote>

## [0.1.13](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.12...deep_causality_ast-v0.1.13) - 2026-09-03

### Other

- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-03

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-03

### Other

- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.3...deep_causality_rand-v0.2.4) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.2...deep_causality_uncertain-v0.5.3) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
</blockquote>

## `ultragraph`

<blockquote>

## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.10.0) - 2026-09-03

### Fixed

- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality`

<blockquote>

## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-03

### Other

- Added CRA compliance notice to README.md and SECURITY.md
- *(workspace)* move ast, file and par into deep_causality_utils
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(build)* [**breaking**] move build/scripts to the repository root
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-03

### Other

- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.8...deep_causality_num_complex-v0.1.9) - 2026-09-03

### Fixed

- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
</blockquote>

## `deep_causality_homology`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.1...deep_causality_homology-v0.1.2) - 2026-09-03

### Other

- Updated Rust depencies to the latest version.
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.5.0) - 2026-09-03

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-03

### Other

- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.9.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.9.0) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated inbound links to archived notes
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_cfd`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology

### Fixed

- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-03

### Added

- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.3.0) - 2026-09-03

### Other

- Added CRA compliance notice to README.md and SECURITY.md
- *(workspace)* move ast, file and par into deep_causality_utils
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(build)* [**breaking**] move build/scripts to the repository root
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_quantum`

<blockquote>

## [0.3.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.2.0...deep_causality_quantum-v0.3.0) - 2026-09-03

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl
- *(deep_causality_quantum)* add the QCL pipeline, from one config origin through validate, Screened and control
- *(deep_causality_quantum)* add Hypothesis with the mechanism-level intervention, embedded prediction and warrant-gated marginalisation
- *(deep_causality_quantum)* add the typed carriers, the shot budget and the default-build Born sampler
- *(deep_causality_quantum)* [**breaking**] finish class invariance with the normalizer check, the Clifford tableau and the tuple cap

### Fixed

- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
- *(deep_causality_quantum,openspec)* correct C₃ to Definition 3.1 and apply the QCL corrections register

### Other

- Fixed PR review issues.
- *(deep_causality_quantum)* add design as an exact pair cover and adjudicate under the verdict law
- Updated Rust depencies to the latest version.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).