### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- Added CRA compliance notice to README.md and SECURITY.md
+- *(workspace)* move ast, file and par into deep_causality_utils
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(build)* [**breaking**] move build/scripts to the repository root
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.15.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.0...deep_causality-v0.15.1) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_algebra"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "deep_causality_num",
 ]
@@ -565,11 +565,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ast"
-version = "0.1.12"
+version = "0.1.13"
 
 [[package]]
 name = "deep_causality_calculus"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -602,14 +602,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "deep_causality_haft",
 ]
 
 [[package]]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "criterion",
  "deep_causality_rand",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "csv",
  "deep_causality_algebra",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "deep_causality",
  "ultragraph",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_fft"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "deep_causality_algebra",
@@ -666,14 +666,14 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_haft"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "deep_causality_algebra",
 ]
 
 [[package]]
 name = "deep_causality_homology"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "deep_causality_linear",
  "deep_causality_num",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_linear"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -692,11 +692,11 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_metric"
-version = "0.2.7"
+version = "0.2.8"
 
 [[package]]
 name = "deep_causality_multivector"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "deep_causality_algebra",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_complex"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_dual"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_haft",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_num_rational"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "deep_causality_physics"
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_rand"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_num",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "deep_causality_topology"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "deep_causality_algebra",
  "deep_causality_fft",
@@ -2237,7 +2237,7 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "deep_causality_rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ homepage = "https://deepcausality.com/"
 # `default-features = false` appears wherever ANY member needs defaults off.
 
 # Internal crates
-deep_causality = { path = "deep_causality", version = "0.15" }
-deep_causality_algebra = { path = "deep_causality_unified_math/deep_causality_algebra", version = "0.4", default-features = false }
+deep_causality = { path = "deep_causality", version = "0.16" }
+deep_causality_algebra = { path = "deep_causality_unified_math/deep_causality_algebra", version = "0.5", default-features = false }
 deep_causality_algorithms = { path = "deep_causality_algorithms", version = "0.4" }
 deep_causality_ast = { path = "deep_causality_utils/deep_causality_ast", version = "0.1", default-features = false }
 deep_causality_calculus = { path = "deep_causality_unified_math/deep_causality_calculus", version = "0.1", default-features = false }
-deep_causality_cfd = { path = "deep_causality_cfd", version = "0.1" }
-deep_causality_core = { path = "deep_causality_core", version = "0.11", default-features = false }
+deep_causality_cfd = { path = "deep_causality_cfd", version = "0.2" }
+deep_causality_core = { path = "deep_causality_core", version = "0.12", default-features = false }
 deep_causality_data_structures = { path = "deep_causality_data_structures", version = "0.10" }
-deep_causality_discovery = { path = "deep_causality_discovery", version = "0.5" }
+deep_causality_discovery = { path = "deep_causality_discovery", version = "0.6" }
 deep_causality_ethos = { path = "deep_causality_ethos", version = "0.2" }
 deep_causality_fft = { path = "deep_causality_unified_math/deep_causality_fft", version = "0.1", default-features = false }
 deep_causality_file = { path = "deep_causality_utils/deep_causality_file", version = "0.1" }
@@ -58,9 +58,9 @@ deep_causality_quantum = { path = "deep_causality_quantum", version = "0.2" }
 deep_causality_rand = { path = "deep_causality_unified_math/deep_causality_rand", version = "0.2" }
 deep_causality_stats = { path = "deep_causality_unified_math/deep_causality_stats", version = "0.1", default-features = false }
 deep_causality_tensor = { path = "deep_causality_unified_math/deep_causality_tensor", version = "0.5", default-features = false }
-deep_causality_topology = { path = "deep_causality_unified_math/deep_causality_topology", version = "0.9" }
+deep_causality_topology = { path = "deep_causality_unified_math/deep_causality_topology", version = "0.10" }
 deep_causality_uncertain = { path = "deep_causality_unified_math/deep_causality_uncertain", version = "0.5" }
-ultragraph = { path = "ultragraph", version = "0.9" }
+ultragraph = { path = "ultragraph", version = "0.10" }
 
 # External crates
 candle-core = { version = "0.11" }

