### PR TITLE
fix(deep_causality_quantum): Fixed broken version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_quantum"
-version = "0.3.1"
+version = "0.2.5"
 dependencies = [
  "deep_causality",
  "deep_causality_algebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ deep_causality_num_dual = { path = "deep_causality_unified_math/deep_causality_n
 deep_causality_num_rational = { path = "deep_causality_unified_math/deep_causality_num_rational", version = "0.1", default-features = false }
 deep_causality_par = { path = "deep_causality_utils/deep_causality_par", version = "0.1", default-features = false }
 deep_causality_physics = { path = "deep_causality_physics", version = "0.8", default-features = false }
-deep_causality_quantum = { path = "deep_causality_quantum", version = "0.3" }
+deep_causality_quantum = { path = "deep_causality_quantum", version = "0.2" }
 deep_causality_rand = { path = "deep_causality_unified_math/deep_causality_rand", version = "0.2" }
 deep_causality_stats = { path = "deep_causality_unified_math/deep_causality_stats", version = "0.1", default-features = false }
 deep_causality_tensor = { path = "deep_causality_unified_math/deep_causality_tensor", version = "0.5", default-features = false }

--- a/deep_causality_quantum/Cargo.toml
+++ b/deep_causality_quantum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_quantum"
-version = "0.3.1"
+version = "0.2.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/examples/physics_examples/Cargo.toml
+++ b/examples/physics_examples/Cargo.toml
@@ -17,7 +17,7 @@ deep_causality_stats = { workspace = true, features = ["std"] }
 deep_causality_core = { workspace = true, features = ["default"] }
 deep_causality_calculus = { workspace = true, features = ["default"] }
 deep_causality_physics = { workspace = true, features = ["default", "os-random"] }
-deep_causality_quantum = { workspace = true }
+deep_causality_quantum = { workspace = true , features = ["default"]}
 deep_causality_multivector = { workspace = true, features = ["default"] }
 deep_causality_tensor = { workspace = true, features = ["default"] }
 deep_causality_topology = { workspace = true }

--- a/openspec/notes/test_audit/dc_all/README.md
+++ b/openspec/notes/test_audit/dc_all/README.md
@@ -1,0 +1,279 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2023 - 2026. The DeepCausality Authors and Contributors. All Rights Reserved.
+-->
+
+# Remaining-crates test-suite audit
+
+This report applies the physics test-audit scanner to the nine workspace crates not covered by the
+physics, utility, or unified-math audits. It is an inventory and a calibrated review, not a
+proposal and not a claim that every syntactic match is a defective test.
+
+## Scope
+
+The audit covers:
+
+- `deep_causality`
+- `deep_causality_algorithms`
+- `deep_causality_cfd`
+- `deep_causality_core`
+- `deep_causality_data_structures`
+- `deep_causality_discovery`
+- `deep_causality_ethos`
+- `deep_causality_quantum`
+- `ultragraph`
+
+Together with the existing physics, utility, and unified-math reports, this completes static
+scanner coverage of all 30 workspace library crates.
+
+## Finding in one line
+
+**The same weakness exists outside physics and unified math, but at a lower raw rate: 3,005 of
+3,633 explicit tests are single-input, while 326 use an unexplained single-point literal oracle;
+the clearest confirmed gaps are value-returning operations that assert only success.**
+
+The raw hard classes contain substantial false-positive populations. Independent analytic CFD
+solutions are classified as circular, explicit match-and-panic error checks are classified as
+assertion-free, and exact `Result` contracts are classified as tautologies. The raw results are
+review queues, not defect counts.
+
+## Method
+
+The unchanged classification logic from `openspec/notes/test_audit/physics/audit_tests.py` was run
+once per crate with that crate's `tests/` directory as its root. It inspected 490 Rust test files,
+containing 82,315 lines, and recognized 3,633 explicit `#[test]` functions. Tests embedded in
+`src/`, doctests, and macro expansions are outside that static count.
+
+The classes overlap. A test can be both single-input and cherry-picked, or both circular and
+cherry-picked. Counts must not be added to obtain a number of defective tests.
+
+| Class | Raw count | Share | Scanner meaning |
+|---|---:|---:|---|
+| single-input | 3,005 | 82.7% | No loop or table was recognized. |
+| cherry-picked | 326 | 9.0% | One input, literal expected value, and no recognized provenance. |
+| circular | 62 | 1.7% | Arithmetic was used to construct an expected value. |
+| tautology | 60 | 1.7% | Only a weak predicate such as `is_ok`, `is_some`, or `is_finite` was recognized. |
+| no-assertion | 5 | 0.1% | No assertion macro or asserting helper was recognized. |
+
+## Per-crate inventory
+
+Percentages use each crate's explicit test-function count. The final five columns are raw,
+overlapping classifications.
+
+| Crate | Test files | Tests | Single-input | Cherry-picked | Tautology | Circular | No assertion |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `deep_causality` | 160 | 1,137 | 1,041 (91.6%) | 90 (7.9%) | 21 (1.8%) | 4 (0.4%) | 2 (0.2%) |
+| `deep_causality_algorithms` | 37 | 334 | 254 (76.0%) | 23 (6.9%) | 3 (0.9%) | 7 (2.1%) | 0 |
+| `deep_causality_cfd` | 123 | 938 | 649 (69.2%) | 129 (13.8%) | 22 (2.3%) | 46 (4.9%) | 0 |
+| `deep_causality_core` | 31 | 252 | 243 (96.4%) | 0 | 0 | 0 | 0 |
+| `deep_causality_data_structures` | 10 | 81 | 66 (81.5%) | 2 (2.5%) | 0 | 0 | 0 |
+| `deep_causality_discovery` | 52 | 194 | 178 (91.8%) | 5 (2.6%) | 3 (1.5%) | 0 | 3 (1.5%) |
+| `deep_causality_ethos` | 17 | 106 | 105 (99.1%) | 0 | 1 (0.9%) | 0 | 0 |
+| `deep_causality_quantum` | 45 | 462 | 371 (80.3%) | 76 (16.5%) | 9 (1.9%) | 3 (0.6%) | 0 |
+| `ultragraph` | 15 | 129 | 98 (76.0%) | 1 (0.8%) | 1 (0.8%) | 2 (1.6%) | 0 |
+| **Total** | **490** | **3,633** | **3,005 (82.7%)** | **326 (9.0%)** | **60 (1.7%)** | **62 (1.7%)** | **5 (0.1%)** |
+
+The percentages do not measure test quality by themselves. `deep_causality_core` has a 96.4%
+single-input rate but no hard or cherry-picked matches: its tests mostly pin discrete monadic,
+state, error, and control-flow behavior at individually named cases. Conversely, one test with many
+inputs can still repeat the same ineffective assertion.
+
+## Calibrated findings
+
+### Two of five no-assertion flags make no observation
+
+The three discovery flags are false positives. `test_from_csv_error`, `test_from_parquet_error`,
+and `test_from_mrmr_error` use explicit variant matching and panic on the wrong branch. The scanner
+recognizes neither `if let ... else { panic!() }` nor match-and-panic assertions.
+
+The two `deep_causality` matches genuinely contain no observation:
+
+- `deep_causality/tests/types/csm_types/csm_action/csm_action_tests.rs`,
+  `test_causal_action_creation`, constructs and clones an action and formats its debug output into
+  an unused binding. It verifies compilation and absence of panic, but none of the constructed
+  state or rendered output.
+- `deep_causality/tests/utils/time_utils_tests.rs`, `test_time`, calls `time_execution` around a
+  function that prints a line. It does not assert that the wrapped function's return value passes
+  through, and it does not observe the timing label.
+
+### Quantum has the clearest weak-assertion cluster
+
+Eight of quantum's nine raw tautology flags are ineffective answer checks:
+
+- `deep_causality_quantum/tests/types/qgates/mechanics_tests.rs` tests valid expectation-value,
+  identity-gate, and commutator kernels only with `result.is_ok()`. These kernels return numeric or
+  state results that are never inspected.
+- `deep_causality_quantum/tests/types/qgates/wrappers_tests.rs` tests five successful wrappers—Born
+  probability, expectation value, gate application, commutator, and fidelity—only with
+  `effect.is_ok()`. A wrapper returning any successful value would pass.
+
+The ninth flag, `faithfulness_tests.rs::test_complete_bipartite_is_c3_free`, is not ineffective. It
+first checks the independently observable absence of a C3 witness and then checks that the
+corresponding validation returns `Ok`.
+
+The 76 quantum cherry-picked matches are also a mixed population. For example,
+`operator_residual_tests.rs` explicitly documents hand-evaluated 3-4-5 oracles, overflow scaling,
+and enumerated corner cases at module level. The scanner misses that provenance because it is too
+far from individual assertions. That file is evidence of good test design, not an 11-test repair
+target.
+
+### Root `deep_causality` tests often assert completion instead of behavior
+
+Several CSM tests name an action or state transition but assert only that evaluation returned
+`Ok`:
+
+- `csm_single_state_tests.rs::eval_single_state_success_fires_action` uses an action that succeeds,
+  so `is_ok()` does not prove it was invoked.
+- `csm_all_states_tests.rs::eval_all_states_success_active_state_fires_action` has the same gap.
+- the uncertain-state success tests establish only acceptance, not the selected state or action.
+
+This does not apply to every CSM `is_ok()` test. Tests that install a deliberately failing action
+for an inactive state use success as evidence that the action was not invoked; that is a meaningful
+negative control.
+
+Other confirmed or high-confidence gaps are:
+
+- `causality_graph_reasoning_sub_tests.rs::test_evaluate_subgraph_follows_a_relay_to_a_valid_target`
+  asserts only success and explicitly discards the target index. It does not prove the relay reached
+  that target or returned its effect.
+- the collection `test_get_item_by_id` cases assert only `is_some()`. They do not show that the
+  returned item has the requested identity.
+- `inferable_vec_tests.rs::test_item_conjoint_delta` constructs its expected value by repeating the
+  default method's stated `abs(1 - observation)` expression at one input. It lacks an independent
+  law or range that could expose a shared formula error.
+
+The tangent-spacetime and NED distance tests are also classified as circular because they calculate
+Euclidean norms in the test. Those formulas can be legitimate independent definitions, but one
+3-4-12 or 100-50-10 example cannot distinguish a generally correct metric implementation from an
+implementation specialized to the same uncomplicated case.
+
+### CFD has the largest candidate set, but many candidates are strong controls
+
+CFD accounts for 129 of the 326 cherry-picked and 46 of the 62 circular matches. Most of the
+circular label is syntactic noise: analytic decay solutions, Fourier-mode diffusion, Taylor-Green
+energy, step-refinement invariance, dense-versus-QTT stencil comparisons, and coordinate Jacobian
+identities are independent or metamorphic controls. They should not be mechanically rewritten.
+
+The clear weak cases are narrower:
+
+- `deep_causality_cfd/tests/theories/wrappers_tests.rs`,
+  `test_compressible_ns_momentum_rhs_effect_wrapper`, asserts only success while the neighboring
+  continuity wrapper checks its carried numeric value.
+- `deep_causality_cfd/tests/tensor_bridge/projection_tests.rs::projected_field_is_finite` checks
+  every output only for finiteness. It does not assert the defining divergence-free property or
+  compare with a dense/reference projection.
+- several configuration tests intentionally assert only successful construction. Those are valid
+  positive-path tests when acceptance is the contract; they are not numeric oracle tests.
+
+`march_run_tests.rs::test_centerline_profile_is_recorded` checks only that the named series exists.
+That exactly establishes presence, but does not validate the series length or values. It is an
+incomplete result check rather than a tautology.
+
+### Algorithms' circular flags are predominantly independent oracles
+
+The seven algorithm circular candidates are named closed forms, a Jacobian identity, and an
+`f32`/`f64` differential comparison. They exercise a path independent of the implementation under
+test and should be preserved unless mutation testing proves otherwise.
+
+The three weak-predicate candidates test finite behavior around covariance singularities and an
+automatic log-to-log1p downgrade. Finiteness is a real robustness contract for the two variance
+floor/ridge tests. `gaussian_tests.rs::auto_downgrade_keeps_density_finite`, however, does not prove
+that log1p was selected: any finite fallback would pass. It should compare the returned density
+with the log1p oracle already used by nearby tests.
+
+### Discovery, ethos, and ultragraph each have a localized incomplete check
+
+- `deep_causality_discovery/tests/types/cdl/brcd_pipeline_tests.rs`,
+  `test_brcd_full_pipeline_boss_fallback`, asserts only that the final inner result is `Ok`. It does
+  not inspect the report or show that the requested BOSS fallback produced the expected outcome.
+- `deep_causality_ethos/tests/types/effect_ethos/effect_ethos_linking_tests.rs`,
+  `test_linking_success`, asserts only that `link_inheritance` returned `Ok`. A successful no-op
+  would pass; the relationship should be observed through graph verification or evaluation.
+- `ultragraph/tests/types/ultra_graph/graph_csm_algo_topological_tests.rs`,
+  `test_topological_sort_on_empty_graph`, asserts `Ok(Some(_))` but not that the returned ordering
+  is empty. Any nonempty ordering would pass the test named for the empty graph.
+
+### Core and data structures form the low-priority baseline
+
+`deep_causality_core` has no raw tautology, circular, cherry-picked, or no-assertion candidates.
+Its high single-input percentage reflects individually named cases rather than a detected oracle
+failure.
+
+`deep_causality_data_structures` has only two cherry-picked matches. Both are ordinary grid
+dimension and storage round-trip tests. The suite also contains explicit distinct-dimension indexing
+regressions, boundary cases, storage variants, and stress tests. No hard defect was established by
+this audit.
+
+## Files with the largest raw hard/cherry signal
+
+This table ranks syntactic leads, not confirmed defect counts.
+
+| Raw matches | File | Composition |
+|---:|---|---|
+| 13 | `deep_causality_algorithms/tests/causal_discovery/brcd/gaussian_tests.rs` | 3 circular, 1 tautology, 9 cherry-picked |
+| 13 | `deep_causality/tests/types/context_node_types/space_time/tangent_spacetime/tangent_spacetime_tests.rs` | 2 circular, 11 cherry-picked |
+| 11 | `deep_causality_quantum/tests/types/qgates/operator_residual_tests.rs` | 11 cherry-picked; manually documented oracles |
+| 9 | `deep_causality_cfd/tests/types/flow/coupling_tests.rs` | 1 circular, 8 cherry-picked |
+| 8 | `deep_causality_cfd/tests/types/flow/blackout_tests.rs` | 2 circular, 1 tautology, 5 cherry-picked |
+| 7 | `deep_causality_cfd/tests/types/flow_config/compressible_march_config_tests.rs` | 1 circular, 6 cherry-picked |
+| 7 | `deep_causality_cfd/tests/types/flow/corridor/lift_tests.rs` | 7 cherry-picked |
+| 7 | `deep_causality_cfd/tests/solvers/dec/surface_force_tests.rs` | 4 circular, 3 cherry-picked |
+| 6 | `deep_causality_quantum/tests/types/qgates/gates_tests.rs` | 6 cherry-picked |
+| 6 | `deep_causality_quantum/tests/formalization_lean/partial_trace_tests.rs` | 6 cherry-picked |
+| 6 | `deep_causality/tests/types/csm_types/csm/csm_all_states_tests.rs` | 6 tautology candidates |
+
+The first and third rows demonstrate why ranking cannot replace review: both contain unusually
+explicit independent-oracle documentation even though the scanner ranks them worst.
+
+## Scanner limits
+
+- Helper bodies are recognized only by name and assertion text, not by control flow.
+- `panic!` in a rejected match arm is not recognized as an assertion.
+- Macros are not expanded, so 3,633 is not the number of runtime cases.
+- A loop or table suppresses `single-input`; the scanner does not judge input diversity.
+- Literal provenance is recognized only through nearby keywords and can miss module-level oracle
+  documentation.
+- Expected-value arithmetic cannot distinguish copied production logic from an independent closed
+  form, analytic solution, or metamorphic relation.
+- Weak predicates may be exact contracts for constructors, classification, validation, domain
+  errors, stability, and path selection.
+- Doctests and tests embedded in `src/` are outside this inventory.
+- Assertions behind early exits and conditional blocks require manual reachability review.
+
+## Verification
+
+All nine packages were tested together with one `cargo test` invocation. The command completed
+successfully. This establishes that the current suites pass, not that every oracle would detect an
+incorrect implementation.
+
+No production code or tests were changed for this audit.
+
+## Recommended order of fixes
+
+This ordering covers the nine crates in this report. It prioritizes confirmed ineffective behavior
+checks, consequence of a missed defect, and then raw mutation risk; it does not sort by scanner
+percentage alone.
+
+1. **`deep_causality_quantum`** — repair the eight output-blind kernel and wrapper success tests
+   first. Exact values and identity laws are available, so these are high-confidence, bounded
+   fixes in a correctness-sensitive crate.
+2. **`deep_causality`** — make CSM action execution observable, assert relay targets and effects,
+   repair the two assertion-free tests, and replace getter-presence checks with identity checks.
+   This is the largest confirmed behavioral cluster and the public root crate.
+3. **`deep_causality_cfd`** — fix the momentum wrapper and projection property checks, then use
+   targeted mutation testing on coupling, blackout, corridor, force, and inverse kernels. Preserve
+   the independent analytic and dense-reference controls.
+4. **`deep_causality_algorithms`** — pin the automatic transform downgrade numerically, then run
+   mutations over BRCD scoring and Gaussian-family code. The raw circular tests should remain when
+   their closed forms are independent.
+5. **`deep_causality_discovery`** — make the BOSS fallback pipeline assert the produced report and
+   selected outcome. Retain the match-and-panic conversion tests or express them as `matches!` for
+   scanner clarity.
+6. **`deep_causality_ethos`** — make successful inheritance linking observable through graph or
+   verdict behavior. This is one localized, inexpensive repair.
+7. **`ultragraph`** — assert that topological sorting an empty graph returns an empty ordering, then
+   mutation-test centrality normalization before changing its independently derived expectations.
+8. **`deep_causality_data_structures`** — no confirmed hard defect; use focused index mutations as
+   a verification pass after the higher-risk crates.
+9. **`deep_causality_core`** — no hard candidate from this audit. Review only through mutation
+   survivors; do not expand tests merely to reduce the single-input percentage.

--- a/openspec/notes/test_audit/physics/audit_tests_v2.py
+++ b/openspec/notes/test_audit/physics/audit_tests_v2.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Find test designs that plausible wrong implementations can survive.
+
+This scanner implements the risk-first methodology described in Dan Luu's
+"How well do agents use test/verification techniques?".  It reports syntactic
+candidates for semantic review; no category is a defect count.
+
+The default target is deliberately the physics crate.  Pass --root to audit a
+different test tree explicitly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_ROOT = Path("deep_causality_physics/tests")
+DEFAULT_JSON = Path("/tmp/physics_test_audit_v2.json")
+
+ASSERT_NAME = re.compile(r"\b(assert|assert_eq|assert_ne|debug_assert|debug_assert_eq|debug_assert_ne)!")
+ARITHMETIC = re.compile(
+    r"[+\-*/]|\.(?:sqrt|cbrt|powi|powf|ln|log|log10|exp|sin|cos|tan|asin|acos|atan|abs|hypot)\s*\("
+)
+PROVENANCE = re.compile(
+    r"(?:NIST|CODATA|reference|published|textbook|handbook|oracle|closed[- ]form|"
+    r"by hand|bisection|analytic|literature|Appendix|ISBN|doi|et al|scipy|numpy|"
+    r"mpmath|Wolfram|golden|high[- ]precision|independent|identity|invariant|"
+    r"conservation|dimensional|scaling|20\d\d\))",
+    re.IGNORECASE,
+)
+WEAK_PREDICATE = re.compile(
+    r"\.(?:is_ok|is_some|is_finite|is_nan|is_sign_positive|is_sign_negative)\s*\(\s*\)"
+)
+ERROR_PREDICATE = re.compile(
+    r"\.(?:is_err|is_none)\s*\(\s*\)|unwrap_err|expect_err|matches!"
+)
+RANDOM_SOURCE = re.compile(r"\b(?:random|rand|rng|sample|fuzz|proptest|quickcheck)\b", re.IGNORECASE)
+DEGENERATE_PURPOSE = re.compile(
+    r"(?:zero|one|identity|default|empty|unit|basis|orthogonal|boundary|limit|constant|uniform)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class TestCase:
+    path: Path
+    name: str
+    line: int
+    attributes: str
+    body: str
+    context: str
+
+
+def mask_non_code(source: str) -> str:
+    """Replace comments and string/character contents while preserving offsets."""
+    out = list(source)
+    i = 0
+    state = "code"
+    while i < len(source):
+        pair = source[i : i + 2]
+        ch = source[i]
+        if state == "code":
+            if pair == "//":
+                out[i] = out[i + 1] = " "
+                i += 2
+                state = "line-comment"
+                continue
+            if pair == "/*":
+                out[i] = out[i + 1] = " "
+                i += 2
+                state = "block-comment"
+                continue
+            if ch == '"':
+                out[i] = " "
+                i += 1
+                state = "string"
+                continue
+            if ch == "'" and i + 2 < len(source) and source[i + 2] == "'":
+                out[i] = out[i + 2] = " "
+                out[i + 1] = " "
+                i += 3
+                continue
+        elif state == "line-comment":
+            if ch == "\n":
+                state = "code"
+            else:
+                out[i] = " "
+        elif state == "block-comment":
+            if pair == "*/":
+                out[i] = out[i + 1] = " "
+                i += 2
+                state = "code"
+                continue
+            if ch != "\n":
+                out[i] = " "
+        elif state == "string":
+            if ch == "\\" and i + 1 < len(source):
+                out[i] = out[i + 1] = " "
+                i += 2
+                continue
+            if ch == '"':
+                out[i] = " "
+                state = "code"
+            elif ch != "\n":
+                out[i] = " "
+        i += 1
+    return "".join(out)
+
+
+def matching_brace(code: str, opening: int) -> int | None:
+    depth = 0
+    for i in range(opening, len(code)):
+        if code[i] == "{":
+            depth += 1
+        elif code[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def split_tests(path: Path, source: str) -> list[TestCase]:
+    masked = mask_non_code(source)
+    lines = source.splitlines()
+    masked_lines = masked.splitlines()
+    offsets: list[int] = []
+    offset = 0
+    for line in source.splitlines(keepends=True):
+        offsets.append(offset)
+        offset += len(line)
+
+    tests: list[TestCase] = []
+    i = 0
+    while i < len(lines):
+        if not masked_lines[i].strip().startswith("#[test]"):
+            i += 1
+            continue
+        attr_start = i
+        j = i + 1
+        while j < len(lines) and not re.match(r"\s*(?:pub\s+)?fn\s+", masked_lines[j]):
+            j += 1
+        if j >= len(lines):
+            break
+        name_match = re.match(r"\s*(?:pub\s+)?fn\s+([A-Za-z0-9_]+)", masked_lines[j])
+        if not name_match:
+            i += 1
+            continue
+        opening = masked.find("{", offsets[j])
+        if opening < 0:
+            i += 1
+            continue
+        closing = matching_brace(masked, opening)
+        if closing is None:
+            i += 1
+            continue
+        end_line = source.count("\n", 0, closing)
+        context_start = max(0, attr_start - 20)
+        tests.append(
+            TestCase(
+                path=path,
+                name=name_match.group(1),
+                line=j + 1,
+                attributes="\n".join(lines[attr_start:j]),
+                body=source[offsets[j] : closing + 1],
+                context="\n".join(lines[context_start : end_line + 1]),
+            )
+        )
+        i = end_line + 1
+    return tests
+
+
+def macro_calls(code: str, pattern: re.Pattern[str]) -> list[tuple[int, str]]:
+    calls: list[tuple[int, str]] = []
+    for match in pattern.finditer(code):
+        opening = code.find("(", match.end())
+        if opening < 0:
+            continue
+        depth = 0
+        for i in range(opening, len(code)):
+            if code[i] == "(":
+                depth += 1
+            elif code[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    calls.append((match.start(), code[match.start() : i + 1]))
+                    break
+    return calls
+
+
+def split_top_level(text: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    paren = bracket = brace = angle = 0
+    for i, ch in enumerate(text):
+        if ch == "(":
+            paren += 1
+        elif ch == ")":
+            paren -= 1
+        elif ch == "[":
+            bracket += 1
+        elif ch == "]":
+            bracket -= 1
+        elif ch == "{":
+            brace += 1
+        elif ch == "}":
+            brace -= 1
+        elif ch == "<":
+            angle += 1
+        elif ch == ">" and angle:
+            angle -= 1
+        elif ch == "," and paren == bracket == brace == angle == 0:
+            parts.append(text[start:i].strip())
+            start = i + 1
+    parts.append(text[start:].strip())
+    return parts
+
+
+def macro_arguments(call: str) -> list[str]:
+    opening = call.find("(")
+    return split_top_level(call[opening + 1 : -1]) if opening >= 0 else []
+
+
+def normalize_expression(expression: str) -> str:
+    value = re.sub(r"\s+", "", expression)
+    value = re.sub(r"\.clone\(\)$", "", value)
+    value = value.removeprefix("&")
+    while value.startswith("(") and value.endswith(")"):
+        value = value[1:-1]
+    return value
+
+
+def has_informative_assertion(assertions: list[tuple[int, str]]) -> bool:
+    for _, call in assertions:
+        args = macro_arguments(call)
+        if call.startswith(("assert_eq!", "assert_ne!", "debug_assert_eq!", "debug_assert_ne!")):
+            if len(args) >= 2 and normalize_expression(args[0]) != normalize_expression(args[1]):
+                return True
+            continue
+        expression = args[0] if args else call
+        if ERROR_PREDICATE.search(expression):
+            return True
+        without_weak = WEAK_PREDICATE.sub("", expression)
+        without_weak = re.sub(r"[\s()!&|]", "", without_weak)
+        if without_weak:
+            return True
+    return False
+
+
+def direct_self_comparison(assertions: list[tuple[int, str]]) -> bool:
+    for _, call in assertions:
+        args = macro_arguments(call)
+        if call.startswith(("assert_eq!", "debug_assert_eq!")) and len(args) >= 2:
+            if normalize_expression(args[0]) == normalize_expression(args[1]):
+                return True
+        if args and re.search(r"\b([A-Za-z_]\w*)\s*-\s*\1\b", args[0]):
+            return True
+    return False
+
+
+def assertion_is_inside_if(code: str, position: int) -> bool:
+    for match in re.finditer(r"\bif\b[^{}]*\{", code):
+        opening = code.find("{", match.start())
+        closing = matching_brace(code, opening)
+        if closing is not None and opening < position < closing:
+            return True
+    return False
+
+
+def has_asserting_helper(code: str, helpers: set[str]) -> bool:
+    return any(re.search(rf"\b{re.escape(name)}\s*(?:::\s*<[^>]*>)?\s*\(", code) for name in helpers)
+
+
+def asserting_helpers(sources: dict[Path, str]) -> set[str]:
+    functions: dict[str, str] = {}
+    for source in sources.values():
+        masked = mask_non_code(source)
+        for match in re.finditer(r"\bfn\s+([A-Za-z_]\w*)\s*(?:<[^{};]*>)?\s*\([^;{}]*\)[^{;]*\{", masked):
+            opening = masked.find("{", match.start())
+            closing = matching_brace(masked, opening)
+            if closing is not None:
+                functions[match.group(1)] = masked[opening : closing + 1]
+    helpers = {
+        name
+        for name, body in functions.items()
+        if ASSERT_NAME.search(body) or re.search(r"\bpanic!", body)
+    }
+    names = set(functions)
+    callers: dict[str, set[str]] = defaultdict(set)
+    for caller, body in functions.items():
+        for callee in re.findall(r"\b([A-Za-z_]\w*)\s*(?:::\s*<[^>]*>)?\s*\(", body):
+            if callee in names and callee != caller:
+                callers[callee].add(caller)
+    queue = deque(helpers)
+    while queue:
+        callee = queue.popleft()
+        for caller in callers.get(callee, ()):
+            if caller not in helpers:
+                helpers.add(caller)
+                queue.append(caller)
+    return helpers
+
+
+def has_duplicate_branch(code: str) -> bool:
+    for match in re.finditer(r"(?:\.|::)conditional\s*\(", code):
+        opening = code.find("(", match.start())
+        closing = None
+        depth = 0
+        for i in range(opening, len(code)):
+            if code[i] == "(":
+                depth += 1
+            elif code[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    closing = i
+                    break
+        if closing is None:
+            continue
+        args = split_top_level(code[opening + 1 : closing])
+        if len(args) >= 3 and normalize_expression(args[-2]) == normalize_expression(args[-1]):
+            return True
+    return False
+
+
+def fixture_flags(test: TestCase, code: str) -> set[str]:
+    flags: set[str] = set()
+    if re.search(r"(?:vec!\s*)?\[\s*[^\[\];,]+\s*;\s*[2-9]\d*\s*\]", code):
+        flags.add("uniform-fixture")
+
+    for match in re.finditer(r"(?:vec!\s*)?\[([^\[\]]+)\]", code):
+        if ";" in match.group(1):
+            continue
+        values = re.findall(r"(?<![A-Za-z_])[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?", match.group(1))
+        if len(values) >= 4 and len(set(values)) > 1 and values == list(reversed(values)):
+            flags.add("palindromic-fixture")
+            break
+
+    before_assert = code[: ASSERT_NAME.search(code).start()] if ASSERT_NAME.search(code) else code
+    values = re.findall(
+        r"(?<![A-Za-z_])[-+]?(?:\d+\.\d*|\d*\.\d+|\d+)(?:[eE][-+]?\d+)?(?:f32|f64)?",
+        before_assert,
+    )
+    numeric = []
+    for value in values:
+        cleaned = re.sub(r"(?:f32|f64)$", "", value)
+        try:
+            numeric.append(float(cleaned))
+        except ValueError:
+            pass
+    if (
+        len(numeric) >= 3
+        and all(value in {-1.0, 0.0, 1.0} for value in numeric)
+        and not DEGENERATE_PURPOSE.search(test.name)
+    ):
+        flags.add("zero-one-fixture")
+    return flags
+
+
+def classify(test: TestCase, helpers: set[str]) -> set[str]:
+    code = mask_non_code(test.body)
+    assertions = macro_calls(code, ASSERT_NAME)
+    panics = macro_calls(code, re.compile(r"\bpanic!"))
+    delegates = has_asserting_helper(code, helpers)
+    flags: set[str] = set()
+
+    if not assertions and not panics and "should_panic" not in test.attributes and not delegates:
+        flags.add("no-observation")
+    if assertions and not has_informative_assertion(assertions):
+        flags.add("answer-blind")
+    if direct_self_comparison(assertions):
+        flags.add("self-comparison")
+    if assertions and all(assertion_is_inside_if(code, position) for position, _ in assertions) and not panics:
+        flags.add("conditional-only")
+
+    discarded = re.findall(r"\blet\s+(_[A-Za-z0-9_]*)\s*=\s*[^;]+;", code)
+    if any(name == "_" or len(re.findall(rf"\b{re.escape(name)}\b", code)) == 1 for name in discarded):
+        flags.add("discarded-result")
+    if has_duplicate_branch(code):
+        flags.add("duplicate-branch")
+
+    flags.update(fixture_flags(test, code))
+
+    varied = bool(
+        re.search(
+            r"\bfor\b|\bwhile\b|\.iter\s*\(|\b(?:cases|rows|inputs|samples|fixtures)\s*=\s*[&]?\[",
+            code,
+        )
+    )
+    if not varied and assertions:
+        flags.add("single-case")
+
+    context_has_provenance = bool(PROVENANCE.search(test.context))
+    literal_oracle = False
+    for _, call in assertions:
+        args = macro_arguments(call)
+        if len(args) >= 2 and re.search(r"(?<![A-Za-z_])[-+]?\d+\.\d+", args[1]):
+            literal_oracle = True
+        elif args and re.search(r"[-,]\s*[-+]?\d+\.\d+", args[0]):
+            literal_oracle = True
+    if literal_oracle and not varied and not context_has_provenance:
+        flags.add("unproven-literal-oracle")
+
+    derived = False
+    for match in re.finditer(
+        r"let\s+\w*(?:expected|want|reference|exp|predicted|analytic|manual)\w*\s*(?::[^=]+)?=\s*([^;]+);",
+        code,
+        re.IGNORECASE,
+    ):
+        if ARITHMETIC.search(match.group(1)):
+            derived = True
+            break
+    if derived:
+        flags.add("derived-oracle")
+        if not context_has_provenance:
+            flags.add("unproven-derived-oracle")
+
+    if RANDOM_SOURCE.search(test.body) and assertions and not has_informative_assertion(assertions):
+        flags.add("random-survival-only")
+    return flags
+
+
+def site(test: TestCase) -> str:
+    return f"{test.path}:{test.line}:{test.name}"
+
+
+def audit(root: Path) -> dict[str, object]:
+    paths = sorted(root.rglob("*.rs"))
+    sources = {path: path.read_text() for path in paths}
+    helpers = asserting_helpers(sources)
+    inventory: dict[str, list[str]] = defaultdict(list)
+    per_file: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    test_count = 0
+    file_count = 0
+
+    for path, source in sources.items():
+        tests = split_tests(path, source)
+        if tests:
+            file_count += 1
+        for test in tests:
+            test_count += 1
+            for flag in sorted(classify(test, helpers)):
+                inventory[flag].append(site(test))
+                per_file[str(path)][flag] += 1
+
+    return {
+        "root": str(root),
+        "tests": test_count,
+        "files": file_count,
+        "counts": {key: len(value) for key, value in sorted(inventory.items())},
+        "inventory": dict(sorted(inventory.items())),
+        "per_file": {path: dict(sorted(flags.items())) for path, flags in sorted(per_file.items())},
+    }
+
+
+def print_report(result: dict[str, object]) -> None:
+    tests = int(result["tests"])
+    print(f"scanned {tests} tests in {result['files']} files\n")
+    counts = result["counts"]
+    assert isinstance(counts, dict)
+    for name, count in sorted(counts.items(), key=lambda item: (-int(item[1]), item[0])):
+        print(f"  {name:25} {int(count):5}  ({100 * int(count) / tests:5.1f}%)")
+
+    risk_classes = {
+        "answer-blind",
+        "conditional-only",
+        "discarded-result",
+        "duplicate-branch",
+        "no-observation",
+        "palindromic-fixture",
+        "random-survival-only",
+        "self-comparison",
+        "uniform-fixture",
+        "unproven-derived-oracle",
+        "unproven-literal-oracle",
+        "zero-one-fixture",
+    }
+    per_file = result["per_file"]
+    assert isinstance(per_file, dict)
+    ranked = []
+    for path, flags in per_file.items():
+        score = sum(int(count) for flag, count in flags.items() if flag in risk_classes)
+        if score:
+            ranked.append((score, path, flags))
+    print("\n  highest candidate density:")
+    for score, path, flags in sorted(ranked, reverse=True)[:20]:
+        detail = ", ".join(f"{name}={count}" for name, count in flags.items() if name in risk_classes)
+        print(f"    {score:4}  {path}  [{detail}]")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT, help="Rust tests directory")
+    parser.add_argument("--json", type=Path, default=DEFAULT_JSON, help="inventory output path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.root.is_dir():
+        raise SystemExit(f"test root does not exist: {args.root}")
+    result = audit(args.root)
+    args.json.write_text(json.dumps(result, indent=2) + "\n")
+    print_report(result)
+    print(f"\nJSON inventory: {args.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Describe your changes

fix(deep_causality_quantum): Fixed broken version number that failed auto-release on CI.


## Issue ticket number and link

## Code checklist before requesting a review

- [x] I have signed the DCO?
- [x] All tests are passing when running make test?
- [x] No errors or security vulnerabilities are reported by make check?

For details on make, [please see BUILD.md](../BUILD.md)

Note: The CI runs all of the above and fixing things before they hit CI speeds
up the review and merge process. Thank you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken `deep_causality_quantum` version number that failed CI auto-release, and adds a test audit scanner with a report covering nine workspace crates.

**Version alignment**
- Sets `deep_causality_quantum` to `0.2.5` in the crate manifest and `0.2` in the workspace, matching `Cargo.lock`.
- Enables the default feature for `deep_causality_quantum` in `examples/physics_examples`.

**Test audit additions**
- Adds `openspec/notes/test_audit/physics/audit_tests_v2.py`, a static scanner that flags test designs where plausible wrong implementations could pass.
- Adds `openspec/notes/test_audit/dc_all/README.md`, a calibrated audit report covering the nine crates not previously scanned.
- No production code or tests were changed; the report is an inventory with prioritized fix recommendations.

<sup>Written for commit a9bdc924d6bc60daaeade88a01e12023693a0756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