--- a/deep_causality/Cargo.toml
+++ b/deep_causality/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality"
-version = "0.15.2"
+version = "0.16.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_algorithms/CHANGELOG.md
+++ b/deep_causality_algorithms/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.4.5) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+- *(topology)* move the Meek closure into MixedGraph, add R4 and a chordality check
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+- *(deep_causality_algorithms)* give the pattern oracle an unclosed input
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+- Fixed multiple issues raised by raview
+- Added BRCD paper
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.4.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.1...deep_causality_algorithms-v0.4.2) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/CHANGELOG.md
+++ b/deep_causality_cfd/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- Fixed multiple issues raised by raview
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_cfd-v0.1.0) - 2026-08-12
 
 ### Added

--- a/deep_causality_cfd/Cargo.toml
+++ b/deep_causality_cfd/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_cfd"
-version = "0.1.1"
+version = "0.2.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_core/CHANGELOG.md
+++ b/deep_causality_core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- *(openspec)* Updated inbound links to archived notes
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.11.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.0...deep_causality_core-v0.11.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_core/Cargo.toml
+++ b/deep_causality_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_core"
-version = "0.11.2"
+version = "0.12.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_data_structures/CHANGELOG.md
+++ b/deep_causality_data_structures/CHANGELOG.md
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.10.16](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.15...deep_causality_data_structures-v0.10.16) - 2026-07-14
 
 ### Added

--- a/deep_causality_data_structures/Cargo.toml
+++ b/deep_causality_data_structures/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_data_structures"
-version = "0.10.17"
+version = "0.10.18"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_discovery/CHANGELOG.md
+++ b/deep_causality_discovery/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(bazel)* migrate to rules_rs and delete the vendored crate tree
+- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.0...deep_causality_discovery-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_discovery/Cargo.toml
+++ b/deep_causality_discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_discovery"
-version = "0.5.2"
+version = "0.6.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_ethos/CHANGELOG.md
+++ b/deep_causality_ethos/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.2.12) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- trigger holesale auto-release.
+- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+
 ## [0.2.10](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.9...deep_causality_ethos-v0.2.10) - 2026-08-12
 
 ### Added

--- a/deep_causality_ethos/Cargo.toml
+++ b/deep_causality_ethos/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "deep_causality_ethos"
-version = "0.2.11"
+version = "0.2.12"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_physics/CHANGELOG.md
+++ b/deep_causality_physics/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.8.3) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
+
+### Fixed
+
+- *(deep_causality_physics)* code lints and fixes.
+- *(deep_causality_physics)* Fixed ks_propagator.rs that failed on CI.
+- *(deep_causality_physics)* make the fictitious-time inversion converge on both platforms
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(deep_causality_physics)* [**breaking**] report non-convergence instead of returning the last iterate
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+- *(deep_causality_physics)* state why Lund sampling stays at f64
+- Fixed multiple issues raised by raview
+- *(deep_causality_num)* internal package refactoring.
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- *(openspec)* Updated inbound links to archived notes
+- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.8.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.0...deep_causality_physics-v0.8.1) - 2026-08-12
 
 ### Added

--- a/deep_causality_quantum/CHANGELOG.md
+++ b/deep_causality_quantum/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.2.0...deep_causality_quantum-v0.2.5) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl
+- *(deep_causality_quantum)* add the QCL pipeline, from one config origin through validate, Screened and control
+- *(deep_causality_quantum)* add Hypothesis with the mechanism-level intervention, embedded prediction and warrant-gated marginalisation
+- *(deep_causality_quantum)* add the typed carriers, the shot budget and the default-build Born sampler
+- *(deep_causality_quantum)* [**breaking**] finish class invariance with the normalizer check, the Clifford tableau and the tuple cap
+
+### Fixed
+
+- *(deep_causality_quantum)* Fixed broken version number that failed auto-release on CI.
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
+- *(deep_causality_quantum,openspec)* correct C₃ to Definition 3.1 and apply the QCL corrections register
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+- Fixed PR review issues.
+- *(deep_causality_quantum)* add design as an exact pair cover and adjudicate under the verdict law
+- Updated Rust depencies to the latest version.

--- a/deep_causality_unified_math/deep_causality_algebra/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_algebra/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.4.3...deep_causality_algebra-v0.5.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_algebra)* put BFloat16 in the algebra tower
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- Fixed multiple issues raised by raview
+- Added BFloat16
+
 ## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.1.1...deep_causality_algebra-v0.2.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_algebra/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_algebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_algebra"
-version = "0.4.3"
+version = "0.5.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_calculus/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_calculus/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.5...deep_causality_calculus-v0.1.6) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.2...deep_causality_calculus-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_calculus/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_calculus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_calculus"
-version = "0.1.5"
+version = "0.1.6"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_fft/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_fft/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.4...deep_causality_fft-v0.1.5) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.1...deep_causality_fft-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_fft/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_fft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_fft"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_haft/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_haft/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.5.1...deep_causality_haft-v0.5.2) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.4.0...deep_causality_haft-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_haft/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_haft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_haft"
-version = "0.5.1"
+version = "0.5.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_homology/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_homology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_homology"
-version = "0.1.1"
+version = "0.1.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_linear/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_linear/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_linear-v0.1.3...deep_causality_linear-v0.1.4) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.

--- a/deep_causality_unified_math/deep_causality_linear/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_linear/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_linear"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_metric/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_metric/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.7...deep_causality_metric-v0.2.8) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.3...deep_causality_metric-v0.2.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_metric/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_metric"
-version = "0.2.7"
+version = "0.2.8"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_multivector/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_multivector/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.6.2...deep_causality_multivector-v0.6.3) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.5.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.5.3...deep_causality_multivector-v0.5.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_multivector/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_multivector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_multivector"
-version = "0.6.2"
+version = "0.6.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.5.0...deep_causality_num-v0.5.1) - 2026-09-08
+
+### Added
+
+- *(deep_causality_stats)* add descriptive and information statistics at tier 4
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_algorithms)* give the pattern oracle an unclosed input
+
+### Other
+
+- *(openspec)* Archived specs and notes for unified_math_next.
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+- Fixed multiple issues raised by raview
+- *(deep_causality_num)* run the BFloat16 suite in both build systems
+- *(deep_causality_num)* internal package refactoring.
+- Added BFloat16
+
 ## [0.4.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.4.0...deep_causality_num-v0.4.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num"
-version = "0.5.1" # Update workspace Cargo.toml internal version dep for a major bump.
+version = "0.5.1"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_complex/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.8...deep_causality_num_complex-v0.1.9) - 2026-09-08
+
+### Added
+
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.3...deep_causality_num_complex-v0.1.4) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_complex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_complex"
-version = "0.1.8"
+version = "0.1.9"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_dual/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_dual/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.7...deep_causality_num_dual-v0.1.8) - 2026-09-08
+
+### Added
+
+- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- *(num_dual)* close the derivative-seed gap in the Real implementation
+
 ## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.3...deep_causality_num_dual-v0.1.4) - 2026-07-14
 
 ### Other

--- a/deep_causality_unified_math/deep_causality_num_dual/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_dual/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_dual"
-version = "0.1.7"
+version = "0.1.8"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_num_rational/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_num_rational/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.1...deep_causality_homology-v0.1.2) - 2026-09-08
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.4...deep_causality_num_rational-v0.1.5) - 2026-09-08
 
 ### Fixed
 
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
 - *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
 
 ### Other
 
 - *(Cargo)* Updated metadata in all crates.
-- Updated Rust depencies to the latest version.

--- a/deep_causality_unified_math/deep_causality_num_rational/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_num_rational/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_num_rational"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_rand/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.3...deep_causality_rand-v0.2.4) - 2026-09-08
+
+### Added
+
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.2.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.0...deep_causality_rand-v0.2.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_rand/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_rand"
-version = "0.2.3"
+version = "0.2.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_stats/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_stats/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_stats-v0.1.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_stats)* add descriptive and information statistics at tier 4
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(openspec)* Archived specs and notes for unified_math_next.
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(deep_causality_stats)* improved some corner case testing.

--- a/deep_causality_unified_math/deep_causality_tensor/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_tensor/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.4...deep_causality_tensor-v0.5.5) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.0...deep_causality_tensor-v0.5.1) - 2026-07-14
 
 ### Added

--- a/deep_causality_unified_math/deep_causality_topology/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_topology/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.9.1...deep_causality_topology-v0.10.0) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(topology)* move the Meek closure into MixedGraph, add R4 and a chordality check
+
+### Fixed
+
+- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
+- *(deep_causality_physics)* [**breaking**] report non-convergence instead of returning the last iterate
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
+
+### Other
+
+- *(openspec)* Archived specs and notes for unified_math_next.
+- *(Cargo)* Updated metadata in all crates.
+- Fixed multiple issues raised by raview
+
 ## [0.7.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.7.0...deep_causality_topology-v0.7.1) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_unified_math/deep_causality_topology/Cargo.toml
+++ b/deep_causality_unified_math/deep_causality_topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_topology"
-version = "0.9.1"
+version = "0.10.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
+++ b/deep_causality_unified_math/deep_causality_uncertain/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.2...deep_causality_uncertain-v0.5.3) - 2026-09-08
+
+### Added
+
+- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
+- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
+
+### Other
+
+- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
+- *(Cargo)* Updated metadata in all crates.
+
 ## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.4.0...deep_causality_uncertain-v0.5.0) - 2026-07-14
 
 ### Added

--- a/deep_causality_utils/deep_causality_ast/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_ast/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.12...deep_causality_ast-v0.1.13) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.8...deep_causality_ast-v0.1.9) - 2026-07-14
 
 ### Fixed

--- a/deep_causality_utils/deep_causality_ast/Cargo.toml
+++ b/deep_causality_utils/deep_causality_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_ast"
-version = "0.1.12"
+version = "0.1.13"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_utils/deep_causality_file/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_file/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-08
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.2...deep_causality_file-v0.1.3) - 2026-07-14
 
 ### Added

--- a/deep_causality_utils/deep_causality_file/Cargo.toml
+++ b/deep_causality_utils/deep_causality_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_file"
-version = "0.1.4"
+version = "0.1.5"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/deep_causality_utils/deep_causality_par/CHANGELOG.md
+++ b/deep_causality_utils/deep_causality_par/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+
+### Other
+
+- *(Cargo)* Updated metadata in all crates.
+- *(workspace)* move ast, file and par into deep_causality_utils
+
 ## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.1...deep_causality_par-v0.1.2) - 2026-07-14
 
 ### Added

--- a/deep_causality_utils/deep_causality_par/Cargo.toml
+++ b/deep_causality_utils/deep_causality_par/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deep_causality_par"
-version = "0.1.3"
+version = "0.1.4"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }

--- a/ultragraph/CHANGELOG.md
+++ b/ultragraph/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.10.0) - 2026-09-08
+
+### Fixed
+
+- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
+- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
+- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings
+
+### Other
+
+- trigger holesale auto-release.
+- *(cargo)* hoist every dependency into [workspace.dependencies]
+- *(bazel)* merge test BUILD files and derive deps from Cargo
+- consolidate the mathematics crates under deep_causality_unified_math/
+
 ## [0.9.3](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.2...ultragraph-v0.9.3) - 2026-07-14
 
 ### Fixed

--- a/ultragraph/Cargo.toml
+++ b/ultragraph/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ultragraph"
-version = "0.9.4"
+version = "0.10.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `deep_causality_num`: 0.5.0 -> 0.5.1
* `deep_causality_algebra`: 0.4.3 -> 0.5.0 (⚠ API breaking changes)
* `deep_causality_ast`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `deep_causality_haft`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `deep_causality_core`: 0.11.2 -> 0.12.0 (✓ API compatible changes)
* `deep_causality_data_structures`: 0.10.17 -> 0.10.18 (✓ API compatible changes)
* `deep_causality_rand`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `deep_causality_linear`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_stats`: 0.1.0
* `deep_causality_uncertain`: 0.5.2 -> 0.5.3
* `ultragraph`: 0.9.4 -> 0.10.0 (⚠ API breaking changes)
* `deep_causality`: 0.15.2 -> 0.16.0 (✓ API compatible changes)
* `deep_causality_num_complex`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `deep_causality_num_rational`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_par`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `deep_causality_num_dual`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `deep_causality_tensor`: 0.5.4 -> 0.5.5
* `deep_causality_fft`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_homology`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `deep_causality_metric`: 0.2.7 -> 0.2.8 (✓ API compatible changes)
* `deep_causality_multivector`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `deep_causality_topology`: 0.9.1 -> 0.10.0 (✓ API compatible changes)
* `deep_causality_algorithms`: 0.4.3 -> 0.4.5
* `deep_causality_calculus`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `deep_causality_file`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `deep_causality_physics`: 0.8.2 -> 0.8.3
* `deep_causality_cfd`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `deep_causality_discovery`: 0.5.2 -> 0.6.0 (✓ API compatible changes)
* `deep_causality_ethos`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `deep_causality_quantum`: 0.2.0 -> 0.2.5

### ⚠ `deep_causality_algebra` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait deep_causality_algebra::RealField gained ToPrimitive in file /tmp/.tmpbIP4Rx/deep_causality/deep_causality_unified_math/deep_causality_algebra/src/algebra/field_real.rs:31

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_method_added.ron

Failed in:
  trait method deep_causality_algebra::Real::cbrt in file /tmp/.tmpbIP4Rx/deep_causality/deep_causality_unified_math/deep_causality_algebra/src/algebra/real.rs:111
```

### ⚠ `ultragraph` breaking changes

```text
--- failure function_now_doc_hidden: pub function is now #[doc(hidden)] ---

Description:
A pub function is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_now_doc_hidden.ron

Failed in:
  function get_acyclic_graph in file /tmp/.tmpbIP4Rx/deep_causality/ultragraph/src/utils/utils_tests.rs:28
  function get_cyclic_graph in file /tmp/.tmpbIP4Rx/deep_causality/ultragraph/src/utils/utils_tests.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `deep_causality_num`

<blockquote>

## [0.5.1](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num-v0.5.0...deep_causality_num-v0.5.1) - 2026-09-08

### Added

- *(deep_causality_stats)* add descriptive and information statistics at tier 4
- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_algorithms)* give the pattern oracle an unclosed input

### Other

- *(openspec)* Archived specs and notes for unified_math_next.
- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
- Fixed multiple issues raised by raview
- *(deep_causality_num)* run the BFloat16 suite in both build systems
- *(deep_causality_num)* internal package refactoring.
- Added BFloat16
</blockquote>

## `deep_causality_algebra`

<blockquote>

## [0.5.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algebra-v0.4.3...deep_causality_algebra-v0.5.0) - 2026-09-08

### Added

- *(deep_causality_algebra)* put BFloat16 in the algebra tower
- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- Fixed multiple issues raised by raview
- Added BFloat16
</blockquote>

## `deep_causality_ast`

<blockquote>

## [0.1.13](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ast-v0.1.12...deep_causality_ast-v0.1.13) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_haft`

<blockquote>

## [0.5.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_haft-v0.5.1...deep_causality_haft-v0.5.2) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_core`

<blockquote>

## [0.12.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_core-v0.11.2...deep_causality_core-v0.12.0) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_data_structures`

<blockquote>


## [0.10.18](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_data_structures-v0.10.17...deep_causality_data_structures-v0.10.18) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_rand`

<blockquote>

## [0.2.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_rand-v0.2.3...deep_causality_rand-v0.2.4) - 2026-09-08

### Added

- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_linear`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_linear-v0.1.3...deep_causality_linear-v0.1.4) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_stats`

<blockquote>

## [0.1.0](https://github.com/deepcausality-rs/deep_causality/releases/tag/deep_causality_stats-v0.1.0) - 2026-09-08

### Added

- *(deep_causality_stats)* add descriptive and information statistics at tier 4

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(openspec)* Archived specs and notes for unified_math_next.
- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(deep_causality_stats)* improved some corner case testing.
</blockquote>

## `deep_causality_uncertain`

<blockquote>

## [0.5.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_uncertain-v0.5.2...deep_causality_uncertain-v0.5.3) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `ultragraph`

<blockquote>

## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/ultragraph-v0.9.4...ultragraph-v0.10.0) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality`

<blockquote>

## [0.16.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality-v0.15.2...deep_causality-v0.16.0) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers

### Other

- *(Cargo)* Updated metadata in all crates.
- Added CRA compliance notice to README.md and SECURITY.md
- *(workspace)* move ast, file and par into deep_causality_utils
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(build)* [**breaking**] move build/scripts to the repository root
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_num_complex`

<blockquote>

## [0.1.9](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_complex-v0.1.8...deep_causality_num_complex-v0.1.9) - 2026-09-08

### Added

- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_num_rational`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_rational-v0.1.4...deep_causality_num_rational-v0.1.5) - 2026-09-08

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_par`

<blockquote>

## [0.1.4](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_par-v0.1.3...deep_causality_par-v0.1.4) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_num_dual`

<blockquote>

## [0.1.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_num_dual-v0.1.7...deep_causality_num_dual-v0.1.8) - 2026-09-08

### Added

- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- *(num_dual)* close the derivative-seed gap in the Real implementation
</blockquote>

## `deep_causality_tensor`

<blockquote>

## [0.5.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_tensor-v0.5.4...deep_causality_tensor-v0.5.5) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_fft`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_fft-v0.1.4...deep_causality_fft-v0.1.5) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_homology`

<blockquote>

## [0.1.2](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_homology-v0.1.1...deep_causality_homology-v0.1.2) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- Updated Rust depencies to the latest version.
</blockquote>

## `deep_causality_metric`

<blockquote>

## [0.2.8](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_metric-v0.2.7...deep_causality_metric-v0.2.8) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_multivector`

<blockquote>

## [0.6.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_multivector-v0.6.2...deep_causality_multivector-v0.6.3) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_topology`

<blockquote>

## [0.10.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_topology-v0.9.1...deep_causality_topology-v0.10.0) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(topology)* move the Meek closure into MixedGraph, add R4 and a chordality check

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(deep_causality_physics)* [**breaking**] report non-convergence instead of returning the last iterate
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers

### Other

- *(openspec)* Archived specs and notes for unified_math_next.
- *(Cargo)* Updated metadata in all crates.
- Fixed multiple issues raised by raview
</blockquote>

## `deep_causality_algorithms`

<blockquote>

## [0.4.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_algorithms-v0.4.3...deep_causality_algorithms-v0.4.5) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
- *(topology)* move the Meek closure into MixedGraph, add R4 and a chordality check
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
- *(deep_causality_algorithms)* give the pattern oracle an unclosed input
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
- Fixed multiple issues raised by raview
- Added BRCD paper
- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_calculus`

<blockquote>

## [0.1.6](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_calculus-v0.1.5...deep_causality_calculus-v0.1.6) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
</blockquote>

## `deep_causality_file`

<blockquote>

## [0.1.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_file-v0.1.4...deep_causality_file-v0.1.5) - 2026-09-08

### Other

- *(Cargo)* Updated metadata in all crates.
- *(workspace)* move ast, file and par into deep_causality_utils
</blockquote>

## `deep_causality_physics`

<blockquote>

## [0.8.3](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_physics-v0.8.2...deep_causality_physics-v0.8.3) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_physics)* code lints and fixes.
- *(deep_causality_physics)* Fixed ks_propagator.rs that failed on CI.
- *(deep_causality_physics)* make the fictitious-time inversion converge on both platforms
- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(deep_causality_physics)* [**breaking**] report non-convergence instead of returning the last iterate
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
- *(deep_causality_topology)* [**breaking**] close an unsound HKT witness and test the laws that hid it
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
- *(deep_causality_physics)* state why Lund sampling stays at f64
- Fixed multiple issues raised by raview
- *(deep_causality_num)* internal package refactoring.
- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(openspec)* Updated inbound links to archived notes
- *(deep_causality_topology)* [**breaking**] separate geometry from payload and drop two unlawful instances
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_cfd`

<blockquote>

## [0.2.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_cfd-v0.1.1...deep_causality_cfd-v0.2.0) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(num,algebra)* add Real::cbrt and RealField: ToPrimitive, and replace the
- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps
- *(deep_causality_homology)* extract the chain-complex layer into deep_causality_homology

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
- *(unified_math)* close E3, add Adjunction::Error, and clear a review batch
- *(deep_causality_cfd)* Applied a number of fixes and lint corrections.
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(Cargo)* Updated metadata in all crates.
- Fixed multiple issues raised by raview
- trigger holesale auto-release.
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- *(openspec)* Updated inbound links to archived notes
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_discovery`

<blockquote>

## [0.6.0](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_discovery-v0.5.2...deep_causality_discovery-v0.6.0) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(homology,topology,quantum)* [**breaking**] close the last five QCL gaps

### Fixed

- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(deep_causality_homology)* correct a mis-versioned breaking change and 42 review findings

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
- *(bazel)* migrate to rules_rs and delete the vendored crate tree
- *(deep_causality_haft)* [**breaking**] remove the HKT Constraint system and the Satisfies marker
- consolidate the mathematics crates under deep_causality_unified_math/
</blockquote>

## `deep_causality_ethos`

<blockquote>

## [0.2.12](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_ethos-v0.2.11...deep_causality_ethos-v0.2.12) - 2026-09-08

### Fixed

- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests

### Other

- *(Cargo)* Updated metadata in all crates.
- trigger holesale auto-release.
- *(bazel)* compile the 71 tests Cargo ran and Bazel never saw
- *(cargo)* hoist every dependency into [workspace.dependencies]
- *(bazel)* merge test BUILD files and derive deps from Cargo
</blockquote>

## `deep_causality_quantum`

<blockquote>

## [0.2.5](https://github.com/deepcausality-rs/deep_causality/compare/deep_causality_quantum-v0.2.0...deep_causality_quantum-v0.2.5) - 2026-09-08

### Added

- *(deep_causality_linear)* move the fixed-size dense forms in, and close the C4 adoption
- *(deep_causality_num)* add the lift module and retire the inherent Float106::from_f64
- *(deep_causality_quantum)* add the three QCL consumer examples and close out add-qcl
- *(deep_causality_quantum)* add the QCL pipeline, from one config origin through validate, Screened and control
- *(deep_causality_quantum)* add Hypothesis with the mechanism-level intervention, embedded prediction and warrant-gated marginalisation
- *(deep_causality_quantum)* add the typed carriers, the shot budget and the default-build Born sampler
- *(deep_causality_quantum)* [**breaking**] finish class invariance with the normalizer check, the Clifford tableau and the tuple cap

### Fixed

- *(deep_causality_quantum)* Fixed broken version number that failed auto-release on CI.
- *(deep_causality_unified_math)* close audited correctness holes across the unified_math stack
- *(Bazel)* align crate features with cargo's resolution and recover 161 unrun tests
- *(deep_causality_linear)* scale the Euclidean norms and adopt the crate across consumers
- *(deep_causality_quantum)* resolve the QCL review findings, with the Float106 defects beneath them
- *(deep_causality_quantum,openspec)* correct C₃ to Definition 3.1 and apply the QCL corrections register

### Other

- *(deep_causality_stats)* [**breaking**] centralize workspace statistics in the stats crate
- *(Cargo)* Updated metadata in all crates.
- Fixed PR review issues.
- *(deep_causality_quantum)* add design as an exact pair cover and adjudicate under the verdict law
- Updated Rust depencies to the latest version.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases new versions for 30 crates across the workspace, including two breaking changes and the first release of `deep_causality_stats`.

**Breaking changes**
- `deep_causality_algebra` makes `RealField` require `ToPrimitive` and adds `Real::cbrt` without a default implementation, so downstream trait implementations must be updated.
- `ultragraph` marks `get_acyclic_graph` and `get_cyclic_graph` as `#[doc(hidden)]`, removing them from the public API.

<sup>Written for commit 526a0d4c2556b4b900e2921389d346a2070e7de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/deepcausality-rs/deep_causality/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

